### PR TITLE
ServiceProvider callback for NATS DI configuration;

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       - name: Install nats
         run: |
-          rel=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/natscli/latest | sed s/v//)
+          rel=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/natscli/latest | sed s/v//)
           wget https://github.com/nats-io/natscli/releases/download/v$rel/nats-$rel-linux-amd64.zip
           unzip nats-$rel-linux-amd64.zip
           sudo mv nats-$rel-linux-amd64/nats /usr/local/bin
-          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
+          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,12 +28,7 @@ jobs:
           wget https://github.com/nats-io/natscli/releases/download/v$rel/nats-$rel-linux-amd64.zip
           unzip nats-$rel-linux-amd64.zip
           sudo mv nats-$rel-linux-amd64/nats /usr/local/bin
-          branch="${{ matrix.config.branch }}"
-          if [[ $branch == "v"* ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
-          elif [[ $branch == "latest" ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
-          fi
+          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -24,16 +24,15 @@ jobs:
     steps:
       - name: Install nats
         run: |
-          rel=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s https://api.github.com/repos/nats-io/natscli/releases/latest | jq -r .tag_name | sed s/v//)
+          rel=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/natscli/latest | sed s/v//)
           wget https://github.com/nats-io/natscli/releases/download/v$rel/nats-$rel-linux-amd64.zip
           unzip nats-$rel-linux-amd64.zip
           sudo mv nats-$rel-linux-amd64/nats /usr/local/bin
-          gh_api_url="https://api.github.com/repos/nats-io/nats-server/releases"
           branch="${{ matrix.config.branch }}"
           if [[ $branch == "v"* ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url | jq -r '.[].tag_name' | grep $branch | sort -V | tail -1)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
           elif [[ $branch == "latest" ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url/latest | jq -r .tag_name)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
           fi
           for i in 1 2 3
           do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Install nats-server
         run: |
-          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
+          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30
@@ -113,7 +113,7 @@ jobs:
         shell: bash
         run: |
           mkdir tools-nats-server && cd tools-nats-server
-          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
+          branch=$(curl https://api.mtmk.dev/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,11 @@ jobs:
     steps:
       - name: Install nats-server
         run: |
-          gh_api_url="https://api.github.com/repos/nats-io/nats-server/releases"
           branch="${{ matrix.config.branch }}"
           if [[ $branch == "v"* ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url | jq -r '.[].tag_name' | grep $branch | sort -V | tail -1)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
           elif [[ $branch == "latest" ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url/latest | jq -r .tag_name)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
           fi
           for i in 1 2 3
           do
@@ -119,12 +118,11 @@ jobs:
         shell: bash
         run: |
           mkdir tools-nats-server && cd tools-nats-server
-          gh_api_url="https://api.github.com/repos/nats-io/nats-server/releases"
           branch="${{ matrix.config.branch }}"
           if [[ $branch == "v"* ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url | jq -r '.[].tag_name' | grep $branch | sort -V | tail -1)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
           elif [[ $branch == "latest" ]]; then
-            branch=$(curl -H 'Authorization: token ${{ secrets.AUTH_TOKEN_FOR_GITHUB_API }}' -s $gh_api_url/latest | jq -r .tag_name)
+            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
           fi
           for i in 1 2 3
           do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,7 @@ jobs:
     steps:
       - name: Install nats-server
         run: |
-          branch="${{ matrix.config.branch }}"
-          if [[ $branch == "v"* ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
-          elif [[ $branch == "latest" ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
-          fi
+          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30
@@ -118,12 +113,7 @@ jobs:
         shell: bash
         run: |
           mkdir tools-nats-server && cd tools-nats-server
-          branch="${{ matrix.config.branch }}"
-          if [[ $branch == "v"* ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/$branch)
-          elif [[ $branch == "latest" ]]; then
-            branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/latest)
-          fi
+          branch=$(curl https://api.mtmk.net/gh/v1/releases/tag/nats-io/nats-server/${{ matrix.config.branch }})
           for i in 1 2 3
           do
             curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$branch | PREFIX=. sh && break || sleep 30

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
@@ -30,7 +30,7 @@ public class NatsBuilder
 
     public NatsBuilder ConfigureOptions(Func<IServiceProvider, NatsOpts, NatsOpts> optsFactory)
     {
-        Func<IServiceProvider, NatsOpts, NatsOpts>? configure = _configureOpts;
+        var configure = _configureOpts;
         _configureOpts = (serviceProvider, opts) =>
         {
             opts = configure?.Invoke(serviceProvider, opts) ?? opts;
@@ -46,7 +46,7 @@ public class NatsBuilder
 
     public NatsBuilder ConfigureConnection(Action<IServiceProvider, NatsConnection> configureConnection)
     {
-        Action<IServiceProvider, NatsConnection>? configure = _configureConnection;
+        var configure = _configureConnection;
         _configureConnection = (serviceProvider, connection) =>
         {
             configure?.Invoke(serviceProvider, connection);
@@ -63,7 +63,7 @@ public class NatsBuilder
     public NatsBuilder AddJsonSerialization(Func<IServiceProvider, JsonSerializerContext> contextFactory)
         => ConfigureOptions((serviceProvider, opts) =>
         {
-            JsonSerializerContext context = contextFactory(serviceProvider);
+            var context = contextFactory(serviceProvider);
             NatsJsonContextSerializerRegistry jsonRegistry = new(context);
 
             return opts with { SerializerRegistry = jsonRegistry };

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
@@ -9,9 +9,10 @@ namespace NATS.Extensions.Microsoft.DependencyInjection;
 public class NatsBuilder
 {
     private readonly IServiceCollection _services;
+
     private int _poolSize = 1;
-    private Func<NatsOpts, NatsOpts>? _configureOpts;
-    private Action<NatsConnection>? _configureConnection;
+    private Func<IServiceProvider, NatsOpts, NatsOpts>? _configureOpts;
+    private Action<IServiceProvider, NatsConnection>? _configureConnection;
     private object? _diKey = null;
 
     public NatsBuilder(IServiceCollection services)
@@ -20,36 +21,48 @@ public class NatsBuilder
     public NatsBuilder WithPoolSize(int size)
     {
         _poolSize = Math.Max(size, 1);
+
         return this;
     }
 
-    public NatsBuilder ConfigureOptions(Func<NatsOpts, NatsOpts> optsFactory)
-    {
-        var previousFactory = _configureOpts;
-        _configureOpts = opts =>
-        {
-            // Apply the previous configurator if it exists.
-            if (previousFactory != null)
-            {
-                opts = previousFactory(opts);
-            }
+    public NatsBuilder ConfigureOptions(Func<NatsOpts, NatsOpts> optsFactory) =>
+        ConfigureOptions((_, opts) => optsFactory(opts));
 
-            // Then apply the new configurator.
-            return optsFactory(opts);
+    public NatsBuilder ConfigureOptions(Func<IServiceProvider, NatsOpts, NatsOpts> optsFactory)
+    {
+        _configureOpts = (serviceProvider, opts) =>
+        {
+            opts = _configureOpts?.Invoke(serviceProvider, opts) ?? opts;
+
+            return optsFactory(serviceProvider, opts);
+        };
+
+        return this;
+    }
+
+    public NatsBuilder ConfigureConnection(Action<NatsConnection> configureConnection) =>
+        ConfigureConnection((_, con) => configureConnection(con));
+
+    public NatsBuilder ConfigureConnection(Action<IServiceProvider, NatsConnection> configureConnection)
+    {
+        _configureConnection = (serviceProvider, connection) =>
+        {
+            _configureConnection?.Invoke(serviceProvider, connection);
+
+            configureConnection(serviceProvider, connection);
         };
         return this;
     }
 
-    public NatsBuilder ConfigureConnection(Action<NatsConnection> connectionOpts)
-    {
-        _configureConnection = connectionOpts;
-        return this;
-    }
+    public NatsBuilder AddJsonSerialization(JsonSerializerContext context) =>
+        AddJsonSerialization(_ => context);
 
-    public NatsBuilder AddJsonSerialization(JsonSerializerContext context)
-        => ConfigureOptions(opts =>
+    public NatsBuilder AddJsonSerialization(Func<IServiceProvider, JsonSerializerContext> contextFactory)
+        => ConfigureOptions((serviceProvider, opts) =>
         {
-            var jsonRegistry = new NatsJsonContextSerializerRegistry(context);
+            JsonSerializerContext context = contextFactory(serviceProvider);
+            NatsJsonContextSerializerRegistry jsonRegistry = new(context);
+
             return opts with { SerializerRegistry = jsonRegistry };
         });
 
@@ -57,6 +70,7 @@ public class NatsBuilder
     public NatsBuilder WithKey(object key)
     {
         _diKey = key;
+
         return this;
     }
 #endif
@@ -117,18 +131,18 @@ public class NatsBuilder
     private NatsConnectionPool PoolFactory(IServiceProvider provider, object? diKey = null)
     {
         var options = NatsOpts.Default with { LoggerFactory = provider.GetRequiredService<ILoggerFactory>() };
-        options = _configureOpts?.Invoke(options) ?? options;
+        options = _configureOpts?.Invoke(provider, options) ?? options;
 
-        return new NatsConnectionPool(_poolSize, options, _configureConnection ?? (_ => { }));
+        return new NatsConnectionPool(_poolSize, options, con => _configureConnection?.Invoke(provider, con));
     }
 
     private NatsConnection SingleConnectionFactory(IServiceProvider provider, object? diKey = null)
     {
         var options = NatsOpts.Default with { LoggerFactory = provider.GetRequiredService<ILoggerFactory>() };
-        options = _configureOpts?.Invoke(options) ?? options;
+        options = _configureOpts?.Invoke(provider, options) ?? options;
 
         var conn = new NatsConnection(options);
-        _configureConnection?.Invoke(conn);
+        _configureConnection?.Invoke(provider, conn);
 
         return conn;
     }

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
@@ -30,9 +30,10 @@ public class NatsBuilder
 
     public NatsBuilder ConfigureOptions(Func<IServiceProvider, NatsOpts, NatsOpts> optsFactory)
     {
+        Func<IServiceProvider, NatsOpts, NatsOpts>? configure = _configureOpts;
         _configureOpts = (serviceProvider, opts) =>
         {
-            opts = _configureOpts?.Invoke(serviceProvider, opts) ?? opts;
+            opts = configure?.Invoke(serviceProvider, opts) ?? opts;
 
             return optsFactory(serviceProvider, opts);
         };
@@ -45,12 +46,14 @@ public class NatsBuilder
 
     public NatsBuilder ConfigureConnection(Action<IServiceProvider, NatsConnection> configureConnection)
     {
+        Action<IServiceProvider, NatsConnection>? configure = _configureConnection;
         _configureConnection = (serviceProvider, connection) =>
         {
-            _configureConnection?.Invoke(serviceProvider, connection);
+            configure?.Invoke(serviceProvider, connection);
 
             configureConnection(serviceProvider, connection);
         };
+
         return this;
     }
 

--- a/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/MyResolvedService.cs
+++ b/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/MyResolvedService.cs
@@ -1,0 +1,11 @@
+namespace NATS.Extensions.Microsoft.DependencyInjection.Tests;
+
+internal interface IMyResolvedService
+{
+    string GetValue();
+}
+
+internal class MyResolvedService(string value) : IMyResolvedService
+{
+    public string GetValue() => value;
+}

--- a/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/NatsHostingExtensionsTests.cs
+++ b/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/NatsHostingExtensionsTests.cs
@@ -80,6 +80,55 @@ public class NatsHostingExtensionsTests
         return Task.CompletedTask;
     }
 
+    [Fact]
+    public Task AddNatsClient_ConfigureOptionsSetsUrlResolvesServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+        services.AddSingleton<IMyResolvedService>(new MyResolvedService("url-set"));
+        services.AddNatsClient(nats => nats.ConfigureOptions((serviceProvider, opts) =>
+        {
+            opts = opts with
+            {
+                Url = serviceProvider.GetRequiredService<IMyResolvedService>().GetValue(),
+            };
+
+            return opts;
+        }));
+
+        var provider = services.BuildServiceProvider();
+        var nats = provider.GetRequiredService<INatsConnection>();
+
+        Assert.Equal("url-set", nats.Opts.Url);
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task AddNatsClient_ConfigureConnectionResolvesServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+        services.AddSingleton<IMyResolvedService>(new MyResolvedService("url-set"));
+
+        AsyncEventHandler<NatsEventArgs> handler = async (sender, args) => { };
+        services.AddNatsClient(nats => nats.ConfigureConnection((serviceProvider, conn) =>
+        {
+            conn.OnConnectingAsync = async instance =>
+            {
+                string resolved = serviceProvider.GetRequiredService<IMyResolvedService>().GetValue();
+
+                return (resolved, instance.Port);
+            };
+        }));
+
+        var provider = services.BuildServiceProvider();
+        var nats = provider.GetRequiredService<NatsConnection>();
+
+        (string host, int _) = await nats.OnConnectingAsync!((Host: "host", Port: 123));
+        Assert.Equal("url-set", host);
+    }
+
 #if NET8_0_OR_GREATER
     [Fact]
     public void AddNats_RegistersKeyedNatsConnection_WhenKeyIsProvided()

--- a/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/NatsHostingExtensionsTests.cs
+++ b/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/NatsHostingExtensionsTests.cs
@@ -118,7 +118,7 @@ public class NatsHostingExtensionsTests
             {
                 conn.OnConnectingAsync = async instance =>
                 {
-                    string resolved = serviceProvider.GetRequiredService<IMyResolvedService>().GetValue();
+                    var resolved = serviceProvider.GetRequiredService<IMyResolvedService>().GetValue();
 
                     return (resolved, instance.Port);
                 };
@@ -127,7 +127,7 @@ public class NatsHostingExtensionsTests
         var provider = services.BuildServiceProvider();
         var nats = provider.GetRequiredService<NatsConnection>();
 
-        (string host, int _) = await nats.OnConnectingAsync!((Host: "host", Port: 123));
+        (var host, var _) = await nats.OnConnectingAsync!((Host: "host", Port: 123));
         Assert.Equal("url-set", host);
     }
 


### PR DESCRIPTION
## Issue

The NATS Client DependencyInjection package (`NatsBuilder`) does all configuration inline when the `.AddNatsClient` method is called. This does not allow consumers to build up a NATS instance across multiple packages, and all configuration must be defined at registration time, rather than runtime.

`MyCompany.Nats.Core`:
```cs
public static IServiceCollection AddMyCompanyNats(this IServiceCollection services)
{
    services.AddNatsClient(natsBuilder => natsBuilder
        .PoolSize(3)
        .ConfigureOptions(opts => {
            return opts; // How to configure??
         }))

    return services;
}
```

## Proposal

Add `IServiceProvider` overloads to configuration methods, to enable resolution-time configuration:

`MyCompany.Nats.Core`:
```cs
interface IConfigurator
{
    NatsOpts Configure(NatsOpts opts);
}

public static IServiceCollection AddMyCompanyNats(this IServiceCollection services)
{
    services.AddNatsClient(natsBuilder => natsBuilder
        .PoolSize(3)
        .ConfigureOptions((serviceProvider, opts) => {
            IOptsConfigurator configurator = serviceProvider.GetRequiredService<IOptsConfigurator>();

            opts = configurator.Configure(opts);

            return opts; 
         }))

    return services;
}
```

`MyCompany.Nats.HighSecurityCluster`:
```cs
public class HighSecurityConfigurator : IConfigurator
{
    public NatsOpts Configure(NatsOpts opts) =>
        opts with {
            TlsOpts = opts.TlsOpts with {
                InsecureSkipVerify = false,
            }
        };
}
```

`MyCompany.Nats.DemoCluster`
```cs
public class DemoConfigurator : IConfigurator
{
    public NatsOpts Configure(NatsOpts opts) =>
        opts with {
            TlsOpts = opts.TlsOpts with {
                InsecureSkipVerify = true,
            }
        };
}
```