### PR TITLE
NatsOpts.ConfigureWebSocketOpts callback handler

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -318,7 +318,7 @@ public partial class NatsConnection : INatsConnection
                 if (uri.IsWebSocket)
                 {
                     var conn = new WebSocketConnection();
-                    await conn.ConnectAsync(uri.Uri, Opts.ConnectTimeout).ConfigureAwait(false);
+                    await conn.ConnectAsync(uri.Uri, Opts).ConfigureAwait(false);
                     _socket = conn;
                 }
                 else
@@ -606,7 +606,7 @@ public partial class NatsConnection : INatsConnection
                     {
                         _logger.LogDebug(NatsLogEvents.Connection, "Trying to reconnect using WebSocket {Url} [{ReconnectCount}]", url, reconnectCount);
                         var conn = new WebSocketConnection();
-                        await conn.ConnectAsync(url.Uri, Opts.ConnectTimeout).ConfigureAwait(false);
+                        await conn.ConnectAsync(url.Uri, Opts).ConfigureAwait(false);
                         _socket = conn;
                     }
                     else

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -1,3 +1,4 @@
+using System.Net.WebSockets;
 using System.Text;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
@@ -113,6 +114,27 @@ public sealed record NatsOpts
     /// case it might risk server disconnecting the client as a slow consumer.
     /// </remarks>
     public BoundedChannelFullMode SubPendingChannelFullMode { get; init; } = BoundedChannelFullMode.DropNewest;
