### PR TITLE
Add support for auth in URL

### DIFF
--- a/src/NATS.Client.Core/Internal/NatsUri.cs
+++ b/src/NATS.Client.Core/Internal/NatsUri.cs
@@ -4,6 +4,8 @@ internal sealed class NatsUri : IEquatable<NatsUri>
 {
     public const string DefaultScheme = "nats";
 
+    private readonly Uri _redactedUri;
+
     public NatsUri(string urlString, bool isSeed, string defaultScheme = DefaultScheme)
     {
         IsSeed = isSeed;
@@ -38,6 +40,20 @@ internal sealed class NatsUri : IEquatable<NatsUri>
         }
 
         Uri = uriBuilder.Uri;
+
+        if (uriBuilder.UserName is { Length: > 0 })
+        {
+            if (uriBuilder.Password is { Length: > 0 })
+            {
+                uriBuilder.Password = "***";
+            }
+            else
+            {
+                uriBuilder.UserName = "***";
+            }
+        }
+
+        _redactedUri = uriBuilder.Uri;
     }
 
     public Uri Uri { get; }
@@ -65,7 +81,7 @@ internal sealed class NatsUri : IEquatable<NatsUri>
 
     public override string ToString()
     {
-        return IsWebSocket && Uri.AbsolutePath != "/" ? Uri.ToString() : Uri.ToString().Trim('/');
+        return IsWebSocket && Uri.AbsolutePath != "/" ? _redactedUri.ToString() : _redactedUri.ToString().Trim('/');
     }
 
     public override int GetHashCode() => Uri.GetHashCode();

--- a/src/NATS.Client.Core/Internal/NatsUri.cs
+++ b/src/NATS.Client.Core/Internal/NatsUri.cs
@@ -4,7 +4,7 @@ internal sealed class NatsUri : IEquatable<NatsUri>
 {
     public const string DefaultScheme = "nats";
 
-    private readonly Uri _redactedUri;
+    private readonly string _redacted;
 
     public NatsUri(string urlString, bool isSeed, string defaultScheme = DefaultScheme)
     {
@@ -41,6 +41,7 @@ internal sealed class NatsUri : IEquatable<NatsUri>
 
         Uri = uriBuilder.Uri;
 
+        // Redact user/password or token from the URI string for logging
         if (uriBuilder.UserName is { Length: > 0 })
         {
             if (uriBuilder.Password is { Length: > 0 })
@@ -53,7 +54,7 @@ internal sealed class NatsUri : IEquatable<NatsUri>
             }
         }
 
-        _redactedUri = uriBuilder.Uri;
+        _redacted = IsWebSocket && Uri.AbsolutePath != "/" ? uriBuilder.Uri.ToString() : uriBuilder.Uri.ToString().Trim('/');
     }
 
     public Uri Uri { get; }
@@ -79,10 +80,7 @@ internal sealed class NatsUri : IEquatable<NatsUri>
         return new NatsUri(newUri, IsSeed);
     }
 
-    public override string ToString()
-    {
-        return IsWebSocket && Uri.AbsolutePath != "/" ? _redactedUri.ToString() : _redactedUri.ToString().Trim('/');
-    }
+    public override string ToString() => _redacted;
 
     public override int GetHashCode() => Uri.GetHashCode();
 

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -292,7 +292,7 @@ public partial class NatsConnection : INatsConnection
     {
         var first = true;
 
-        var natsUris = opts.GetSeedUris();
+        var natsUris = opts.GetSeedUris(suppressRandomization: true);
         var maskedUris = new List<string>(natsUris.Length);
 
         foreach (var natsUri in natsUris)

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -302,9 +302,9 @@ public partial class NatsConnection : INatsConnection
         {
             var uriBuilder = new UriBuilder(natsUri.Uri);
 
-            if (uriBuilder.UserName is { Length: > 0 } username)
+            if (uriBuilder.UserName is { Length: > 0 })
             {
-                if (uriBuilder.Password is { Length: > 0 } password)
+                if (uriBuilder.Password is { Length: > 0 })
                 {
                     if (first)
                     {
@@ -317,11 +317,10 @@ public partial class NatsConnection : INatsConnection
                             {
                                 Username = uriBuilder.UserName,
                                 Password = uriBuilder.Password,
+                                Token = null, // override token in case it was set
                             },
                         };
                     }
-
-                    uriBuilder.Password = "***"; // to redact the password from logs
                 }
                 else
                 {
@@ -335,17 +334,18 @@ public partial class NatsConnection : INatsConnection
                             AuthOpts = opts.AuthOpts with
                             {
                                 Token = uriBuilder.UserName,
+                                Username = null, // override user-password in case it was set
+                                Password = null,
                             },
                         };
                     }
-
-                    uriBuilder.UserName = "***"; // to redact the token from logs
                 }
             }
 
             if (usesPasswordInUrl)
             {
-                uriBuilder.UserName = opts.AuthOpts.Username; // show actual used user name in logs
+                uriBuilder.UserName = opts.AuthOpts.Username; // show actual used username in logs
+                uriBuilder.Password = "***"; // to redact the password from logs
             }
             else if (usesTokenInUrl)
             {

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core.Commands;
@@ -302,12 +301,12 @@ public partial class NatsConnection : INatsConnection
 
             if (uriBuilder.UserName is { Length: > 0 } username)
             {
-                if (first)
+                if (uriBuilder.Password is { Length: > 0 } password)
                 {
-                    first = false;
-
-                    if (uriBuilder.Password is { Length: > 0 } password)
+                    if (first)
                     {
+                        first = false;
+
                         opts = opts with
                         {
                             AuthOpts = opts.AuthOpts with
@@ -316,11 +315,16 @@ public partial class NatsConnection : INatsConnection
                                 Password = uriBuilder.Password,
                             },
                         };
-
-                        uriBuilder.Password = "***"; // to redact the password from logs
                     }
-                    else
+
+                    uriBuilder.Password = "***"; // to redact the password from logs
+                }
+                else
+                {
+                    if (first)
                     {
+                        first = false;
+
                         opts = opts with
                         {
                             AuthOpts = opts.AuthOpts with
@@ -328,9 +332,9 @@ public partial class NatsConnection : INatsConnection
                                 Token = uriBuilder.UserName,
                             },
                         };
-
-                        uriBuilder.UserName = "***"; // to redact the token from logs
                     }
+
+                    uriBuilder.UserName = "***"; // to redact the token from logs
                 }
             }
 

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -315,8 +315,8 @@ public partial class NatsConnection : INatsConnection
                         {
                             AuthOpts = opts.AuthOpts with
                             {
-                                Username = uriBuilder.UserName,
-                                Password = uriBuilder.Password,
+                                Username = Uri.UnescapeDataString(uriBuilder.UserName),
+                                Password = Uri.UnescapeDataString(uriBuilder.Password),
                                 Token = null, // override token in case it was set
                             },
                         };
