### PR TITLE
Use NatsMemoryOwner for Base64Url Encoder

### DIFF
--- a/src/NATS.Client.ObjectStore/Internal/Encoder.cs
+++ b/src/NATS.Client.ObjectStore/Internal/Encoder.cs
@@ -127,7 +127,7 @@ internal static class Base64UrlEncoder
                 j += 3;
             }
 
-        break;
+            break;
 
         case 1:
             {
@@ -138,7 +138,7 @@ internal static class Base64UrlEncoder
                 j += 2;
             }
 
-        break;
+            break;
 
             // default or case 0: no further operations are needed.
         }

--- a/src/NATS.Client.ObjectStore/Internal/Encoder.cs
+++ b/src/NATS.Client.ObjectStore/Internal/Encoder.cs
@@ -75,7 +75,7 @@ internal static class Base64UrlEncoder
             var segment = owner.DangerousGetArray();
             if (segment.Array == null || segment.Array.Length == 0)
             {
-                return String.Empty;
+                return string.Empty;
             }
 
             return new string(segment.Array, segment.Offset, segment.Count);
@@ -96,6 +96,7 @@ internal static class Base64UrlEncoder
         var table = SBase64Table;
         int i, j = 0;
         var output = owner.Span;
+
         // takes 3 bytes from inArray and insert 4 bytes into output
         for (i = offset; i < limit; i += 3)
         {
@@ -116,30 +117,30 @@ internal static class Base64UrlEncoder
         switch (lengthMod3)
         {
         case 2:
-        {
-            var d0 = inArray[i];
-            var d1 = inArray[i + 1];
+            {
+                var d0 = inArray[i];
+                var d1 = inArray[i + 1];
 
-            output[j + 0] = table[d0 >> 2];
-            output[j + 1] = table[((d0 & 0x03) << 4) | (d1 >> 4)];
-            output[j + 2] = table[(d1 & 0x0f) << 2];
-            j += 3;
-        }
+                output[j + 0] = table[d0 >> 2];
+                output[j + 1] = table[((d0 & 0x03) << 4) | (d1 >> 4)];
+                output[j + 2] = table[(d1 & 0x0f) << 2];
+                j += 3;
+            }
 
-            break;
+        break;
 
         case 1:
-        {
-            var d0 = inArray[i];
+            {
+                var d0 = inArray[i];
 
-            output[j + 0] = table[d0 >> 2];
-            output[j + 1] = table[(d0 & 0x03) << 4];
-            j += 2;
-        }
+                output[j + 0] = table[d0 >> 2];
+                output[j + 1] = table[(d0 & 0x03) << 4];
+                j += 2;
+            }
 
-            break;
+        break;
 
-        // default or case 0: no further operations are needed.
+            // default or case 0: no further operations are needed.
         }
 
         if (raw)

--- a/src/NATS.Client.ObjectStore/Internal/Encoder.cs
+++ b/src/NATS.Client.ObjectStore/Internal/Encoder.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Security.Cryptography;
+using NATS.Client.Core;
 
 namespace NATS.Client.ObjectStore.Internal;
 
@@ -69,18 +70,32 @@ internal static class Base64UrlEncoder
     /// <exception cref="ArgumentOutOfRangeException">offset or length is negative OR offset plus length is greater than the length of inArray.</exception>
     public static string Encode(Span<byte> inArray, bool raw = false)
     {
+        using (var owner = EncodeToMemoryOwner(inArray, raw))
+        {
+            var segment = owner.DangerousGetArray();
+            if (segment.Array == null || segment.Array.Length == 0)
+            {
+                return String.Empty;
+            }
+
+            return new string(segment.Array, segment.Offset, segment.Count);
+        }
+    }
+
+    public static NatsMemoryOwner<char> EncodeToMemoryOwner(Span<byte> inArray, bool raw = false)
+    {
         var offset = 0;
         var length = inArray.Length;
 
         if (length == 0)
-            return string.Empty;
+            return NatsMemoryOwner<char>.Empty;
 
         var lengthMod3 = length % 3;
         var limit = length - lengthMod3;
-        var output = new char[(length + 2) / 3 * 4];
+        var owner = NatsMemoryOwner<char>.Allocate((length + 2) / 3 * 4);
         var table = SBase64Table;
         int i, j = 0;
-
+        var output = owner.Span;
         // takes 3 bytes from inArray and insert 4 bytes into output
         for (i = offset; i < limit; i += 3)
         {
@@ -101,41 +116,41 @@ internal static class Base64UrlEncoder
         switch (lengthMod3)
         {
         case 2:
-            {
-                var d0 = inArray[i];
-                var d1 = inArray[i + 1];
+        {
+            var d0 = inArray[i];
+            var d1 = inArray[i + 1];
 
-                output[j + 0] = table[d0 >> 2];
-                output[j + 1] = table[((d0 & 0x03) << 4) | (d1 >> 4)];
-                output[j + 2] = table[(d1 & 0x0f) << 2];
-                j += 3;
-            }
+            output[j + 0] = table[d0 >> 2];
+            output[j + 1] = table[((d0 & 0x03) << 4) | (d1 >> 4)];
+            output[j + 2] = table[(d1 & 0x0f) << 2];
+            j += 3;
+        }
 
             break;
 
         case 1:
-            {
-                var d0 = inArray[i];
+        {
+            var d0 = inArray[i];
 
-                output[j + 0] = table[d0 >> 2];
-                output[j + 1] = table[(d0 & 0x03) << 4];
-                j += 2;
-            }
+            output[j + 0] = table[d0 >> 2];
+            output[j + 1] = table[(d0 & 0x03) << 4];
+            j += 2;
+        }
 
             break;
 
-            // default or case 0: no further operations are needed.
+        // default or case 0: no further operations are needed.
         }
 
         if (raw)
-            return new string(output, 0, j);
+            return owner.Slice(0, j);
 
         for (var k = j; k < output.Length; k++)
         {
             output[k] = Base64PadCharacter;
         }
 
-        return new string(output);
+        return owner;
     }
 
     /// <summary>

--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -240,7 +240,7 @@ public class NatsObjStore : INatsObjStore
 #if NETSTANDARD2_0
                 using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Read))
 #else