+
+    /// <summary>
+    /// An optional async callback handler for manipulation of ClientWebSocketOptions used for WebSocket connections.
+    /// </summary>
+    /// <remarks>
+    /// This can be used to set authorization header and other HTTP header values.
+    /// Note: Setting HTTP header values is not supported by Blazor WebAssembly as the underlying browser implementation does not support adding headers to a WebSocket.
+    /// The callback's execution time contributes to the connection establishment subject to the <see cref="ConnectTimeout"/>.
+    /// Implementors should use the passed CancellationToken for async operations called by this handler.
+    /// </remarks>
+    /// <example>
+    /// await using var nats = new NatsConnection(new NatsOpts
+    /// {
+    ///     Url = "ws://localhost:8080",
+    ///     ConfigureWebSocketOpts = async (serverUri, clientWsOpts, ct) =>
+    ///     {
+    ///         clientWsOpts.SetRequestHeader("authorization", $"Bearer MY_TOKEN");
+    ///     },
+    /// });
+    /// </example>
+    public Func<Uri, ClientWebSocketOptions, CancellationToken, ValueTask>? ConfigureWebSocketOpts { get; init; } = null;
 
     internal NatsUri[] GetSeedUris()
     {

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -128,9 +128,10 @@ public sealed record NatsOpts
     /// await using var nats = new NatsConnection(new NatsOpts
     /// {
     ///     Url = "ws://localhost:8080",
-    ///     ConfigureWebSocketOpts = async (serverUri, clientWsOpts, ct) =>
+    ///     ConfigureWebSocketOpts = (serverUri, clientWsOpts, ct) =>
     ///     {
     ///         clientWsOpts.SetRequestHeader("authorization", $"Bearer MY_TOKEN");
+    ///         return ValueTask.CompletedTask;
     ///     },
     /// });
     /// </example>

--- a/tests/NATS.Client.Core.Tests/WebSocketOptionsTest.cs
+++ b/tests/NATS.Client.Core.Tests/WebSocketOptionsTest.cs
@@ -1,0 +1,329 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using NATS.Client.TestUtilities;
+
+namespace NATS.Client.Core.Tests;
+
+public class WebSocketOptionsTest
+{
+    private readonly List<string> _logs = new();
+
+    // Modeled after similar test in SendBufferTest.cs which also uses the MockServer.
+    [Fact]
+    public async Task MockWebsocketServer_PubSubWithCancelAndReconnect_ShouldCallbackTwice()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        List<string> pubs = new();
+        await using var server = new MockServer(
+            handler: (client, cmd) =>
+            {
+                if (cmd.Name == "PUB")
+                {
+                    lock (pubs)
+                        pubs.Add($"PUB {cmd.Subject}");
+                }
+
+                if (cmd is { Name: "PUB", Subject: "close" })
+                {
+                    client.Close();
+                }
+
+                return Task.CompletedTask;
+            },
+            Log,
+            info: $"{{\"max_payload\":{1024 * 4}}}",
+            cancellationToken: cts.Token);
+
+        await using var wsServer = new WebSocketMockServer(
+            server.Url,
+            connectHandler: (httpContext) =>
+            {
+                return true;
+            },
+            Log,
+            cts.Token);
+
+        Log("__________________________________");
+
+        var testLogger = new InMemoryTestLoggerFactory(LogLevel.Warning, m =>
+        {
+            Log($"[NC] {m.Message}");
+        });
+
+        var tokenCount = 0;
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = wsServer.WebSocketUrl,
+            LoggerFactory = testLogger,
+            ConfigureWebSocketOpts = async (serverUri, clientWsOpts, ct) =>
+            {
+                tokenCount++;
+                Log($"[C] ConfigureWebSocketOpts {serverUri}, accessToken TOKEN_{tokenCount}");
+                clientWsOpts.SetRequestHeader("authorization", $"Bearer TOKEN_{tokenCount}");
+            },
+        });
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        Log($"[C] connect {server.Url}");
+        await nats.ConnectAsync();
+
+        Log($"[C] ping");
+        var rtt = await nats.PingAsync(cts.Token);
+        Log($"[C] ping rtt={rtt}");
+
+        Log($"[C] publishing x1...");
+        await nats.PublishAsync("x1", "x", cancellationToken: cts.Token);
+
+        // we will close the connection in mock server when we receive subject "close"
+        Log($"[C] publishing close (4KB)...");
+        var pubTask = nats.PublishAsync("close", new byte[1024 * 4], cancellationToken: cts.Token).AsTask();
+
+        await pubTask.WaitAsync(cts.Token);
+
+        for (var i = 1; i <= 10; i++)
+        {
+            try
+            {
+                await nats.PingAsync(cts.Token);
+                break;
+            }
+            catch (OperationCanceledException)
+            {
+                if (i == 10)
+                    throw;
+                await Task.Delay(10 * i, cts.Token);
+            }
+        }
+
+        Log($"[C] publishing x2...");
+        await nats.PublishAsync("x2", "x", cancellationToken: cts.Token);
+
+        Log($"[C] flush...");
+        await nats.PingAsync(cts.Token);
+
+        // Look for logs like the following:
+        // [WS] Received WebSocketRequest with authorization header: Bearer TOKEN_2
+        var tokens = GetLogs().Where(l => l.Contains("Bearer")).ToList();
+        Assert.Equal(2, tokens.Count);
+        var token = tokens.Where(t => t.Contains("TOKEN_1"));
+        Assert.Single(token);
+        token = tokens.Where(t => t.Contains("TOKEN_2"));
+        Assert.Single(token);
+
+        lock (pubs)
+        {
+            Assert.Equal(3, pubs.Count);
+            Assert.Equal("PUB x1", pubs[0]);
+            Assert.Equal("PUB close", pubs[1]);
+            Assert.Equal("PUB x2", pubs[2]);
+        }
+    }
+
+    [Fact]
+    public async Task WebSocketRespondsWithHttpError_ShouldThrowNatsException()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await using var server = new MockServer(
+            handler: (client, cmd) =>
+            {
+                return Task.CompletedTask;
+            },
+            Log,
+            info: $"{{\"max_payload\":{1024 * 4}}}",
+            cancellationToken: cts.Token);
+
+        await using var wsServer = new WebSocketMockServer(
+            server.Url,
+            connectHandler: (httpContext) =>
+            {
+                httpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                return false; // reject connection
+            },
+            Log,
+            cts.Token);
+
+        Log("__________________________________");
+
+        var testLogger = new InMemoryTestLoggerFactory(LogLevel.Warning, m =>
+        {
+            Log($"[NC] {m.Message}");
+        });
+
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = wsServer.WebSocketUrl,
+            LoggerFactory = testLogger,
+        });
+
+        Log($"[C] connect {server.Url}");
+
+        // expect: NATS.Client.Core.NatsException : can not connect uris: ws://127.0.0.1:5004
+        var exception = await Assert.ThrowsAsync<NatsException>(async () => await nats.ConnectAsync());
+    }
+
+    [Fact]
+    public async Task HttpErrorDuringReconnect_ShouldContinueToReconnect()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await using var server = new MockServer(
+            handler: (client, cmd) =>
+            {
+                if (cmd is { Name: "PUB", Subject: "close" })
+                {
+                    client.Close();
+                }
+
+                return Task.CompletedTask;
+            },
+            Log,
+            info: $"{{\"max_payload\":{1024 * 4}}}",
+            cancellationToken: cts.Token);
+
+        var tokenCount = 0;
+
+        await using var wsServer = new WebSocketMockServer(
+            server.Url,
+            connectHandler: (httpContext) =>
+            {
+                var token = httpContext.Request.Headers.Authorization;
+                if (token.Contains("Bearer TOKEN_1") || token.Contains("Bearer TOKEN_4"))
+                {
+                    return true;
+                }
+                else
+                {
+                    httpContext.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                    return false; // reject connection
+                }
+            },
+            Log,
+            cts.Token);
+
+        Log("__________________________________");
+
+        var testLogger = new InMemoryTestLoggerFactory(LogLevel.Warning, m =>
+        {
+            Log($"[NC] {m.Message}");
+        });
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = wsServer.WebSocketUrl,
+            LoggerFactory = testLogger,
+            ConfigureWebSocketOpts = async (serverUri, clientWsOpts, ct) =>
+            {
+                tokenCount++;
+                Log($"[C] ConfigureWebSocketOpts {serverUri}, accessToken TOKEN_{tokenCount}");
+                clientWsOpts.SetRequestHeader("authorization", $"Bearer TOKEN_{tokenCount}");
+            },
+        });
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        Log($"[C] connect {server.Url}");
+
+        // close connection and trigger reconnect
+        Log($"[C] publishing close ...");
+        await nats.PublishAsync("close", "x", cancellationToken: cts.Token);
+
+        for (var i = 1; i <= 10; i++)
+        {
+            try
+            {
+                await nats.PingAsync(cts.Token);
+                break;
+            }
+            catch (OperationCanceledException)
+            {
+                if (i == 10)
+                    throw;
+                await Task.Delay(100 * i, cts.Token);
+            }
+        }
+
+        Log($"[C] publishing reconnected");
+        await nats.PublishAsync("reconnected", "rc", cancellationToken: cts.Token);
+        await Task.Delay(100); // short delay to allow log to be collected for reconnect
+
+        // Expect to see in logs:
+        // 1st callback and TOKEN_1
+        // Initial Connect
+        // 2nd callback with rejected TOKEN_2
+        // NC reconnect
+        // 3rd callback with rejected TOKEN_3
+        // NC reconnect
+        // 4th callback with good TOKEN_4
+        // Successful Publish after reconnect
+
+        // 4 tokens
+        var logs = GetLogs();
+        var tokens = logs.Where(l => l.Contains("Bearer")).ToList();
+        Assert.Equal(4, tokens.Count);
+        Assert.Single(tokens.Where(t => t.Contains("TOKEN_1")));
+        Assert.Single(tokens.Where(t => t.Contains("TOKEN_2")));
+        Assert.Single(tokens.Where(t => t.Contains("TOKEN_3")));
+        Assert.Single(tokens.Where(t => t.Contains("TOKEN_4")));
+
+        // 2 errors in NATS.Client triggering the reconnect
+        var failures = logs.Where(l => l.Contains("[NC] Failed to connect NATS"));
+        Assert.Equal(2, failures.Count());
+
+        // 2 connects in MockServer
+        var connects = logs.Where(l => l.Contains("RCV CONNECT"));
+        Assert.Equal(2, failures.Count());
+
+        // 1 reconnect in MockServer
+        var reconnectPublish = logs.Where(l => l.Contains("RCV PUB reconnected"));
+        Assert.Single(reconnectPublish);
+    }
+
+    [Fact]
+    public async Task ExceptionThrownInCallback_ShouldThrowNatsException()
+    {
+        // void Log(string m) => TmpFileLogger.Log(m);
+        List<string> logs = new();
+        void Log(string m)
+        {
+            lock (logs)
+                logs.Add(m);
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var testLogger = new InMemoryTestLoggerFactory(LogLevel.Warning, m =>
+        {
+            Log($"[NC] {m.Message}");
+        });
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = "ws://localhost:1234",
+            LoggerFactory = testLogger,
+            ConfigureWebSocketOpts = async (serverUri, clientWsOpts, ct) =>
+            {
+                throw new Exception("Error in callback");
+            },
+        });
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        // expect: NATS.Client.Core.NatsException : can not connect uris: ws://localhost:1234
+        var exception = await Assert.ThrowsAsync<NatsException>(async () => await nats.ConnectAsync());
+    }
+
+    private void Log(string m)
+    {
+        lock (_logs)
+            _logs.Add(m);
+    }
+
+    private List<string> GetLogs()
+    {
+        lock (_logs)
+            return _logs.ToList();
+    }
+}

