### PR TITLE
Add isAotCompatible build flag

### DIFF
--- a/src/NATS.Client.Core/NATS.Client.Core.csproj
+++ b/src/NATS.Client.Core/NATS.Client.Core.csproj
@@ -22,7 +22,11 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0'">
-        <Trimmable>true</Trimmable>
+        <IsTrimmable>true</IsTrimmable>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <isAotCompatible>true</isAotCompatible>
     </PropertyGroup>
 
     <!--  Dependencies for all -->

--- a/src/NATS.Client.Hosting/NATS.Client.Hosting.csproj
+++ b/src/NATS.Client.Hosting/NATS.Client.Hosting.csproj
@@ -16,6 +16,10 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <isAotCompatible>true</isAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
   </ItemGroup>

--- a/src/NATS.Client.JetStream/NATS.Client.JetStream.csproj
+++ b/src/NATS.Client.JetStream/NATS.Client.JetStream.csproj
@@ -16,6 +16,10 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <isAotCompatible>true</isAotCompatible>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
     <NoWarn>$(NoWarn);CS8774</NoWarn>
   </PropertyGroup>

--- a/src/NATS.Client.KeyValueStore/NATS.Client.KeyValueStore.csproj
+++ b/src/NATS.Client.KeyValueStore/NATS.Client.KeyValueStore.csproj
@@ -16,6 +16,10 @@
       <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <isAotCompatible>true</isAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\NATS.Client.JetStream\NATS.Client.JetStream.csproj"/>
     <InternalsVisibleTo Include="$(AssemblyName).Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db7da1f2f89089327b47d26d69666fad20861f24e9acdb13965fb6c64dfee8da589b495df37a75e934ddbacb0752a42c40f3dbc79614eec9bb2a0b6741f9e2ad2876f95e74d54c23eef0063eb4efb1e7d824ee8a695b647c113c92834f04a3a83fb60f435814ddf5c4e5f66a168139c4c1b1a50a3e60c164d180e265b1f000cd"/>

--- a/src/NATS.Client.ObjectStore/NATS.Client.ObjectStore.csproj
+++ b/src/NATS.Client.ObjectStore/NATS.Client.ObjectStore.csproj
@@ -16,6 +16,10 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <isAotCompatible>true</isAotCompatible>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <NoWarn>$(NoWarn);CS8604</NoWarn>
   </PropertyGroup>

--- a/src/NATS.Client.Services/NATS.Client.Services.csproj
+++ b/src/NATS.Client.Services/NATS.Client.Services.csproj
@@ -16,6 +16,10 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <isAotCompatible>true</isAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\NATS.Client.Core\NATS.Client.Core.csproj"/>
     <InternalsVisibleTo Include="$(AssemblyName).Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db7da1f2f89089327b47d26d69666fad20861f24e9acdb13965fb6c64dfee8da589b495df37a75e934ddbacb0752a42c40f3dbc79614eec9bb2a0b6741f9e2ad2876f95e74d54c23eef0063eb4efb1e7d824ee8a695b647c113c92834f04a3a83fb60f435814ddf5c4e5f66a168139c4c1b1a50a3e60c164d180e265b1f000cd"/>

--- a/tests/NATS.Client.CheckNativeAot/NATS.Client.CheckNativeAot.csproj
+++ b/tests/NATS.Client.CheckNativeAot/NATS.Client.CheckNativeAot.csproj
@@ -23,19 +23,12 @@
       <ProjectReference Include="..\..\src\NATS.Client.ObjectStore\NATS.Client.ObjectStore.csproj" />
       <ProjectReference Include="..\..\src\NATS.Client.Services\NATS.Client.Services.csproj" />
       <ProjectReference Include="..\NATS.Client.TestUtilities\NATS.Client.TestUtilities.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Remove="dist\testhost.exe" />
-      <None Remove="dist\testhost.dll" />
-      <None Remove="dist\NATS.Client.TestUtilities.runtimeconfig.json" />
-      <None Remove="dist\NATS.Client.Services.xml" />
-      <None Remove="dist\NATS.Client.ObjectStore.xml" />
-      <None Remove="dist\NATS.Client.KeyValueStore.xml" />
-      <None Remove="dist\NATS.Client.JetStream.xml" />
-      <None Remove="dist\NATS.Client.Hosting.xml" />
-      <None Remove="dist\NATS.Client.Core.xml" />
-      <None Remove="dist\NATS.Client.CheckNativeAot.exe" />
+      <TrimmerRootAssembly Include="NATS.Client.Core" />
+      <TrimmerRootAssembly Include="NATS.Client.Hosting" />
+      <TrimmerRootAssembly Include="NATS.Client.JetStream" />
+      <TrimmerRootAssembly Include="NATS.Client.KeyValueStore" />
+      <TrimmerRootAssembly Include="NATS.Client.ObjectStore" />
+      <TrimmerRootAssembly Include="NATS.Client.Services" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Just to make sure we are AOT friendly in core libraries. I think we were good anyway especially with our native AOT check runs this is to be compliant with general advice: https://learn.microsoft.com/dotnet/core/deploying/native-aot#aot-compatibility-analyzers