-            await using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Read, leaveOpen))
+                await using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Read, leaveOpen))
 #endif
                 {
                     while (true)
@@ -276,7 +276,7 @@ public class NatsObjStore : INatsObjStore
                             }
 
 #else
-                        var read = await hashedStream.ReadAsync(memory, cancellationToken);
+                            var read = await hashedStream.ReadAsync(memory, cancellationToken);
 #endif
 
                             // End of stream

--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -94,65 +94,75 @@ public class NatsObjStore : INatsObjStore
 
         pushConsumer.Init();
 
-        string digest;
-        var chunks = 0;
-        var size = 0;
-        using (var sha256 = SHA256.Create())
+        var digest = NatsMemoryOwner<char>.Empty;
+        try
         {
+            var chunks = 0;
+            var size = 0;
+            using (var sha256 = SHA256.Create())
+            {
 #if NETSTANDARD2_0
-            using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Write))
+                using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Write))
 #else
             await using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Write, leaveOpen))
 #endif
-            {
-                await foreach (var msg in pushConsumer.Msgs.ReadAllAsync(cancellationToken))
                 {
-                    // We have to make sure to carry on consuming the channel to avoid any blocking:
-                    // e.g. if the channel is full, we would be blocking the reads off the socket (this was intentionally
-                    // done ot avoid bloating the memory with a large backlog of messages or dropping messages at this level
-                    // and signal the server that we are a slow consumer); then when we make an request-reply API call to
-                    // delete the consumer, the socket would be blocked trying to send the response back to us; so we need to
-                    // keep consuming the channel to avoid this.
-                    if (pushConsumer.IsDone)
-                        continue;
-
-                    if (msg.Data.Length > 0)
+                    await foreach (var msg in pushConsumer.Msgs.ReadAllAsync(cancellationToken))
                     {
-                        using var memoryOwner = msg.Data;
-                        chunks++;
-                        size += memoryOwner.Memory.Length;
+                        // We have to make sure to carry on consuming the channel to avoid any blocking:
+                        // e.g. if the channel is full, we would be blocking the reads off the socket (this was intentionally
+                        // done ot avoid bloating the memory with a large backlog of messages or dropping messages at this level
+                        // and signal the server that we are a slow consumer); then when we make an request-reply API call to
+                        // delete the consumer, the socket would be blocked trying to send the response back to us; so we need to
+                        // keep consuming the channel to avoid this.
+                        if (pushConsumer.IsDone)
+                            continue;
+
+                        if (msg.Data.Length > 0)
+                        {
+                            using var memoryOwner = msg.Data;
+                            chunks++;
+                            size += memoryOwner.Memory.Length;
 #if NETSTANDARD2_0
-                        var segment = memoryOwner.DangerousGetArray();
-                        await hashedStream.WriteAsync(segment.Array, segment.Offset, segment.Count, cancellationToken);
+                            var segment = memoryOwner.DangerousGetArray();
+                            await hashedStream.WriteAsync(segment.Array, segment.Offset, segment.Count, cancellationToken);
 #else
                         await hashedStream.WriteAsync(memoryOwner.Memory, cancellationToken);
 #endif
-                    }
+                        }
 
-                    var p = msg.Metadata?.NumPending;
-                    if (p is 0)
-                    {
-                        pushConsumer.Done();
+                        var p = msg.Metadata?.NumPending;
+                        if (p is 0)
+                        {
+                            pushConsumer.Done();
+                        }
                     }
                 }
+
+                digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
             }
 
