### PR TITLE
Make NuidWriter public

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       - name: Install nats
         run: |
-          rel=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/natscli/latest | sed s/v//)
+          rel=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/natscli/latest | sed s/v//)
           wget https://github.com/nats-io/natscli/releases/download/v$rel/nats-$rel-linux-amd64.zip
           unzip nats-$rel-linux-amd64.zip
           sudo mv nats-$rel-linux-amd64/nats /usr/local/bin
-          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
+          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,12 +28,7 @@ jobs:
           wget https://github.com/nats-io/natscli/releases/download/v$rel/nats-$rel-linux-amd64.zip
           unzip nats-$rel-linux-amd64.zip
           sudo mv nats-$rel-linux-amd64/nats /usr/local/bin
-          branch="${{ matrix.config.branch }}"
-          if [[ $branch == "v"* ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
-          elif [[ $branch == "latest" ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
-          fi
+          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -24,16 +24,15 @@ jobs:
     steps:
       - name: Install nats
         run: |
-          rel=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s https://api.github.com/repos/nats-io/natscli/releases/latest | jq -r .tag_name | sed s/v//)
+          rel=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/natscli/latest | sed s/v//)
           wget https://github.com/nats-io/natscli/releases/download/v$rel/nats-$rel-linux-amd64.zip
           unzip nats-$rel-linux-amd64.zip
           sudo mv nats-$rel-linux-amd64/nats /usr/local/bin
-          gh_api_url="https://api.github.com/repos/nats-io/nats-server/releases"
           branch="${{ matrix.config.branch }}"
           if [[ $branch == "v"* ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url | jq -r '.[].tag_name' | grep $branch | sort -V | tail -1)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
           elif [[ $branch == "latest" ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url/latest | jq -r .tag_name)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
           fi
           for i in 1 2 3
           do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Install nats-server
         run: |
-          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
+          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30
@@ -113,7 +113,7 @@ jobs:
         shell: bash
         run: |
           mkdir tools-nats-server && cd tools-nats-server
-          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
+          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,11 @@ jobs:
     steps:
       - name: Install nats-server
         run: |
-          gh_api_url="https://api.github.com/repos/nats-io/nats-server/releases"
           branch="${{ matrix.config.branch }}"
           if [[ $branch == "v"* ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url | jq -r '.[].tag_name' | grep $branch | sort -V | tail -1)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
           elif [[ $branch == "latest" ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url/latest | jq -r .tag_name)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
           fi
           for i in 1 2 3
           do
@@ -119,12 +118,11 @@ jobs:
         shell: bash
         run: |
           mkdir tools-nats-server && cd tools-nats-server
-          gh_api_url="https://api.github.com/repos/nats-io/nats-server/releases"
           branch="${{ matrix.config.branch }}"
           if [[ $branch == "v"* ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url | jq -r '.[].tag_name' | grep $branch | sort -V | tail -1)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
           elif [[ $branch == "latest" ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url/latest | jq -r .tag_name)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
           fi
           for i in 1 2 3
           do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,7 @@ jobs:
     steps:
       - name: Install nats-server
         run: |
-          branch="${{ matrix.config.branch }}"
-          if [[ $branch == "v"* ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
-          elif [[ $branch == "latest" ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
-          fi
+          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30
@@ -118,12 +113,7 @@ jobs:
         shell: bash
         run: |
           mkdir tools-nats-server && cd tools-nats-server
-          branch="${{ matrix.config.branch }}"
-          if [[ $branch == "v"* ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
-          elif [[ $branch == "latest" ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
-          fi
+          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30

--- a/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
+++ b/sandbox/MicroBenchmark/NewInboxBenchmarks.cs
@@ -25,14 +25,14 @@ public class NewInboxBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        NuidWriter.TryWriteNuid(new char[100]);
+        Nuid.TryWriteNuid(new char[100]);
     }
 
     [Benchmark(Baseline = true)]
     [SkipLocalsInit]
     public bool TryWriteNuid()
     {
-        return NuidWriter.TryWriteNuid(_buf);
+        return Nuid.TryWriteNuid(_buf);
     }
 
     [Benchmark]

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -112,12 +112,12 @@ public partial class NatsConnection
             state.prefix.AsSpan().CopyTo(buffer);
             buffer[state.prefix.Length] = '.';
             var remaining = buffer.Slice(state.pfxLen);
-            var didWrite = NuidWriter.TryWriteNuid(remaining);
+            var didWrite = Nuid.TryWriteNuid(remaining);
             Debug.Assert(didWrite, "didWrite");
         }
 
         var separatorLength = prefix.Length > 0 ? 1 : 0;
-        var totalLength = prefix.Length + (int)NuidWriter.NuidLength + separatorLength;
+        var totalLength = prefix.Length + (int)Nuid.NuidLength + separatorLength;
         var totalPrefixLength = prefix.Length + separatorLength;
 
 #if NET6_0_OR_GREATER || NETSTANDARD2_1

--- a/src/NATS.Client.Core/Nuid.cs
+++ b/src/NATS.Client.Core/Nuid.cs
@@ -8,8 +8,15 @@ using Random = NATS.Client.Core.Internal.NetStandardExtensions.Random;
 
 namespace NATS.Client.Core;
 
+/// <summary>
+/// Represents a unique identifier generator.
+/// </summary>
+/// <remarks>
+/// The <c>Nuid</c> class generates unique identifiers that can be used
+/// to ensure uniqueness in distributed systems.
+/// </remarks>
 [SkipLocalsInit]
-public sealed class NuidWriter
+public sealed class Nuid
 {
     // NuidLength, PrefixLength, SequentialLength were nuint (System.UIntPtr) in the original code
     // however, they were changed to uint to fix the compilation error for IL2CPP Unity projects.
@@ -25,13 +32,13 @@ public sealed class NuidWriter
     private const int MaxIncrement = 333;
 
     [ThreadStatic]
-    private static NuidWriter? _writer;
+    private static Nuid? _writer;
 
     private char[] _prefix;
     private ulong _increment;
     private ulong _sequential;
 
-    private NuidWriter()
+    private Nuid()
     {
         Refresh(out _);
     }
@@ -42,16 +49,11 @@ public sealed class NuidWriter
     private static ReadOnlySpan<char> Digits => "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 #endif
 
-    public static bool TryWriteNuid(Span<char> nuidBuffer)
-    {
-        if (_writer is not null)
-        {
-            return _writer.TryWriteNuidCore(nuidBuffer);
-        }
-
-        return InitAndWrite(nuidBuffer);
-    }
-
+    /// <summary>
+    /// Generates a new NATS unique identifier (NUID).
+    /// </summary>
+    /// <returns>A new NUID as a string.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when unable to generate the NUID.</exception>
     public static string NewNuid()
     {
         Span<char> buffer = stackalloc char[22];
@@ -61,6 +63,16 @@ public sealed class NuidWriter
         }
 
         throw new InvalidOperationException("Internal error: can't generate nuid");
+    }
+
+    internal static bool TryWriteNuid(Span<char> nuidBuffer)
+    {
+        if (_writer is not null)
+        {
+            return _writer.TryWriteNuidCore(nuidBuffer);
+        }
+
+        return InitAndWrite(nuidBuffer);
     }
 
     private static bool TryWriteNuidCore(Span<char> buffer, Span<char> prefix, ulong sequential)
@@ -140,7 +152,7 @@ public sealed class NuidWriter
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static bool InitAndWrite(Span<char> span)
     {
-        _writer = new NuidWriter();
+        _writer = new Nuid();
         return _writer.TryWriteNuidCore(span);
     }
 

--- a/src/NATS.Client.Core/Nuid.cs
+++ b/src/NATS.Client.Core/Nuid.cs
@@ -56,7 +56,7 @@ public sealed class Nuid
     /// <exception cref="InvalidOperationException">Thrown when unable to generate the NUID.</exception>
     public static string NewNuid()
     {
-        Span<char> buffer = stackalloc char[22];
+        Span<char> buffer = stackalloc char[NuidLength];
         if (TryWriteNuid(buffer))
         {
             return buffer.ToString();

--- a/src/NATS.Client.Core/Nuid.cs
+++ b/src/NATS.Client.Core/Nuid.cs
@@ -56,7 +56,7 @@ public sealed class Nuid
     /// <exception cref="InvalidOperationException">Thrown when unable to generate the NUID.</exception>
     public static string NewNuid()
     {
-        Span<char> buffer = stackalloc char[NuidLength];
+        Span<char> buffer = stackalloc char[(int)NuidLength];
         if (TryWriteNuid(buffer))
         {
             return buffer.ToString();

--- a/src/NATS.Client.Core/NuidWriter.cs
+++ b/src/NATS.Client.Core/NuidWriter.cs
@@ -6,10 +6,10 @@ using System.Security.Cryptography;
 using Random = NATS.Client.Core.Internal.NetStandardExtensions.Random;
 #endif
 
-namespace NATS.Client.Core.Internal;
+namespace NATS.Client.Core;
 
 [SkipLocalsInit]
-internal sealed class NuidWriter
+public sealed class NuidWriter
 {
     // NuidLength, PrefixLength, SequentialLength were nuint (System.UIntPtr) in the original code
     // however, they were changed to uint to fix the compilation error for IL2CPP Unity projects.

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
@@ -390,7 +390,7 @@ internal class NatsJSOrderedPushConsumer<T>
     private string NewNuid()
     {
         Span<char> buffer = stackalloc char[22];
-        if (NuidWriter.TryWriteNuid(buffer))
+        if (Nuid.TryWriteNuid(buffer))
         {
             return buffer.ToString();
         }

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -228,7 +228,7 @@ public partial class NatsJSContext : INatsJSContext
             request.Config.FilterSubjects = opts.FilterSubjects;
         }
 
-        var name = NuidWriter.NewNuid();
+        var name = Nuid.NewNuid();
         var subject = $"{Opts.Prefix}.CONSUMER.CREATE.{stream}.{name}";
 
         return JSRequestResponseAsync<ConsumerCreateRequest, ConsumerInfo>(

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -1,5 +1,5 @@
 using System.Runtime.CompilerServices;
-using NATS.Client.Core.Internal;
+using NATS.Client.Core;
 using NATS.Client.JetStream.Models;
 
 namespace NATS.Client.JetStream;

--- a/src/NATS.Client.KeyValueStore/Internal/NatsKVWatcher.cs
+++ b/src/NATS.Client.KeyValueStore/Internal/NatsKVWatcher.cs
@@ -444,7 +444,7 @@ internal class NatsKVWatcher<T> : IAsyncDisposable
     private string NewNuid()
     {
         Span<char> buffer = stackalloc char[22];
-        if (NuidWriter.TryWriteNuid(buffer))
+        if (Nuid.TryWriteNuid(buffer))
         {
             return buffer.ToString();
         }

--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -707,7 +707,7 @@ public class NatsObjStore : INatsObjStore
     private string NewNuid()
     {
         Span<char> buffer = stackalloc char[22];
-        if (NuidWriter.TryWriteNuid(buffer))
+        if (Nuid.TryWriteNuid(buffer))
         {
             return buffer.ToString();
         }

--- a/src/NATS.Client.Services/NatsSvcServer.cs
+++ b/src/NATS.Client.Services/NatsSvcServer.cs
@@ -34,7 +34,7 @@ public class NatsSvcServer : INatsSvcServer
     public NatsSvcServer(NatsConnection nats, NatsSvcConfig config, CancellationToken cancellationToken)
     {
         _logger = nats.Opts.LoggerFactory.CreateLogger<NatsSvcServer>();
-        _id = NuidWriter.NewNuid();
+        _id = Nuid.NewNuid();
         _nats = nats;
         _config = config;
         _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
@@ -611,7 +611,7 @@ public class KeyValueStoreTest
     [Fact]
     public async Task TestDirectMessageRepublishedSubject()
     {
-        var streamBucketName = "sb-" + NuidWriter.NewNuid();
+        var streamBucketName = "sb-" + Nuid.NewNuid();
         var subject = "test";
         var streamSubject = subject + ".>";
         var publishSubject1 = subject + ".one";


### PR DESCRIPTION
This PR makes the `NuidWriter` class public, and moves it into the `Core` namespace out of the `Internal` namespace. 

Resolves #617.