### PR TITLE
Add OnSocketAvailableAsync Hook

### DIFF
--- a/src/NATS.Client.Core/INatsConnection.cs
+++ b/src/NATS.Client.Core/INatsConnection.cs
@@ -6,16 +6,6 @@ namespace NATS.Client.Core;
 public interface INatsConnection : INatsClient
 {
     /// <summary>
-    /// Hook before TCP connection open.
-    /// </summary>
-    Func<(string Host, int Port), ValueTask<(string Host, int Port)>>? OnConnectingAsync { get; set; }
-
-    /// <summary>
-    /// Hook when socket is available.
-    /// </summary>
-    Func<ISocketConnection, ValueTask<ISocketConnection>>? OnSocketAvailableAsync { get; set; }
-
-    /// <summary>
     /// Event that is raised when the connection to the NATS server is disconnected.
     /// </summary>
     event AsyncEventHandler<NatsEventArgs>? ConnectionDisconnected;
@@ -60,6 +50,16 @@ public interface INatsConnection : INatsClient
     /// used by the NATS connection.
     /// </summary>
     NatsHeaderParser HeaderParser { get; }
+
+    /// <summary>
+    /// Hook before TCP connection open.
+    /// </summary>
+    Func<(string Host, int Port), ValueTask<(string Host, int Port)>>? OnConnectingAsync { get; set; }
+
+    /// <summary>
+    /// Hook when socket is available.
+    /// </summary>
+    Func<ISocketConnection, ValueTask<ISocketConnection>>? OnSocketAvailableAsync { get; set; }
 
     /// <summary>
     /// Publishes a serializable message payload to the given subject name, optionally supplying a reply subject.

--- a/src/NATS.Client.Core/INatsConnection.cs
+++ b/src/NATS.Client.Core/INatsConnection.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
-using NATS.Client.Core.Internal;
 
 namespace NATS.Client.Core;
 

--- a/src/NATS.Client.Core/INatsConnection.cs
+++ b/src/NATS.Client.Core/INatsConnection.cs
@@ -1,10 +1,21 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
+using NATS.Client.Core.Internal;
 
 namespace NATS.Client.Core;
 
 public interface INatsConnection : INatsClient
 {
+    /// <summary>
+    /// Hook before TCP connection open.
+    /// </summary>
+    Func<(string Host, int Port), ValueTask<(string Host, int Port)>>? OnConnectingAsync { get; set; }
+
+    /// <summary>
+    /// Hook when socket is available.
+    /// </summary>
+    Func<ISocketConnection, ValueTask<ISocketConnection>>? OnSocketAvailableAsync { get; set; }
+
     /// <summary>
     /// Event that is raised when the connection to the NATS server is disconnected.
     /// </summary>

--- a/src/NATS.Client.Core/ISocketConnection.cs
+++ b/src/NATS.Client.Core/ISocketConnection.cs
@@ -1,4 +1,4 @@
-namespace NATS.Client.Core.Internal;
+namespace NATS.Client.Core;
 
 public interface ISocketConnection : IAsyncDisposable
 {

--- a/src/NATS.Client.Core/Internal/ISocketConnection.cs
+++ b/src/NATS.Client.Core/Internal/ISocketConnection.cs
@@ -1,6 +1,6 @@
 namespace NATS.Client.Core.Internal;
 
-internal interface ISocketConnection : IAsyncDisposable
+public interface ISocketConnection : IAsyncDisposable
 {
     public Task<Exception> WaitForClosed { get; }
 

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -530,4 +530,3 @@ public class SampleClass : IEquatable<SampleClass>
         return $"{Id}-{Name}";
     }
 }
-

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -412,6 +412,60 @@ public abstract partial class NatsConnectionTest
 
         Assert.Matches("A{512}\\.[A-z0-9]{22}", inbox);
     }
+
+    [Fact]
+    public async Task OnSocketAvailableAsync_ShouldBeInvokedOnInitialConnection()
+    {
+        // Arrange
+        await using var server = NatsServer.Start();
+        var clientOpts = server.ClientOpts(NatsOpts.Default);
+
+        var wasInvoked = false;
+        var nats = new NatsConnection(clientOpts);
+        nats.OnSocketAvailableAsync = async socket =>
+        {
+            wasInvoked = true;
+            await Task.Delay(10);
+            return socket;
+        };
+
+        // Act
+        await nats.ConnectAsync();
+
+        // Assert
+        Assert.True(wasInvoked, "OnSocketAvailableAsync should be invoked on initial connection.");
+    }
+
+    [Fact]
+    public async Task OnSocketAvailableAsync_ShouldBeInvokedOnReconnection()
+    {
+        // Arrange
+        await using var server = NatsServer.Start();
+        var clientOpts = server.ClientOpts(NatsOpts.Default);
+
+        var invocationCount = 0;
+        var nats = new NatsConnection(clientOpts);
+        nats.OnSocketAvailableAsync = async socket =>
+        {
+            invocationCount++;
+            await Task.Delay(10);
+            return socket;
+        };
+
+        // Simulate initial connection
+        await nats.ConnectAsync();
+
+        // Simulate disconnection
+        await server.StopAsync();
+
+        // Act
+        // Simulate reconnection
+        server.StartServerProcess();
+        await nats.ConnectAsync();
+
+        // Assert
+        Assert.Equal(2, invocationCount);
+    }
 }
 
 [JsonSerializable(typeof(SampleClass))]
