### PR TITLE
Fix date time serialization to use ISO8601

### DIFF
--- a/src/NATS.Client.Core/INatsSerialize.cs
+++ b/src/NATS.Client.Core/INatsSerialize.cs
@@ -116,7 +116,7 @@ public class NatsUtf8PrimitivesSerializer<T> : INatsSerializer<T>
         {
             if (value is DateTime input)
             {
-                if (Utf8Formatter.TryFormat(input, span, out var written))
+                if (Utf8Formatter.TryFormat(input, span, out var written, new StandardFormat('O')))
                 {
                     bufferWriter.Advance(written);
                 }
@@ -133,7 +133,19 @@ public class NatsUtf8PrimitivesSerializer<T> : INatsSerializer<T>
         {
             if (value is DateTimeOffset input)
             {
-                if (Utf8Formatter.TryFormat(input, span, out var written))
+                bool result;
+                int written;
+                if (input.Offset == TimeSpan.Zero)
+                {
+                    // This will make it place `Z` instead of `+00:00` at the end
+                    result = Utf8Formatter.TryFormat(input.UtcDateTime, span, out written, new StandardFormat('O'));
+                }
+                else
+                {
+                    result = Utf8Formatter.TryFormat(input, span, out written, new StandardFormat('O'));
+                }
+
+                if (result)
                 {
                     bufferWriter.Advance(written);
                 }
@@ -392,7 +404,7 @@ public class NatsUtf8PrimitivesSerializer<T> : INatsSerializer<T>
             if (buffer.Length == 0)
                 return default;
 
-            if (Utf8Parser.TryParse(span, out DateTime value, out _))
+            if (Utf8Parser.TryParse(span, out DateTime value, out _, 'O'))
             {
                 return (T)(object)value;
             }
@@ -405,7 +417,7 @@ public class NatsUtf8PrimitivesSerializer<T> : INatsSerializer<T>
             if (buffer.Length == 0)
                 return default;
 
-            if (Utf8Parser.TryParse(span, out DateTimeOffset value, out _))
+            if (Utf8Parser.TryParse(span, out DateTimeOffset value, out _, 'O'))
             {
                 return (T)(object)value;
             }

--- a/src/NATS.Client.Core/INatsSerialize.cs
+++ b/src/NATS.Client.Core/INatsSerialize.cs
@@ -116,7 +116,7 @@ public class NatsUtf8PrimitivesSerializer<T> : INatsSerializer<T>
         {
             if (value is DateTime input)
             {
-                if (Utf8Formatter.TryFormat(input, span, out var written, new StandardFormat('O')))
+                if (Utf8Formatter.TryFormat(input, span, out var written, Formats.DateTimeIsoFormat))
                 {
                     bufferWriter.Advance(written);
                 }
@@ -138,11 +138,11 @@ public class NatsUtf8PrimitivesSerializer<T> : INatsSerializer<T>
                 if (input.Offset == TimeSpan.Zero)
                 {
                     // This will make it place `Z` instead of `+00:00` at the end
-                    result = Utf8Formatter.TryFormat(input.UtcDateTime, span, out written, new StandardFormat('O'));
+                    result = Utf8Formatter.TryFormat(input.UtcDateTime, span, out written, Formats.DateTimeIsoFormat);
                 }
                 else
                 {
-                    result = Utf8Formatter.TryFormat(input, span, out written, new StandardFormat('O'));
+                    result = Utf8Formatter.TryFormat(input, span, out written, Formats.DateTimeIsoFormat);
                 }
 
                 if (result)
@@ -871,6 +871,11 @@ public class NatsSerializerBuilder<T>
 
         return _serializers[0];
     }
+}
+
+internal static class Formats
+{
+    public static readonly StandardFormat DateTimeIsoFormat = new(symbol: 'O');
 }
 
 internal sealed class NullBufferWriter : IBufferWriter<byte>

--- a/tests/NATS.Client.Core2.Tests/SerializerTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SerializerTest.cs
@@ -68,8 +68,9 @@ public class SerializerTest
     public void Utf8_serializer()
     {
         SerializeDeserialize<string>("foo", "foo");
-        SerializeDeserialize<DateTime>(DateTime.MinValue, "01/01/0001 00:00:00");
-        SerializeDeserialize<DateTimeOffset>(DateTimeOffset.MinValue, "01/01/0001 00:00:00 +00:00");
+        SerializeDeserialize<DateTime>(new DateTime(1970, 12, 31, 23, 42, 2, DateTimeKind.Utc), "1970-12-31T23:42:02.0000000Z");
+        SerializeDeserialize<DateTimeOffset>(new DateTimeOffset(1970, 12, 31, 23, 42, 2, TimeSpan.Zero), "1970-12-31T23:42:02.0000000Z");
+        SerializeDeserialize<DateTimeOffset>(new DateTimeOffset(1970, 12, 31, 23, 42, 2, TimeSpan.FromHours(1)), "1970-12-31T23:42:02.0000000+01:00");
         SerializeDeserialize<Guid>(Guid.Empty, "00000000-0000-0000-0000-000000000000");
         SerializeDeserialize<TimeSpan>(TimeSpan.Zero, "00:00:00");
         SerializeDeserialize<bool>(true, "True");


### PR DESCRIPTION
Doesn't make sense to serialize datetime types with the default culture dependent formatting since it might differ between different platforms. with this PR we use ISO8601 formatting as indicated by `O` to maximize the compatibility among different platforms and languages.