--- a/tests/NATS.Client.Core.Tests/WebSocketOptionsTest.cs
+++ b/tests/NATS.Client.Core.Tests/WebSocketOptionsTest.cs
@@ -52,19 +52,18 @@ public class WebSocketOptionsTest
         });
 
         var tokenCount = 0;
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         await using var nats = new NatsConnection(new NatsOpts
         {
             Url = wsServer.WebSocketUrl,
             LoggerFactory = testLogger,
-            ConfigureWebSocketOpts = async (serverUri, clientWsOpts, ct) =>
+            ConfigureWebSocketOpts = (serverUri, clientWsOpts, ct) =>
             {
                 tokenCount++;
                 Log($"[C] ConfigureWebSocketOpts {serverUri}, accessToken TOKEN_{tokenCount}");
                 clientWsOpts.SetRequestHeader("authorization", $"Bearer TOKEN_{tokenCount}");
+                return ValueTask.CompletedTask;
             },
         });
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 
         Log($"[C] connect {server.Url}");
         await nats.ConnectAsync();
@@ -210,19 +209,18 @@ public class WebSocketOptionsTest
             Log($"[NC] {m.Message}");
         });
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         await using var nats = new NatsConnection(new NatsOpts
         {
             Url = wsServer.WebSocketUrl,
             LoggerFactory = testLogger,
-            ConfigureWebSocketOpts = async (serverUri, clientWsOpts, ct) =>
+            ConfigureWebSocketOpts = (serverUri, clientWsOpts, ct) =>
             {
                 tokenCount++;
                 Log($"[C] ConfigureWebSocketOpts {serverUri}, accessToken TOKEN_{tokenCount}");
                 clientWsOpts.SetRequestHeader("authorization", $"Bearer TOKEN_{tokenCount}");
+                return ValueTask.CompletedTask;
             },
         });
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 
         Log($"[C] connect {server.Url}");
 
