### PR TITLE
Update repository renaming information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-### :mega: :warning: This repository will be renamed to `nats.net` on Wednesday, July 17th, 2024
+### Looking for NATS .NET v1? [Click here](https://github.com/nats-io/nats.net.v1)
 
-Please be prepared to update your references to the new name.
-You can also read the [announcement](REPO_RENAME.md) for more information.
+Please update your references to the new name. You can also read the [announcement](REPO_RENAME.md) for more information.
 
 ---
 

--- a/REPO_RENAME.md
+++ b/REPO_RENAME.md
@@ -1,4 +1,4 @@
-# This repository will be renamed to `nats.net` on Wednesday, July 17th, 2024
+# This repository was renamed to `nats.net` on Wednesday, July 17th, 2024
 
 We wanted to let you know about an upcoming rename to our NATS .NET GitHub repositories on Wednesday, July 17. Here's what's changing:
 


### PR DESCRIPTION
The renaming info of the repository has been updated from the future tense to the past tense in both README.md and REPO_RENAME.md files. An additional link has been added in README.md pointing to the old NATS .NET v1 repository.