-            digest = Base64UrlEncoder.Encode(sha256.Hash);
-        }
+            if (info.Digest == null
+                || info.Digest.StartsWith("SHA-256=") == false
+                || info.Digest.AsSpan().Slice("SHA-256=".Length).SequenceEqual(digest.Span) == false)
+            {
+                throw new NatsObjException("SHA-256 digest mismatch");
+            }
 
-        if ($"SHA-256={digest}" != info.Digest)
-        {
-            throw new NatsObjException("SHA-256 digest mismatch");
-        }
 
-        if (chunks != info.Chunks)
-        {
-            throw new NatsObjException("Chunks mismatch");
-        }
+            if (chunks != info.Chunks)
+            {
+                throw new NatsObjException("Chunks mismatch");
+            }
 
-        if (size != info.Size)
+            if (size != info.Size)
+            {
+                throw new NatsObjException("Size mismatch");
+            }
+        }
+        finally
         {
-            throw new NatsObjException("Size mismatch");
+            digest.Dispose();
         }
 
         return info;
@@ -223,116 +233,120 @@ public class NatsObjStore : INatsObjStore
         var chunks = 0;
         var chunkSize = meta.Options.MaxChunkSize.Value;
 
-        string digest;
-        using (var sha256 = SHA256.Create())
+        var digest = NatsMemoryOwner<char>.Empty;
+        try
         {
+            using (var sha256 = SHA256.Create())
+            {
 #if NETSTANDARD2_0
-            using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Read))
+                using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Read))
 #else
             await using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Read, leaveOpen))
 #endif
-            {
-                while (true)
                 {
-                    var memoryOwner = NatsMemoryOwner<byte>.Allocate(chunkSize);
-
-                    var memory = memoryOwner.Memory;
-                    var currentChunkSize = 0;
-                    var eof = false;
-
-                    // Fill a chunk
                     while (true)
                     {
+                        var memoryOwner = NatsMemoryOwner<byte>.Allocate(chunkSize);
+
+                        var memory = memoryOwner.Memory;
+                        var currentChunkSize = 0;
+                        var eof = false;
+
+                        // Fill a chunk
+                        while (true)
+                        {
 #if NETSTANDARD2_0
-                        int read;
-                        if (MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment) == false)
-                        {
-                            read = await hashedStream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken);
-                        }
-                        else
-                        {
-                            var bytes = ArrayPool<byte>.Shared.Rent(memory.Length);
-                            try
+                            int read;
+                            if (MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment) == false)
                             {
-                                segment = new ArraySegment<byte>(bytes, 0, memory.Length);
                                 read = await hashedStream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken);
-                                segment.Array.AsMemory(0, read).CopyTo(memory);
                             }
-                            finally
+                            else
                             {
-                                ArrayPool<byte>.Shared.Return(bytes);
+                                var bytes = ArrayPool<byte>.Shared.Rent(memory.Length);
+                                try
+                                {
+                                    segment = new ArraySegment<byte>(bytes, 0, memory.Length);
+                                    read = await hashedStream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken);
+                                    segment.Array.AsMemory(0, read).CopyTo(memory);
+                                }
+                                finally
+                                {
+                                    ArrayPool<byte>.Shared.Return(bytes);
+                                }
                             }