@@ -299,17 +297,15 @@ public class WebSocketOptionsTest
             Log($"[NC] {m.Message}");
         });
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         await using var nats = new NatsConnection(new NatsOpts
         {
             Url = "ws://localhost:1234",
             LoggerFactory = testLogger,
-            ConfigureWebSocketOpts = async (serverUri, clientWsOpts, ct) =>
+            ConfigureWebSocketOpts = (serverUri, clientWsOpts, ct) =>
             {
                 throw new Exception("Error in callback");
             },
         });
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 
         // expect: NATS.Client.Core.NatsException : can not connect uris: ws://localhost:1234
         var exception = await Assert.ThrowsAsync<NatsException>(async () => await nats.ConnectAsync());

--- a/tests/NATS.Client.TestUtilities/InMemoryTestLoggerFactory.cs
+++ b/tests/NATS.Client.TestUtilities/InMemoryTestLoggerFactory.cs
@@ -47,7 +47,12 @@ public class InMemoryTestLoggerFactory(LogLevel level, Action<InMemoryTestLogger
 
         public bool IsEnabled(LogLevel logLevel) => logLevel >= level;
 
+#if NET8_0_OR_GREATER
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => new NullDisposable();
+#else
         public IDisposable BeginScope<TState>(TState state) => new NullDisposable();
+#endif
 
         private class NullDisposable : IDisposable
         {

--- a/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
+++ b/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>

--- a/tests/NATS.Client.TestUtilities/OutputHelperLogger.cs
+++ b/tests/NATS.Client.TestUtilities/OutputHelperLogger.cs
@@ -41,7 +41,12 @@ public class OutputHelperLoggerFactory : ILoggerFactory
             _natsServer = natsServer;
         }
 
+#if NET8_0_OR_GREATER
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+#else
         public IDisposable BeginScope<TState>(TState state)
+#endif
         {
             return NullDisposable.Instance;
         }

--- a/tests/NATS.Client.TestUtilities/WebSocketMockServer.cs
+++ b/tests/NATS.Client.TestUtilities/WebSocketMockServer.cs
@@ -1,0 +1,138 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using System.Text;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace NATS.Client.TestUtilities;
+
+public class WebSocketMockServer : IAsyncDisposable
+{
+    private readonly string _natsServerUrl;
+    private readonly Action<string> _logger;
+    private readonly CancellationTokenSource _cts;
+    private readonly Task _wsServerTask;
+
+    public WebSocketMockServer(
+        string natsServerUrl,
+        Func<HttpContext, bool> connectHandler,
+        Action<string> logger,
+        CancellationToken cancellationToken = default)
+    {
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellationToken = _cts.Token;
+        _natsServerUrl = natsServerUrl;
+        _logger = logger;
+        WebSocketPort = 5004;
+
+        _wsServerTask = RunWsServer(connectHandler, cancellationToken);
+    }
+
+    public int WebSocketPort { get; }
+
+    public string WebSocketUrl => $"ws://127.0.0.1:{WebSocketPort}";
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+
+        try
+        {
+            await _wsServerTask.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        catch (TimeoutException)
+        {
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (SocketException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private Task RunWsServer(Func<HttpContext, bool> connectHandler, CancellationToken ct)
+    {
+        var wsServerTask = WebHost.CreateDefaultBuilder()
+            .SuppressStatusMessages(true)
+            .ConfigureLogging(logging => logging.ClearProviders())
+            .ConfigureKestrel(options => options.ListenLocalhost(WebSocketPort)) // unfortunately need to hard-code WebSocket port because ListenLocalhost() doesn't support picking a dynamic port
+            .Configure(app => app.UseWebSockets().Run(async context =>
+            {
+                _logger($"[WS] Received WebSocketRequest with authorization header: {context.Request.Headers.Authorization}");
+
+                if (!connectHandler(context))
+                    return;
+
+                if (context.WebSockets.IsWebSocketRequest)
+                {
+                    using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                    await HandleRequestResponse(webSocket, ct);
+                }
+            }))
+            .Build().RunAsync(ct);
+
+        return wsServerTask;
+    }
+
+    private async Task HandleRequestResponse(WebSocket webSocket, CancellationToken ct)
+    {
+        var wsRequestBuffer = new byte[1024 * 4];
+        using TcpClient tcpClient = new();
+        var endpoint = IPEndPoint.Parse(_natsServerUrl);
+        await tcpClient.ConnectAsync(endpoint);
+        await using var stream = tcpClient.GetStream();
+
+        // send responses received from NATS mock server back to WebSocket client
+        var respondBackTask = Task.Run(async () =>
+        {
+            try
+            {
+                var tcpResponseBuffer = new byte[1024 * 4];
+
+                while (!ct.IsCancellationRequested)
+                {
+                    var received = await stream.ReadAsync(tcpResponseBuffer, ct);
+
+                    var message = Encoding.UTF8.GetString(tcpResponseBuffer, 0, received);
+
+                    await webSocket.SendAsync(
+                        new ArraySegment<byte>(tcpResponseBuffer, 0, received),
+                        WebSocketMessageType.Binary,
+                        true,
+                        ct);
+                }
+            }
+            catch (Exception e)
+            {
+                // if our TCP connection with the NATS mock server breaks then close the WebSocket too.
+                _logger($"[WS] Exception in response task: {e.Message}");
+                webSocket.Abort();
+            }
+        });
+
+        // forward received message via TCP to NATS mock server
+        var receiveResult = await webSocket.ReceiveAsync(
+            new ArraySegment<byte>(wsRequestBuffer), ct);
+
+        while (!receiveResult.CloseStatus.HasValue)
+        {
+            await stream.WriteAsync(wsRequestBuffer, 0, receiveResult.Count, ct);
+
+            receiveResult = await webSocket.ReceiveAsync(
+                new ArraySegment<byte>(wsRequestBuffer), ct);
+        }
+
+        await webSocket.CloseAsync(
+            receiveResult.CloseStatus.Value,
+            receiveResult.CloseStatusDescription,
+            CancellationToken.None);
+    }
+}


### PR DESCRIPTION
As discussed in #305 this PR is adding support for manipulating the ClientWebSocketOptions used for WebSocket connections. Among other things, this allows setting an authorization header.

* resolves #305