### PR TITLE
open Header.Writer class and create GetBytesLength method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,9 @@ jobs:
 
           cd tests/NATS.Client.CheckNativeAot
           rm -rf bin obj
-          dotnet publish -r linux-x64 -c Release -o dist | tee output.txt
+
+          # temporarily ignore MsQuicApi warnings
+          dotnet publish -r linux-x64 -c Release -o dist | grep -v MsQuicApi | tee output.txt
 
           # check for warnings
           grep -i warning output.txt && exit 1

--- a/src/NATS.Client.Core/NatsHeaders.cs
+++ b/src/NATS.Client.Core/NatsHeaders.cs
@@ -295,6 +295,16 @@ public class NatsHeaders : IDictionary<string, StringValues>
     }
 
     /// <summary>
+    /// Returns the bytes length of the header
+    /// </summary>
+    /// <param name="headerWriter">an instance of headerWriter</param>
+    /// <returns>bytes length of th header</returns>
+    public long GetBytesLength(HeaderWriter headerWriter)
+    {
+        return headerWriter.GetBytesLength(this);
+    }
+
+    /// <summary>
     /// Removes the given item from the the collection.
     /// </summary>
     /// <param name="item">The item.</param>

--- a/src/NATS.Client.Core/NatsHeaders.cs
+++ b/src/NATS.Client.Core/NatsHeaders.cs
@@ -1,7 +1,9 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Microsoft.Extensions.Primitives;
+using NATS.Client.Core.Internal;
 
 namespace NATS.Client.Core;
 
@@ -297,11 +299,15 @@ public class NatsHeaders : IDictionary<string, StringValues>
     /// <summary>
     /// Returns the bytes length of the header
     /// </summary>
-    /// <param name="headerWriter">an instance of headerWriter</param>
-    /// <returns>bytes length of th header</returns>
-    public long GetBytesLength(HeaderWriter headerWriter)
+    /// <param name="encoding">Encoding used.  Default to utf8 if not provided</param>
+    /// <returns>Bytes length of the header</returns>
+    public long GetBytesLength(Encoding? encoding = null)
     {
-        return headerWriter.GetBytesLength(this);
+        // if null set to utf-8
+        encoding = encoding ?? Encoding.UTF8;
+
+        var len = HeaderWriter.GetBytesLength(this, encoding);
+        return len;
     }
 
     /// <summary>

--- a/tests/NATS.Client.CoreUnit.Tests/NatsHeaderTest.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsHeaderTest.cs
@@ -207,7 +207,7 @@ public class NatsHeaderTest
             ["key"] = "a-long-header-value",
         };
         var writer = new HeaderWriter(Encoding.UTF8);
-        var bytesLength = writer.GetBytesLength(headers);
+        var bytesLength = headers.GetBytesLength(writer);
 
         var text = "NATS/1.0\r\nk1: v1\r\nk2: v2-0\r\nk2: v2-1\r\na-long-header-key: value\r\nkey: a-long-header-value\r\n\r\n";
         var expected = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(text));

--- a/tests/NATS.Client.CoreUnit.Tests/NatsHeaderTest.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsHeaderTest.cs
@@ -195,4 +195,23 @@ public class NatsHeaderTest
         Assert.Equal(result, expectedResult);
         Assert.Equal(lastValue, expectedLastValue);
     }
+
+    [Fact]
+    public void GetBytesLengthTest()
+    {
+        var headers = new NatsHeaders
+        {
+            ["k1"] = "v1",
+            ["k2"] = new[] { "v2-0", "v2-1" },
+            ["a-long-header-key"] = "value",
+            ["key"] = "a-long-header-value",
+        };
+        var writer = new HeaderWriter(Encoding.UTF8);
+        var bytesLength = writer.GetBytesLength(headers);
+
+        var text = "NATS/1.0\r\nk1: v1\r\nk2: v2-0\r\nk2: v2-1\r\na-long-header-key: value\r\nkey: a-long-header-value\r\n\r\n";
+        var expected = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(text));
+
+        Assert.Equal(expected.Length, bytesLength);
+    }
 }

--- a/tests/NATS.Client.CoreUnit.Tests/NatsHeaderTest.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsHeaderTest.cs
@@ -206,8 +206,8 @@ public class NatsHeaderTest
             ["a-long-header-key"] = "value",
             ["key"] = "a-long-header-value",
         };
-        var writer = new HeaderWriter(Encoding.UTF8);
-        var bytesLength = headers.GetBytesLength(writer);
+        var encoding = Encoding.UTF8;
+        var bytesLength = headers.GetBytesLength(encoding);
 
         var text = "NATS/1.0\r\nk1: v1\r\nk2: v2-0\r\nk2: v2-1\r\na-long-header-key: value\r\nkey: a-long-header-value\r\n\r\n";
         var expected = new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(text));


### PR DESCRIPTION
Open Header.Writer class and create GetBytesLength method for calculating NatsHeaders size (length in bytes) up front to call Publish for large Nats message which may exceeds payload size against server's maximum payload size.

* fixes #638 