@@ -476,3 +530,4 @@ public class SampleClass : IEquatable<SampleClass>
         return $"{Id}-{Name}";
     }
 }
+

--- a/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
@@ -105,6 +105,8 @@ public class NatsJSContextFactoryTest
         public INatsSubscriptionManager SubscriptionManager { get; } = new TestSubscriptionManager();
 
         public NatsHeaderParser HeaderParser { get; } = new NatsHeaderParser(Encoding.UTF8);
+        public Func<(string Host, int Port), ValueTask<(string Host, int Port)>>? OnConnectingAsync { get; set; }
+        public Func<ISocketConnection, ValueTask<ISocketConnection>>? OnSocketAvailableAsync { get; set; }
 
         public ValueTask<TimeSpan> PingAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
 

--- a/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
@@ -105,7 +105,9 @@ public class NatsJSContextFactoryTest
         public INatsSubscriptionManager SubscriptionManager { get; } = new TestSubscriptionManager();
 
         public NatsHeaderParser HeaderParser { get; } = new NatsHeaderParser(Encoding.UTF8);
+
         public Func<(string Host, int Port), ValueTask<(string Host, int Port)>>? OnConnectingAsync { get; set; }
+
         public Func<ISocketConnection, ValueTask<ISocketConnection>>? OnSocketAvailableAsync { get; set; }
 
         public ValueTask<TimeSpan> PingAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();


### PR DESCRIPTION
# Motivation

This change adds the `OnSocketAvailableAsync` hook, allowing users to perform actions on the socket once it becomes available. This is particularly useful for scenarios where an HTTP proxy is required to connect to a NATS server.

# Key Change

This hook enables users to interact with the socket directly, allowing custom actions such as sending an HTTP CONNECT request to establish a tunnel through a proxy.

# Example Usage

```csharp
_connection.OnSocketAvailableAsync = async (_socket) =>
{
    var hostname = "my-http-proxy-host";
    var port = 3128;
    string connectRequest = $"CONNECT {hostname}:{port} HTTP/1.1\r\nHost: {hostname}:{port}\r\n\r\n";
    byte[] requestBytes = Encoding.ASCII.GetBytes(connectRequest);
    await _socket.SendAsync(requestBytes);

    // Validate proxy response
    byte[] buffer = new byte[4096];
    int bytesRead = await _socket.ReceiveAsync(buffer);
    string response = Encoding.ASCII.GetString(buffer, 0, bytesRead);

    if (!response.Contains("200 Connection established"))
    {
        throw new Exception($"Proxy connection failed. Response: {response}");
    }
};
```