### PR TITLE
 Add (force) reconnect method 

### DIFF
--- a/src/NATS.Client.Core/INatsClient.cs
+++ b/src/NATS.Client.Core/INatsClient.cs
@@ -115,4 +115,12 @@ public interface INatsClient : IAsyncDisposable
         INatsDeserialize<TReply>? replySerializer = default,
         NatsSubOpts? replyOpts = default,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Force a reconnection to the NATS server.
+    /// </summary>
+    /// <remarks>
+    /// This method doesn't wait for the connection to be established.
+    /// </remarks>
+    ValueTask ReconnectAsync();
 }

--- a/src/NATS.Client.Core/NatsConnection.Reconnect.cs
+++ b/src/NATS.Client.Core/NatsConnection.Reconnect.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.Logging;
+
+namespace NATS.Client.Core;
+
+public partial class NatsConnection
+{
+    /// <inheritdoc/>
+    public async ValueTask ReconnectAsync()
+    {
+        if (ConnectionState != NatsConnectionState.Open)
+        {
+            return;
+        }
+
+        _logger.LogInformation(NatsLogEvents.Connection, "Forcing reconnection to NATS server");
+        await _socket!.AbortConnectionAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+}

--- a/src/NATS.Client.Simplified/NatsClient.cs
+++ b/src/NATS.Client.Simplified/NatsClient.cs
@@ -102,5 +102,8 @@ public class NatsClient : INatsClient
         => Connection.RequestAsync(subject, replySerializer, replyOpts, cancellationToken);
 
     /// <inheritdoc />
+    public ValueTask ReconnectAsync() => Connection.ReconnectAsync();
+
+    /// <inheritdoc />
     public ValueTask DisposeAsync() => Connection.DisposeAsync();
 }

--- a/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
@@ -159,6 +159,8 @@ public class NatsJSContextFactoryTest
 
         public ValueTask ConnectAsync() => throw new NotImplementedException();
 
+        public ValueTask ReconnectAsync() => throw new NotImplementedException();
+
         public ValueTask DisposeAsync() => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Resolves #479

- Add `ReconnectAsync` method
- Add test for `ReconnectAsync` method

I decided to follow naming proposed in [design issue](https://github.com/nats-io/nats-architecture-and-design/issues/259).

Ps. `OnSocketAvailableAsync_ShouldBeInvokedOnReconnection()` test in `NatsConnectionTest.cs` sometimes passes sometimes fails, so maybe there is some race? I've also noticed that it uses default `TransportType` (Tcp) instead of one provided by `NatsConnectionTest` class. It means same test runs 4 times if i understand correctly.