### PR TITLE
Adds type-forwarders NET 5.0+

### DIFF
--- a/src/NATS.Client.Core/Internal/netstandard.cs
+++ b/src/NATS.Client.Core/Internal/netstandard.cs
@@ -10,9 +10,11 @@
 #pragma warning disable SA1204
 #pragma warning disable SA1405
 
-#if NETSTANDARD
-
 // Enable init only setters
+#if NET5_0_OR_GREATER
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsExternalInit))]
+#elif NETSTANDARD
+
 namespace System.Runtime.CompilerServices
 {
     internal static class IsExternalInit
@@ -33,7 +35,9 @@ namespace System.Runtime.CompilerServices
     {
     }
 }
+#endif
 
+#if NETSTANDARD
 namespace System.Diagnostics
 {
     internal sealed class StackTraceHiddenAttribute : Attribute


### PR DESCRIPTION
Adds missing type forwarders to fix `MissingMethodExceptions` when this library is consumed by a .NET standard library, which is then consumed by a > .NET 5 app

Resolves #640