-                        }
 
 #else
                         var read = await hashedStream.ReadAsync(memory, cancellationToken);
 #endif
 
-                        // End of stream
-                        if (read == 0)
-                        {
-                            eof = true;
-                            break;
+                            // End of stream
+                            if (read == 0)
+                            {
+                                eof = true;
+                                break;
+                            }
+
+                            memory = memory.Slice(read);
+                            currentChunkSize += read;
+
+                            // Chunk filled
+                            if (memory.IsEmpty)
+                            {
+                                break;
+                            }
                         }
 
-                        memory = memory.Slice(read);
-                        currentChunkSize += read;
-
-                        // Chunk filled
-                        if (memory.IsEmpty)
+                        if (currentChunkSize > 0)
                         {
-                            break;
+                            size += currentChunkSize;
+                            chunks++;
                         }
+
+                        var buffer = memoryOwner.Slice(0, currentChunkSize);
+
+                        // Chunks
+                        var ack = await _context.PublishAsync(GetChunkSubject(nuid), buffer, serializer: NatsRawSerializer<NatsMemoryOwner<byte>>.Default, cancellationToken: cancellationToken);
+                        ack.EnsureSuccess();
+
+                        if (eof)
+                            break;
                     }
+                }
 
-                    if (currentChunkSize > 0)
-                    {
-                        size += currentChunkSize;
-                        chunks++;
-                    }
+                if (sha256.Hash == null)
+                    throw new NatsObjException("Can't compute SHA256 hash");
 
-                    var buffer = memoryOwner.Slice(0, currentChunkSize);
+                digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
+            }
 
-                    // Chunks
-                    var ack = await _context.PublishAsync(GetChunkSubject(nuid), buffer, serializer: NatsRawSerializer<NatsMemoryOwner<byte>>.Default, cancellationToken: cancellationToken);
-                    ack.EnsureSuccess();
+            meta.Chunks = chunks;
+            meta.Size = size;
+            meta.Digest = $"SHA-256={digest}";
 
-                    if (eof)
-                        break;
+            // Metadata
+            await PublishMeta(meta, cancellationToken);
+
+            // Delete the old object
+            if (info?.Nuid != null && info.Nuid != nuid)
+            {
+                try
+                {
+                    await _context.JSRequestResponseAsync<StreamPurgeRequest, StreamPurgeResponse>(
+                        subject: $"{_context.Opts.Prefix}.STREAM.PURGE.OBJ_{Bucket}",
+                        request: new StreamPurgeRequest { Filter = GetChunkSubject(info.Nuid), },
+                        cancellationToken);
+                }
+                catch (NatsJSApiException e)
+                {
+                    if (e.Error.Code != 404)
+                        throw;
                 }
             }
-
-            if (sha256.Hash == null)
-                throw new NatsObjException("Can't compute SHA256 hash");
-
-            digest = Base64UrlEncoder.Encode(sha256.Hash);
         }
-
-        meta.Chunks = chunks;
-        meta.Size = size;
-        meta.Digest = $"SHA-256={digest}";
-
-        // Metadata
-        await PublishMeta(meta, cancellationToken);
-
-        // Delete the old object
-        if (info?.Nuid != null && info.Nuid != nuid)
+        finally
         {
-            try
-            {
-                await _context.JSRequestResponseAsync<StreamPurgeRequest, StreamPurgeResponse>(
-                    subject: $"{_context.Opts.Prefix}.STREAM.PURGE.OBJ_{Bucket}",
-                    request: new StreamPurgeRequest
-                    {
-                        Filter = GetChunkSubject(info.Nuid),
-                    },
-                    cancellationToken);
-            }
-            catch (NatsJSApiException e)
-            {
-                if (e.Error.Code != 404)
-                    throw;
-            }
+            digest.Dispose();
         }
 
         return meta;

