### PR TITLE
netstandard Nullable ref fix

### DIFF
--- a/src/NATS.Client.Core/NATS.Client.Core.csproj
+++ b/src/NATS.Client.Core/NATS.Client.Core.csproj
@@ -28,7 +28,10 @@
     <PackageReference Include="System.Text.Json" Version="8.0.3"/>
     <PackageReference Include="System.Threading.Channels" Version="8.0.0"/>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1"/>
-    <PackageReference Include="Nullable" Version="1.3.1"/>
+    <PackageReference Include="Nullable" Version="1.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.5" />


### PR DESCRIPTION
Made a mistake with Nullable reference. It's only required compile time.

![image](https://github.com/nats-io/nats.net.v2/assets/386903/c4c3921b-fc7b-42b3-9950-f1a0c294a558)

![image](https://github.com/nats-io/nats.net.v2/assets/386903/421234d4-2448-4c4d-a0b0-c9e27567ce70)


see also https://github.com/nats-io/nats.net.v2/issues/306#issuecomment-2209404686

cc @galvesribeiro