### PR TITLE
Fetch idle timeout default fix

### DIFF
--- a/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
@@ -134,7 +134,15 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
             serializer: NatsJSJsonSerializer<ConsumerGetnextRequest>.Default,
             cancellationToken: cancellationToken);
 
-    public void ResetHeartbeatTimer() => _hbTimer.Change(_hbTimeout, Timeout.Infinite);
+    public void ResetHeartbeatTimer()
+    {
+        // if we don't have an idle timeout, we don't need to reset the timer
+        // because we don't expect any heartbeats.
+        if (_idle == TimeSpan.Zero)
+            return;
+
+        _hbTimer.Change(_hbTimeout, Timeout.Infinite);
+    }
 
     public override async ValueTask DisposeAsync()
     {

--- a/src/NATS.Client.JetStream/Internal/NatsJSOptsDefaults.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOptsDefaults.cs
@@ -76,7 +76,7 @@ internal static class NatsJSOptsDefaults
             throw new NatsJSException($"{nameof(idleHeartbeat)} must be less than {HeartbeatCap}");
         }
 
-        if (idleHeartbeatOut < HeartbeatMin)
+        if (idleHeartbeatOut != TimeSpan.Zero && idleHeartbeatOut < HeartbeatMin)
         {
             throw new NatsJSException($"{nameof(idleHeartbeat)} must be greater than {HeartbeatMin}");
         }


### PR DESCRIPTION
Allow heartbeat timeout to be set as TimeSpan.Zero so it's not sent to server e.g.
```
PUB $JS.API.CONSUMER.MSG.NEXT.s1.c1 _INBOX.hHyTxVZaGlxkX2lhPMFlho 35
{"expires":30000000000,"batch":100}
```