### PR TITLE
Add default timeout to initial commands

### DIFF
--- a/src/NATS.Client.Core/Commands/PriorityCommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/PriorityCommandWriter.cs
@@ -8,7 +8,7 @@ internal sealed class PriorityCommandWriter : IAsyncDisposable
 
     public PriorityCommandWriter(NatsConnection connection, ObjectPool pool, ISocketConnection socketConnection, NatsOpts opts, ConnectionStatsCounter counter, Action<PingCommand> enqueuePing)
     {
-        CommandWriter = new CommandWriter("init", connection, pool, opts, counter, enqueuePing, overrideCommandTimeout: Timeout.InfiniteTimeSpan);
+        CommandWriter = new CommandWriter("init", connection, pool, opts, counter, enqueuePing);
         CommandWriter.Reset(socketConnection);
     }
 


### PR DESCRIPTION
By removing infinite timeout sets the command writing to use default timeouts. There is a chance, while reconnecting, socket errors might be causing the re-subscriptions (performed by the PriorityCommandWriter) to stall. By having a timeout, we should recover from socket errors happening during re-subscriptions.