--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -127,7 +127,7 @@ public class NatsObjStore : INatsObjStore
                             var segment = memoryOwner.DangerousGetArray();
                             await hashedStream.WriteAsync(segment.Array, segment.Offset, segment.Count, cancellationToken);
 #else
-                        await hashedStream.WriteAsync(memoryOwner.Memory, cancellationToken);
+                            await hashedStream.WriteAsync(memoryOwner.Memory, cancellationToken);
 #endif
                         }
 
@@ -139,7 +139,7 @@ public class NatsObjStore : INatsObjStore
                     }
                 }
 
-                digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
+            digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
             }
 
             if (info.Digest == null
@@ -148,7 +148,6 @@ public class NatsObjStore : INatsObjStore
             {
                 throw new NatsObjException("SHA-256 digest mismatch");
             }
-
 
             if (chunks != info.Chunks)
             {
@@ -281,17 +280,17 @@ public class NatsObjStore : INatsObjStore
 #endif
 
                             // End of stream
-                            if (read == 0)
+                        if (read == 0)
                             {
                                 eof = true;
                                 break;
                             }
 
-                            memory = memory.Slice(read);
-                            currentChunkSize += read;
+                        memory = memory.Slice(read);
+                        currentChunkSize += read;
 
                             // Chunk filled
-                            if (memory.IsEmpty)
+                        if (memory.IsEmpty)
                             {
                                 break;
                             }
@@ -314,10 +313,10 @@ public class NatsObjStore : INatsObjStore
                     }
                 }
 
-                if (sha256.Hash == null)
+            if (sha256.Hash == null)
                     throw new NatsObjException("Can't compute SHA256 hash");
 
-                digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
+            digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
             }
 
             meta.Chunks = chunks;

--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -104,7 +104,7 @@ public class NatsObjStore : INatsObjStore
 #if NETSTANDARD2_0
                 using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Write))
 #else
-            await using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Write, leaveOpen))
+                await using (var hashedStream = new CryptoStream(stream, sha256, CryptoStreamMode.Write, leaveOpen))
 #endif
                 {
                     await foreach (var msg in pushConsumer.Msgs.ReadAllAsync(cancellationToken))
@@ -139,7 +139,7 @@ public class NatsObjStore : INatsObjStore
                     }
                 }
 
-            digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
+                digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
             }
 
             if (info.Digest == null
@@ -280,17 +280,17 @@ public class NatsObjStore : INatsObjStore
 #endif
 
                             // End of stream
-                        if (read == 0)
+                            if (read == 0)
                             {
                                 eof = true;
                                 break;
                             }
 
-                        memory = memory.Slice(read);
-                        currentChunkSize += read;
+                            memory = memory.Slice(read);
+                            currentChunkSize += read;
 
                             // Chunk filled
-                        if (memory.IsEmpty)
+                            if (memory.IsEmpty)
                             {
                                 break;
                             }
@@ -313,10 +313,10 @@ public class NatsObjStore : INatsObjStore
                     }
                 }
 
-            if (sha256.Hash == null)
+                if (sha256.Hash == null)
                     throw new NatsObjException("Can't compute SHA256 hash");
 
-            digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
+                digest = Base64UrlEncoder.EncodeToMemoryOwner(sha256.Hash);
             }
 
             meta.Chunks = chunks;


### PR DESCRIPTION
Resolves #557

By using NatsMemoryOwner we can avoid a lot of GC thrashing here.

#### Note:

Once Microsoft.Bcl.Memory hits 9.0, there will be a `Base64Url` class to get rid of our encoder, see : https://github.com/dotnet/runtime/pull/103617

If we are OK pulling in 'odd-numbered' deps, once that is released, we will want to revisit the topic. 

-----

Above note aside, this PR should lower GC pressure on ObjectStore operations all targets (i.e. NETSTANDARD/NET).

I kept it as simple as I could in the mindset that longer term, we can lean on BCL instead, i.e. Future PRs can optimize for scenarios where more IFDEFs are worth the cost and/or we update deps.