### PR TITLE
Refactor exception handling in NatsException

### DIFF
--- a/src/NATS.Client.Core/Internal/HeaderWriter.cs
+++ b/src/NATS.Client.Core/Internal/HeaderWriter.cs
@@ -67,7 +67,9 @@ internal class HeaderWriter
                     var keySpan = bufferWriter.GetSpan(keyLength);
                     _encoding.GetBytes(kv.Key, keySpan);
                     if (!ValidateKey(keySpan.Slice(0, keyLength)))
-                        throw new NatsException($"Invalid header key '{kv.Key}': contains colon, space, or other non-printable ASCII characters");
+                    {
+                        NatsException.Throw($"Invalid header key '{kv.Key}': contains colon, space, or other non-printable ASCII characters");
+                    }
 
                     bufferWriter.Advance(keyLength);
                     len += keyLength;
@@ -80,7 +82,9 @@ internal class HeaderWriter
                     var valueSpan = bufferWriter.GetSpan(valueLength);
                     _encoding.GetBytes(value, valueSpan);
                     if (!ValidateValue(valueSpan.Slice(0, valueLength)))
-                        throw new NatsException($"Invalid header value for key '{kv.Key}': contains CRLF");
+                    {
+                        NatsException.Throw($"Invalid header value for key '{kv.Key}': contains CRLF");
+                    }
 
                     bufferWriter.Advance(valueLength);
                     len += valueLength;

--- a/src/NATS.Client.Core/NatsException.cs
+++ b/src/NATS.Client.Core/NatsException.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace NATS.Client.Core;
 
 public class NatsException : Exception
@@ -11,6 +13,9 @@ public class NatsException : Exception
         : base(message, exception)
     {
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Throw(string message) => throw new NatsException(message);
 }
 
 public sealed class NatsNoReplyException : NatsException


### PR DESCRIPTION
I think we did put private throw helpers in a few classes going forward static method on the exception class itself looks very expressive and accessible.

> @to11mtm 
> Main advantage of such is we can get some better inlining/opts and avoid certain callstack checks on happy path....

see also review comments https://github.com/nats-io/nats.net/pull/674#discussion_r1839088340