@@ -333,7 +333,7 @@ public partial class NatsConnection : INatsConnection
                         {
                             AuthOpts = opts.AuthOpts with
                             {
-                                Token = uriBuilder.UserName,
+                                Token = Uri.UnescapeDataString(uriBuilder.UserName),
                                 Username = null, // override user-password in case it was set
                                 Password = null,
                             },
@@ -344,7 +344,7 @@ public partial class NatsConnection : INatsConnection
 
             if (usesPasswordInUrl)
             {
-                uriBuilder.UserName = opts.AuthOpts.Username; // show actual used username in logs
+                uriBuilder.UserName = Uri.EscapeDataString(opts.AuthOpts.Username!); // show actual used username in logs
                 uriBuilder.Password = "***"; // to redact the password from logs
             }
             else if (usesTokenInUrl)

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -295,6 +295,9 @@ public partial class NatsConnection : INatsConnection
         var natsUris = opts.GetSeedUris(suppressRandomization: true);
         var maskedUris = new List<string>(natsUris.Length);
 
+        var usesPasswordInUrl = false;
+        var usesTokenInUrl = false;
+
         foreach (var natsUri in natsUris)
         {
             var uriBuilder = new UriBuilder(natsUri.Uri);
@@ -306,6 +309,7 @@ public partial class NatsConnection : INatsConnection
                     if (first)
                     {
                         first = false;
+                        usesPasswordInUrl = true;
 
                         opts = opts with
                         {
@@ -324,6 +328,7 @@ public partial class NatsConnection : INatsConnection
                     if (first)
                     {
                         first = false;
+                        usesTokenInUrl = true;
 
                         opts = opts with
                         {
@@ -336,6 +341,16 @@ public partial class NatsConnection : INatsConnection
 
                     uriBuilder.UserName = "***"; // to redact the token from logs
                 }
+            }
+
+            if (usesPasswordInUrl)
+            {
+                uriBuilder.UserName = opts.AuthOpts.Username; // show actual used user name in logs
+            }
+            else if (usesTokenInUrl)
+            {
+                uriBuilder.UserName = "***"; // to redact the token from logs
+                uriBuilder.Password = null; // when token is used remove password
             }
 
             maskedUris.Add(uriBuilder.ToString().TrimEnd('/'));

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -289,7 +289,6 @@ public partial class NatsConnection : INatsConnection
         return default;
     }
 
-
     private static NatsOpts ReadUserInfoFromConnectionString(NatsOpts opts)
     {
         var first = true;
@@ -326,14 +325,13 @@ public partial class NatsConnection : INatsConnection
                         {
                             AuthOpts = opts.AuthOpts with
                             {
-                               Token = uriBuilder.UserName,
+                                Token = uriBuilder.UserName,
                             },
                         };
 
                         uriBuilder.UserName = "***"; // to redact the token from logs
                     }
                 }
-
             }
 
             maskedUris.Add(uriBuilder.ToString().TrimEnd('/'));

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -14,6 +14,28 @@ public sealed record NatsOpts
 {
     public static readonly NatsOpts Default = new();
 
+    /// <summary>
+    /// NATS server URL to connect to. (default: nats://localhost:4222)
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// You can set more than one server as seed servers in a comma-separated list.
+    /// The client will randomly select a server from the list to connect to unless
+    /// <see cref="NoRandomize"/> (which is <c>false</c> by default) is set to <c>true</c>.
+    /// </para>
+    /// <para>
+    /// User-password or token authentication can be set in the URL.
+    /// For example, <c>nats://derek:s3cr3t@localhost:4222</c> or <c>nats://token@localhost:4222</c>.
+    /// You can also set the username and password or token separately using <see cref="AuthOpts"/>;
+    /// however, if both are set, the URL will take precedence.
+    /// You should URL-encode the username and password or token if they contain special characters.
+    /// </para>
+    /// <para>
+    /// If multiple servers are specified and user-password or token authentication is used in the URL,
+    /// only the credentials in the first server URL will be used; credentials in the remaining server
+    /// URLs will be ignored.
+    /// </para>
+    /// </remarks>
     public string Url { get; init; } = "nats://localhost:4222";
 
     public string Name { get; init; } = "NATS .NET Client";

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -27,7 +27,7 @@ public sealed record NatsOpts
     /// User-password or token authentication can be set in the URL.
     /// For example, <c>nats://derek:s3cr3t@localhost:4222</c> or <c>nats://token@localhost:4222</c>.
     /// You can also set the username and password or token separately using <see cref="AuthOpts"/>;
-    /// however, if both are set, the URL will take precedence.
+    /// however, if both are set, the <see cref="AuthOpts"/> will take precedence.
     /// You should URL-encode the username and password or token if they contain special characters.
     /// </para>
     /// <para>

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -117,10 +117,10 @@ public sealed record NatsOpts
     /// </remarks>
     public BoundedChannelFullMode SubPendingChannelFullMode { get; init; } = BoundedChannelFullMode.DropNewest;
 
-    internal NatsUri[] GetSeedUris()
+    internal NatsUri[] GetSeedUris(bool suppressRandomization = false)
     {
         var urls = Url.Split(',');
-        return NoRandomize
+        return NoRandomize || suppressRandomization
             ? urls.Select(x => new NatsUri(x, true)).Distinct().ToArray()
             : urls.Select(x => new NatsUri(x, true)).OrderBy(_ => Guid.NewGuid()).Distinct().ToArray();
     }

--- a/src/NATS.Client.Simplified/NatsClient.cs
+++ b/src/NATS.Client.Simplified/NatsClient.cs
@@ -11,9 +11,25 @@ public class NatsClient : INatsClient
     /// <summary>
     /// Initializes a new instance of the <see cref="NatsClient"/> class.
     /// </summary>
-    /// <param name="url">NATS server URL</param>
-    /// <param name="name">Client name</param>
-    /// <param name="credsFile">Credentials filepath</param>
+    /// <param name="url">NATS server URL to connect to. (default: nats://localhost:4222)</param>
+    /// <param name="name">Client name. (default: NATS .NET Client)</param>
+    /// <param name="credsFile">Credentials filepath.</param>
+    /// <remarks>
+    /// <para>
+    /// You can set more than one server as seed servers in a comma-separated list in the <paramref name="url"/>.
+    /// The client will randomly select a server from the list to connect.
+    /// </para>
+    /// <para>
+    /// User-password or token authentication can be set in the <paramref name="url"/>.
+    /// For example, <c>nats://derek:s3cr3t@localhost:4222</c> or <c>nats://token@localhost:4222</c>.
+    /// You should URL-encode the username and password or token if they contain special characters.
+    /// </para>
+    /// <para>
+    /// If multiple servers are specified and user-password or token authentication is used in the <paramref name="url"/>,
+    /// only the credentials in the first server URL will be used; credentials in the remaining server
+    /// URLs will be ignored.
+    /// </para>
+    /// </remarks>
     public NatsClient(
         string url = "nats://localhost:4222",
         string name = "NATS .NET Client",

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.Auth.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.Auth.cs
@@ -112,7 +112,7 @@ public abstract partial class NatsConnectionTest
 
         if (useAuthInUrl)
         {
-            serverOptsBuilder.WithClientUrlAuthentication(auth.UrlAuth);
+            serverOptsBuilder.WithClientUrlAuthentication(auth.UrlAuth!);
         }
 
         var serverOpts = serverOptsBuilder.Build();
@@ -187,7 +187,7 @@ public abstract partial class NatsConnectionTest
 
     public class Auth
     {
-        public Auth(string name, string serverConfig, NatsOpts clientOpts, string urlAuth = null)
+        public Auth(string name, string serverConfig, NatsOpts clientOpts, string? urlAuth = null)
         {
             Name = name;
             ServerConfig = serverConfig;
@@ -201,7 +201,7 @@ public abstract partial class NatsConnectionTest
 
         public NatsOpts ClientOpts { get; }
 
-        public string UrlAuth { get; }
+        public string? UrlAuth { get; }
 
         public override string ToString() => Name;
     }

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.Auth.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.Auth.cs
@@ -15,12 +15,30 @@ public abstract partial class NatsConnectionTest
         yield return new object[]
         {
             new Auth(
+                "TOKEN_IN_CONNECTIONSTRING",
+                "resources/configs/auth/token.conf",
+                NatsOpts.Default,
+                urlAuth: "s3cr3t"),
+        };
+
+        yield return new object[]
+        {
+            new Auth(
                 "USER-PASSWORD",
                 "resources/configs/auth/password.conf",
                 NatsOpts.Default with
                 {
                     AuthOpts = NatsAuthOpts.Default with { Username = "a", Password = "b", },
                 }),
+        };
+
+        yield return new object[]
+        {
+            new Auth(
+                "USER-PASSWORD_IN_CONNECTIONSTRING",
+                "resources/configs/auth/password.conf",
+                NatsOpts.Default,
+                urlAuth: "a:b"),
         };
 
         yield return new object[]
@@ -84,15 +102,22 @@ public abstract partial class NatsConnectionTest
         var name = auth.Name;
         var serverConfig = auth.ServerConfig;
         var clientOpts = auth.ClientOpts;
+        var useAuthInUrl = !string.IsNullOrEmpty(auth.UrlAuth);
 
         _output.WriteLine($"AUTH TEST {name}");
 
-        var serverOpts = new NatsServerOptsBuilder()
+        var serverOptsBuilder = new NatsServerOptsBuilder()
             .UseTransport(_transportType)
-            .AddServerConfig(serverConfig)
-            .Build();
+            .AddServerConfig(serverConfig);
 
-        await using var server = NatsServer.Start(_output, serverOpts, clientOpts);
+        if (useAuthInUrl)
+        {
+            serverOptsBuilder.WithClientUrlAuthentication(auth.UrlAuth);
+        }
+
+        var serverOpts = serverOptsBuilder.Build();
+
+        await using var server = NatsServer.Start(_output, serverOpts, clientOpts, useAuthInUrl);
 
         var subject = Guid.NewGuid().ToString("N");
 
@@ -104,8 +129,8 @@ public abstract partial class NatsConnectionTest
             Assert.Contains("Authorization Violation", natsException.GetBaseException().Message);
         }
 
-        await using var subConnection = server.CreateClientConnection(clientOpts);
-        await using var pubConnection = server.CreateClientConnection(clientOpts);
+        await using var subConnection = server.CreateClientConnection(clientOpts, useAuthInUrl: useAuthInUrl);
+        await using var pubConnection = server.CreateClientConnection(clientOpts, useAuthInUrl: useAuthInUrl);
 
         var signalComplete1 = new WaitSignal();
         var signalComplete2 = new WaitSignal();
@@ -141,7 +166,7 @@ public abstract partial class NatsConnectionTest
         await disconnectSignal2;
 
         _output.WriteLine("START NEW SERVER");
-        await using var newServer = NatsServer.Start(_output, serverOpts, clientOpts);
+        await using var newServer = NatsServer.Start(_output, serverOpts, clientOpts, useAuthInUrl);
         await subConnection.ConnectAsync(); // wait open again
         await pubConnection.ConnectAsync(); // wait open again
 
@@ -162,11 +187,12 @@ public abstract partial class NatsConnectionTest
 
     public class Auth
     {
-        public Auth(string name, string serverConfig, NatsOpts clientOpts)
+        public Auth(string name, string serverConfig, NatsOpts clientOpts, string urlAuth = null)
         {
             Name = name;
             ServerConfig = serverConfig;
             ClientOpts = clientOpts;
+            UrlAuth = urlAuth;
         }
 
         public string Name { get; }
@@ -174,6 +200,8 @@ public abstract partial class NatsConnectionTest
         public string ServerConfig { get; }
 
         public NatsOpts ClientOpts { get; }
+
+        public string UrlAuth { get; }
 
         public override string ToString() => Name;
     }

--- a/tests/NATS.Client.CoreUnit.Tests/OptsUrlTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/OptsUrlTests.cs
@@ -9,6 +9,22 @@ public class OptsUrlTests
         Assert.Equal("nats://localhost:4222", opts.Url);
     }
 
+    [Fact]
+    public void Redact_URL_user_password()
+    {
+        var natsUri = new NatsUri("u:p@host", true);
+        Assert.Equal("nats://u:***@host:4222", natsUri.ToString());
+        Assert.Equal("u:p", natsUri.Uri.UserInfo);
+    }
+
+    [Fact]
+    public void Redact_URL_token()
+    {
+        var natsUri = new NatsUri("t@host", true);
+        Assert.Equal("nats://***@host:4222", natsUri.ToString());
+        Assert.Equal("t", natsUri.Uri.UserInfo);
+    }
+
     [Theory]
     [InlineData("host1", "nats://host1:4222", null, null, null)]
     [InlineData("host1:1234", "nats://host1:1234", null, null, null)]
@@ -16,15 +32,15 @@ public class OptsUrlTests
     [InlineData("u:p@host1:1234", "nats://u:***@host1:1234", "u", "p", null)]
     [InlineData("t@host1:1234", "nats://***@host1:1234", null, null, "t")]
     [InlineData("host1,host2", "nats://host1:4222,nats://host2:4222", null, null, null)]
-    [InlineData("u:p@host1,host2", "nats://u:***@host1:4222,nats://u:***@host2:4222", "u", "p", null)]
-    [InlineData("u:p@host1,x@host2", "nats://u:***@host1:4222,nats://u:***@host2:4222", "u", "p", null)]
-    [InlineData("t@host1,x:x@host2", "nats://***@host1:4222,nats://***@host2:4222", null, null, "t")]
-    [InlineData("u:p@host1,host2,host3", "nats://u:***@host1:4222,nats://u:***@host2:4222,nats://u:***@host3:4222", "u", "p", null)]
-    [InlineData("t@host1,@host2,host3", "nats://***@host1:4222,nats://***@host2:4222,nats://***@host3:4222", null, null, "t")]
+    [InlineData("u:p@host1,host2", "nats://u:***@host1:4222,nats://host2:4222", "u", "p", null)]
+    [InlineData("u:p@host1,x@host2", "nats://u:***@host1:4222,nats://***@host2:4222", "u", "p", null)]
+    [InlineData("t@host1,x:x@host2", "nats://***@host1:4222,nats://x:***@host2:4222", null, null, "t")]
+    [InlineData("u:p@host1,host2,host3", "nats://u:***@host1:4222,nats://host2:4222,nats://host3:4222", "u", "p", null)]
+    [InlineData("t@host1,@host2,host3", "nats://***@host1:4222,nats://host2:4222,nats://host3:4222", null, null, "t")]
     public void URL_parts(string url, string expected, string? user, string? pass, string? token)
     {
         var opts = new NatsConnection(new NatsOpts { Url = url }).Opts;
-        Assert.Equal(expected, opts.Url);
+        Assert.Equal(expected, GetUrisAsRedactedString(opts));
         Assert.Equal(user, opts.AuthOpts.Username);
         Assert.Equal(pass, opts.AuthOpts.Password);
         Assert.Equal(token, opts.AuthOpts.Token);
@@ -33,29 +49,29 @@ public class OptsUrlTests
     [Theory]
     [InlineData("u:p@host1:1234", "nats://u:***@host1:1234", "u", "p", null)]
     [InlineData("t@host1:1234", "nats://***@host1:1234", null, null, "t")]
-    public void URL_should_override_auth_options(string url, string expected, string? user, string? pass, string? token)
+    public void URL_should_not_override_auth_options(string url, string expected, string? user, string? pass, string? token)
     {
         var opts = new NatsConnection(new NatsOpts
         {
             Url = url,
             AuthOpts = new NatsAuthOpts
             {
-                Username = "should override username",
-                Password = "should override password",
-                Token = "should override token",
+                Username = "shouldn't override username",
+                Password = "shouldn't override password",
+                Token = "shouldn't override token",
             },
         }).Opts;
-        Assert.Equal(expected, opts.Url);
-        Assert.Equal(user, opts.AuthOpts.Username);
-        Assert.Equal(pass, opts.AuthOpts.Password);
-        Assert.Equal(token, opts.AuthOpts.Token);
+        Assert.Equal(expected, GetUrisAsRedactedString(opts));
+        Assert.Equal("shouldn't override username", opts.AuthOpts.Username);
+        Assert.Equal("shouldn't override password", opts.AuthOpts.Password);
+        Assert.Equal("shouldn't override token", opts.AuthOpts.Token);
     }
 
     [Fact]
     public void URL_escape_user_password()
     {
         var opts = new NatsConnection(new NatsOpts { Url = "nats://u%2C:p%2C@host1,host2" }).Opts;
-        Assert.Equal("nats://u%2C:***@host1:4222,nats://u%2C:***@host2:4222", opts.Url);
+        Assert.Equal("nats://u%2C:***@host1:4222,nats://host2:4222", GetUrisAsRedactedString(opts));
         Assert.Equal("u,", opts.AuthOpts.Username);
         Assert.Equal("p,", opts.AuthOpts.Password);
         Assert.Null(opts.AuthOpts.Token);
@@ -64,18 +80,18 @@ public class OptsUrlTests
         uris[0].Uri.Scheme.Should().Be("nats");
         uris[0].Uri.Host.Should().Be("host1");
         uris[0].Uri.Port.Should().Be(4222);
-        uris[0].Uri.UserInfo.Should().Be("u%2C:***");
+        uris[0].Uri.UserInfo.Should().Be("u%2C:p%2C");
         uris[1].Uri.Scheme.Should().Be("nats");
         uris[1].Uri.Host.Should().Be("host2");
         uris[1].Uri.Port.Should().Be(4222);
-        uris[1].Uri.UserInfo.Should().Be("u%2C:***");
+        uris[1].Uri.UserInfo.Should().Be(string.Empty);
     }
 
     [Fact]
     public void URL_escape_token()
     {
         var opts = new NatsConnection(new NatsOpts { Url = "nats://t%2C@host1,nats://t%2C@host2" }).Opts;
-        Assert.Equal("nats://***@host1:4222,nats://***@host2:4222", opts.Url);
+        Assert.Equal("nats://***@host1:4222,nats://***@host2:4222", GetUrisAsRedactedString(opts));
         Assert.Null(opts.AuthOpts.Username);
         Assert.Null(opts.AuthOpts.Password);
         Assert.Equal("t,", opts.AuthOpts.Token);
@@ -84,10 +100,22 @@ public class OptsUrlTests
         uris[0].Uri.Scheme.Should().Be("nats");
         uris[0].Uri.Host.Should().Be("host1");
         uris[0].Uri.Port.Should().Be(4222);
-        uris[0].Uri.UserInfo.Should().Be("***");
+        uris[0].Uri.UserInfo.Should().Be("t%2C");
         uris[1].Uri.Scheme.Should().Be("nats");
         uris[1].Uri.Host.Should().Be("host2");
         uris[1].Uri.Port.Should().Be(4222);
-        uris[1].Uri.UserInfo.Should().Be("***");
+        uris[1].Uri.UserInfo.Should().Be("t%2C");
     }
+
+    [Fact]
+    public void Keep_URL_wss_path_and_query_string()
+    {
+        var opts = new NatsConnection(new NatsOpts { Url = "wss://t%2C@host1/path1/path2?q1=1" }).Opts;
+        Assert.Equal("wss://***@host1/path1/path2?q1=1", GetUrisAsRedactedString(opts));
+        Assert.Null(opts.AuthOpts.Username);
+        Assert.Null(opts.AuthOpts.Password);
+        Assert.Equal("t,", opts.AuthOpts.Token);
+    }
+
+    private static string GetUrisAsRedactedString(NatsOpts opts) => string.Join(",", opts.GetSeedUris(true).Select(u => u.ToString()));
 }

--- a/tests/NATS.Client.CoreUnit.Tests/OptsUrlTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/OptsUrlTests.cs
@@ -1,0 +1,53 @@
+﻿namespace NATS.Client.Core.Tests;
+
+public class OptsUrlTests
+{
+    [Fact]
+    public void Default_URL()
+    {
+        var opts = new NatsConnection().Opts;
+        Assert.Equal("nats://localhost:4222", opts.Url);
+    }
+
+    [Theory]
+    [InlineData("host1", "nats://host1:4222", null, null, null)]
+    [InlineData("host1:1234", "nats://host1:1234", null, null, null)]
+    [InlineData("tls://host1", "tls://host1:4222", null, null, null)]
+    [InlineData("u:p@host1:1234", "nats://u:***@host1:1234", "u", "p", null)]
+    [InlineData("t@host1:1234", "nats://***@host1:1234", null, null, "t")]
+    [InlineData("host1,host2", "nats://host1:4222,nats://host2:4222", null, null, null)]
+    [InlineData("u:p@host1,host2", "nats://u:***@host1:4222,nats://u:***@host2:4222", "u", "p", null)]
+    [InlineData("u:p@host1,x@host2", "nats://u:***@host1:4222,nats://u:***@host2:4222", "u", "p", null)]
+    [InlineData("t@host1,x:x@host2", "nats://***@host1:4222,nats://***@host2:4222", null, null, "t")]
+    [InlineData("u:p@host1,host2,host3", "nats://u:***@host1:4222,nats://u:***@host2:4222,nats://u:***@host3:4222", "u", "p", null)]
+    [InlineData("t@host1,@host2,host3", "nats://***@host1:4222,nats://***@host2:4222,nats://***@host3:4222", null, null, "t")]
+    public void URL_parts(string url, string expected, string? user, string? pass, string? token)
+    {
+        var opts = new NatsConnection(new NatsOpts { Url = url }).Opts;
+        Assert.Equal(expected, opts.Url);
+        Assert.Equal(user, opts.AuthOpts.Username);
+        Assert.Equal(pass, opts.AuthOpts.Password);
+        Assert.Equal(token, opts.AuthOpts.Token);
+    }
+
+    [Theory]
+    [InlineData("u:p@host1:1234", "nats://u:***@host1:1234", "u", "p", null)]
+    [InlineData("t@host1:1234", "nats://***@host1:1234", null, null, "t")]
+    public void URL_should_override_auth_options(string url, string expected, string? user, string? pass, string? token)
+    {
+        var opts = new NatsConnection(new NatsOpts
+        {
+            Url = url,
+            AuthOpts = new NatsAuthOpts
+            {
+                Username = "should override username",
+                Password = "should override password",
+                Token = "should override token",
+            },
+        }).Opts;
+        Assert.Equal(expected, opts.Url);
+        Assert.Equal(user, opts.AuthOpts.Username);
+        Assert.Equal(pass, opts.AuthOpts.Password);
+        Assert.Equal(token, opts.AuthOpts.Token);
+    }
+}

--- a/tests/NATS.Client.CoreUnit.Tests/OptsUrlTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/OptsUrlTests.cs
@@ -1,4 +1,4 @@
-﻿namespace NATS.Client.Core.Tests;
+namespace NATS.Client.Core.Tests;
 
 public class OptsUrlTests
 {

--- a/tests/NATS.Client.CoreUnit.Tests/OptsUrlTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/OptsUrlTests.cs
@@ -47,9 +47,9 @@ public class OptsUrlTests
     }
 
     [Theory]
-    [InlineData("u:p@host1:1234", "nats://u:***@host1:1234", "u", "p", null)]
-    [InlineData("t@host1:1234", "nats://***@host1:1234", null, null, "t")]
-    public void URL_should_not_override_auth_options(string url, string expected, string? user, string? pass, string? token)
+    [InlineData("u:p@host1:1234", "nats://u:***@host1:1234")]
+    [InlineData("t@host1:1234", "nats://***@host1:1234")]
+    public void URL_should_not_override_auth_options(string url, string expected)
     {
         var opts = new NatsConnection(new NatsOpts
         {

--- a/tests/NATS.Client.TestUtilities/NatsServer.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServer.cs
@@ -160,7 +160,7 @@ public class NatsServer : IAsyncDisposable
             {
                 server = new NatsServer(outputHelper, opts);
                 server.StartServerProcess();
-                nats = server.CreateClientConnection(clientOpts ?? GetDefaultClientOpts(server), reTryCount: 3, useAuthInUrl: useAuthInUrl);
+                nats = server.CreateClientConnection(clientOpts ?? NatsOpts.Default, reTryCount: 3, useAuthInUrl: useAuthInUrl);
 #pragma warning disable CA2012
                 return server;
             }
@@ -176,11 +176,6 @@ public class NatsServer : IAsyncDisposable
         }
 
         throw new Exception("Can't start nats-server and connect to it");
-    }
-
-    private static NatsOpts GetDefaultClientOpts(NatsServer server)
-    {
-        return NatsOpts.Default/* with { Url = server.ClientUrl }*/;
     }
 
     public void StartServerProcess()
@@ -362,7 +357,7 @@ public class NatsServer : IAsyncDisposable
         {
             try
             {
-                var nats = new NatsConnection(ClientOpts(options ?? GetDefaultClientOpts(this), testLogger: testLogger, useAuthInUrl: useAuthInUrl));
+                var nats = new NatsConnection(ClientOpts(options ?? NatsOpts.Default, testLogger: testLogger, useAuthInUrl: useAuthInUrl));
 
                 try
                 {
@@ -390,7 +385,7 @@ public class NatsServer : IAsyncDisposable
         throw new Exception("Can't create a connection to nats-server");
     }
 
-    public NatsConnectionPool CreatePooledClientConnection() => CreatePooledClientConnection(GetDefaultClientOpts(this));
+    public NatsConnectionPool CreatePooledClientConnection() => CreatePooledClientConnection(NatsOpts.Default);
 
     public NatsConnectionPool CreatePooledClientConnection(NatsOpts opts)
     {

--- a/tests/NATS.Client.TestUtilities/NatsServer.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServer.cs
@@ -85,6 +85,22 @@ public class NatsServer : IAsyncDisposable
         _ => throw new ArgumentOutOfRangeException(),
     };
 
+    public string ClientUrlWithAuth
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(Opts.ClientUrlUserName))
+            {
+                var uriBuilder = new UriBuilder(ClientUrl);
+                uriBuilder.UserName = Opts.ClientUrlUserName;
+                uriBuilder.Password = Opts.ClientUrlPassword;
+                return uriBuilder.ToString().TrimEnd('/');
+            }
+
+            return ClientUrl;
+        }
+    }
+
     public int ConnectionPort
     {
         get
@@ -134,7 +150,7 @@ public class NatsServer : IAsyncDisposable
     public static NatsServer Start(ITestOutputHelper outputHelper, TransportType transportType) =>
         Start(outputHelper, new NatsServerOptsBuilder().UseTransport(transportType).Build());
 
-    public static NatsServer Start(ITestOutputHelper outputHelper, NatsServerOpts opts, NatsOpts? clientOpts = default)
+    public static NatsServer Start(ITestOutputHelper outputHelper, NatsServerOpts opts, NatsOpts? clientOpts = default, bool useAuthInUrl = false)
     {
         NatsServer? server = null;
         NatsConnection? nats = null;
@@ -144,7 +160,7 @@ public class NatsServer : IAsyncDisposable
             {
                 server = new NatsServer(outputHelper, opts);
                 server.StartServerProcess();
-                nats = server.CreateClientConnection(clientOpts ?? NatsOpts.Default, reTryCount: 3);
+                nats = server.CreateClientConnection(clientOpts ?? GetDefaultClientOpts(server), reTryCount: 3, useAuthInUrl: useAuthInUrl);
 #pragma warning disable CA2012
                 return server;
             }
@@ -160,6 +176,11 @@ public class NatsServer : IAsyncDisposable
         }
 
         throw new Exception("Can't start nats-server and connect to it");
+    }
+
+    private static NatsOpts GetDefaultClientOpts(NatsServer server)
+    {
+        return NatsOpts.Default/* with { Url = server.ClientUrl }*/;
     }
 
     public void StartServerProcess()
@@ -335,13 +356,13 @@ public class NatsServer : IAsyncDisposable
         return (client, proxy);
     }
 
-    public NatsConnection CreateClientConnection(NatsOpts? options = default, int reTryCount = 10, bool ignoreAuthorizationException = false, bool testLogger = true)
+    public NatsConnection CreateClientConnection(NatsOpts? options = default, int reTryCount = 10, bool ignoreAuthorizationException = false, bool testLogger = true, bool useAuthInUrl = false)
     {
         for (var i = 0; i < reTryCount; i++)
         {
             try
             {
-                var nats = new NatsConnection(ClientOpts(options ?? NatsOpts.Default, testLogger: testLogger));
+                var nats = new NatsConnection(ClientOpts(options ?? GetDefaultClientOpts(this), testLogger: testLogger, useAuthInUrl: useAuthInUrl));
 
                 try
                 {
@@ -369,14 +390,14 @@ public class NatsServer : IAsyncDisposable
         throw new Exception("Can't create a connection to nats-server");
     }
 
-    public NatsConnectionPool CreatePooledClientConnection() => CreatePooledClientConnection(NatsOpts.Default);
+    public NatsConnectionPool CreatePooledClientConnection() => CreatePooledClientConnection(GetDefaultClientOpts(this));
 
     public NatsConnectionPool CreatePooledClientConnection(NatsOpts opts)
     {
         return new NatsConnectionPool(4, ClientOpts(opts));
     }
 
-    public NatsOpts ClientOpts(NatsOpts opts, bool testLogger = true)
+    public NatsOpts ClientOpts(NatsOpts opts, bool testLogger = true, bool useAuthInUrl = false)
     {
         var natsTlsOpts = Opts.EnableTls
             ? opts.TlsOpts with
@@ -392,7 +413,7 @@ public class NatsServer : IAsyncDisposable
         {
             LoggerFactory = testLogger ? _loggerFactory : opts.LoggerFactory,
             TlsOpts = natsTlsOpts,
-            Url = ClientUrl,
+            Url = useAuthInUrl ? ClientUrlWithAuth : ClientUrl,
         };
     }
 
@@ -431,6 +452,15 @@ public class NatsServer : IAsyncDisposable
 
         var cmd = $"{NatsServerPath} -c {configFileName}";
 
+        //var cmdBuilder = new StringBuilder($"{NatsServerPath} -c {configFileName}");
+
+        //if (!string.IsNullOrEmpty(opts.UserName) && !string.IsNullOrEmpty(opts.Password))
+        //{
+        //    cmdBuilder.Append($" --user {opts.UserName} --pass {opts.Password}");
+        //}
+
+        //var cmd = cmdBuilder.ToString();
+
         return (configFileName, config, cmd);
     }
 
@@ -464,7 +494,7 @@ public class NatsCluster : IAsyncDisposable
 {
     private readonly ITestOutputHelper _outputHelper;
 
-    public NatsCluster(ITestOutputHelper outputHelper, TransportType transportType, Action<int, NatsServerOptsBuilder>? configure = default)
+    public NatsCluster(ITestOutputHelper outputHelper, TransportType transportType, Action<int, NatsServerOptsBuilder>? configure = default, bool useAuthInUrl = false)
     {
         _outputHelper = outputHelper;
 
@@ -516,13 +546,13 @@ public class NatsCluster : IAsyncDisposable
         }
 
         _outputHelper.WriteLine($"Starting server 1...");
-        Server1 = NatsServer.Start(outputHelper, opts1);
+        Server1 = NatsServer.Start(outputHelper, opts1, useAuthInUrl: useAuthInUrl);
 
         _outputHelper.WriteLine($"Starting server 2...");
-        Server2 = NatsServer.Start(outputHelper, opts2);
+        Server2 = NatsServer.Start(outputHelper, opts2, useAuthInUrl: useAuthInUrl);
 
         _outputHelper.WriteLine($"Starting server 3...");
-        Server3 = NatsServer.Start(outputHelper, opts3);
+        Server3 = NatsServer.Start(outputHelper, opts3, useAuthInUrl: useAuthInUrl);
     }
 
     public NatsServer Server1 { get; }

--- a/tests/NATS.Client.TestUtilities/NatsServer.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServer.cs
@@ -452,15 +452,6 @@ public class NatsServer : IAsyncDisposable
 
         var cmd = $"{NatsServerPath} -c {configFileName}";
 
-        //var cmdBuilder = new StringBuilder($"{NatsServerPath} -c {configFileName}");
-
-        //if (!string.IsNullOrEmpty(opts.UserName) && !string.IsNullOrEmpty(opts.Password))
-        //{
-        //    cmdBuilder.Append($" --user {opts.UserName} --pass {opts.Password}");
-        //}
-
-        //var cmd = cmdBuilder.ToString();
-
         return (configFileName, config, cmd);
     }
 

--- a/tests/NATS.Client.TestUtilities/NatsServerOpts.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServerOpts.cs
@@ -31,6 +31,8 @@ public sealed class NatsServerOptsBuilder
     private bool _serverDisposeReturnsPorts;
     private bool _enableClustering;
     private bool _trace;
+    private string? _clientUrlUserName;
+    private string? _clientUrlPassword;
 
     public NatsServerOpts Build() => new()
     {
@@ -40,6 +42,8 @@ public sealed class NatsServerOptsBuilder
         TlsVerify = _tlsVerify,
         EnableJetStream = _enableJetStream,
         ServerName = _serverName,
+        ClientUrlUserName = _clientUrlUserName,
+        ClientUrlPassword = _clientUrlPassword,
         TlsServerCertFile = _tlsServerCertFile,
         TlsServerKeyFile = _tlsServerKeyFile,
         TlsClientCertFile = _tlsClientCertFile,
@@ -110,6 +114,21 @@ public sealed class NatsServerOptsBuilder
         return this;
     }
 
+    public NatsServerOptsBuilder WithClientUrlAuthentication(string userName, string password)
+    {
+        _clientUrlUserName = userName;
+        _clientUrlPassword = password;
+        return this;
+    }
+
+    public NatsServerOptsBuilder WithClientUrlAuthentication(string authInfo)
+    {
+        var infoParts = authInfo.Split(':');
+        _clientUrlUserName = infoParts.FirstOrDefault();
+        _clientUrlPassword = infoParts.ElementAtOrDefault(1);
+        return this;
+    }
+
     public NatsServerOptsBuilder UseJetStream()
     {
         _enableJetStream = true;
@@ -175,6 +194,10 @@ public sealed class NatsServerOpts : IDisposable
     public string? JetStreamStoreDir { get; set; }
 
     public bool ServerDisposeReturnsPorts { get; init; } = true;
+
+    public string? ClientUrlUserName { get; set; }
+
+    public string? ClientUrlPassword { get; set; }
 
     public string? TlsClientCertFile { get; init; }
 


### PR DESCRIPTION
@mtmk As discussed, here is the PR for support for Auth in URL, I also made it to support token in URL, since if it works with username + password, I think users would also expect for it to work with a token.

Aspire PR that will uses this: https://github.com/dotnet/aspire/pull/6259

Note: some Serializer unit test were already failing before I made changes.