### PR TITLE
Initial implementation of per-key-TTL for KV

### DIFF
--- a/NATS.Net.sln
+++ b/NATS.Net.sln
@@ -17,23 +17,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NATS.Client.Core.Tests", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MicroBenchmark", "sandbox\MicroBenchmark\MicroBenchmark.csproj", "{A10F0D89-13F3-49B3-ACF7-66E45DC95225}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".", ".", "{899BE3EA-C5CA-4394-9B62-C45CBFF3AF4E}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-		Directory.Build.props = Directory.Build.props
-		README.md = README.md
-		version.txt = version.txt
-		.gitattributes = .gitattributes
-		.gitignore = .gitignore
-		CODE-OF-CONDUCT.md = CODE-OF-CONDUCT.md
-		CONTRIBUTING.md = CONTRIBUTING.md
-		dependencies.md = dependencies.md
-		global.json = global.json
-		Icon.png = Icon.png
-		LICENSE = LICENSE
-		REPO_RENAME.md = REPO_RENAME.md
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NATS.Client.Hosting", "src\NATS.Client.Hosting\NATS.Client.Hosting.csproj", "{D3F09B30-1ED5-48C2-81CD-A2AD88E751AC}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimumWebApp", "sandbox\MinimumWebApp\MinimumWebApp.csproj", "{44881DEE-8B49-44EA-B0BA-8BDA4F706E1A}"
@@ -137,6 +120,23 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\perf.yml = .github\workflows\perf.yml
 		.github\workflows\release.yml = .github\workflows\release.yml
 		.github\workflows\test.yml = .github\workflows\test.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1D1B89B7-5963-48AE-B5F8-BB9AA4834CD6}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		CODE-OF-CONDUCT.md = CODE-OF-CONDUCT.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		dependencies.md = dependencies.md
+		Directory.Build.props = Directory.Build.props
+		global.json = global.json
+		Icon.png = Icon.png
+		LICENSE = LICENSE
+		README.md = README.md
+		REPO_RENAME.md = REPO_RENAME.md
+		version.txt = version.txt
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NATS.Client.TestUtilities2", "tests\NATS.Client.TestUtilities2\NATS.Client.TestUtilities2.csproj", "{25E4C70A-196C-4855-8DFC-796C08837987}"
@@ -402,7 +402,6 @@ Global
 		{227C88B1-0510-4010-B142-C44725578FCD} = {4827B3EC-73D8-436D-AE2A-5E29AC95FD0C}
 		{8A676AAA-FEE3-4C18-870A-66E59AD9069F} = {C526E8AB-739A-48D7-8FC4-048978C9B650}
 		{9521D9E0-642A-4C7E-BD10-372DF235CF62} = {C526E8AB-739A-48D7-8FC4-048978C9B650}
-		{B9EF0111-6720-46DF-B11A-8F8C88C3F5C1} = {899BE3EA-C5CA-4394-9B62-C45CBFF3AF4E}
 		{0B7F1286-4426-45DE-82C2-FE7CF13CA0DA} = {B9EF0111-6720-46DF-B11A-8F8C88C3F5C1}
 		{25E4C70A-196C-4855-8DFC-796C08837987} = {C526E8AB-739A-48D7-8FC4-048978C9B650}
 	EndGlobalSection

--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -247,6 +247,14 @@ public record StreamConfig
     public bool AllowMsgTTL { get; set; }
 
     /// <summary>
+    /// Enables and sets a duration for adding server markers for delete, purge and max age limits.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("subject_delete_marker_ttl")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonNanosecondsConverter))]
+    public TimeSpan SubjectDeleteMarkerTTL { get; set; }
+
+    /// <summary>
     /// Additional metadata for the Stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("metadata")]

--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -240,6 +240,13 @@ public record StreamConfig
     public bool DiscardNewPerSubject { get; set; }
 
     /// <summary>
+    /// AllowMsgTTL allows header initiated per-message TTLs. If disabled, then the `NATS-TTL` header will be ignored.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("allow_msg_ttl")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public bool AllowMsgTTL { get; set; }
+
+    /// <summary>
     /// Additional metadata for the Stream
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("metadata")]

--- a/src/NATS.Client.KeyValueStore/INatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/INatsKVStore.cs
@@ -20,19 +20,29 @@ public interface INatsKVStore
     /// </summary>
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
-    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
     /// <returns>Revision number</returns>
-    ValueTask<ulong> PutAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<ulong> PutAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Put a value into the bucket using the key
+    /// </summary>
+    /// <param name="key">Key of the entry</param>
+    /// <param name="value">Value of the entry</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true). For a key that should never expire, use the <see cref="TimeSpan.MaxValue"/> constant.</param>
+    /// <param name="serializer">Serializer to use for the message type.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <typeparam name="T">Serialized value type</typeparam>
+    /// <returns>Revision number</returns>
+    ValueTask<ulong> PutAsync<T>(string key, T value, TimeSpan ttl, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Tries to put a value into the bucket using the key
     /// </summary>
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
-    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
@@ -40,26 +50,51 @@ public interface INatsKVStore
     /// <remarks>
     /// Use this method to avoid exceptions
     /// </remarks>
-    ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Tries to put a value into the bucket using the key
+    /// </summary>
+    /// <param name="key">Key of the entry</param>
+    /// <param name="value">Value of the entry</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true). For a key that should never expire, use the <see cref="TimeSpan.MaxValue"/> constant.</param>
+    /// <param name="serializer">Serializer to use for the message type.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <typeparam name="T">Serialized value type</typeparam>
+    /// <returns>Revision number</returns>
+    /// <remarks>
+    /// Use this method to avoid exceptions
+    /// </remarks>
+    ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, TimeSpan ttl, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a new entry in the bucket only if it doesn't exist
     /// </summary>
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
-    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
     /// <returns>The revision number of the entry</returns>
-    ValueTask<ulong> CreateAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<ulong> CreateAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a new entry in the bucket only if it doesn't exist
+    /// </summary>
+    /// <param name="key">Key of the entry</param>
+    /// <param name="value">Value of the entry</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true). For a key that should never expire, use the <see cref="TimeSpan.MaxValue"/> constant.</param>
+    /// <param name="serializer">Serializer to use for the message type.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <typeparam name="T">Serialized value type</typeparam>
+    /// <returns>The revision number of the entry</returns>
+    ValueTask<ulong> CreateAsync<T>(string key, T value, TimeSpan ttl, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Tries to create a new entry in the bucket only if it doesn't exist
     /// </summary>
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
-    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
@@ -67,7 +102,22 @@ public interface INatsKVStore
     /// <remarks>
     /// Use this method to avoid exceptions
     /// </remarks>
-    ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Tries to create a new entry in the bucket only if it doesn't exist
+    /// </summary>
+    /// <param name="key">Key of the entry</param>
+    /// <param name="value">Value of the entry</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true). For a key that should never expire, use the <see cref="TimeSpan.MaxValue"/> constant.</param>
+    /// <param name="serializer">Serializer to use for the message type.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <typeparam name="T">Serialized value type</typeparam>
+    /// <returns>A NatsResult object representing the revision number of the created entry or an error.</returns>
+    /// <remarks>
+    /// Use this method to avoid exceptions
+    /// </remarks>
+    ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, TimeSpan ttl, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update an entry in the bucket only if last update revision matches
@@ -75,12 +125,24 @@ public interface INatsKVStore
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
     /// <param name="revision">Last revision number to match</param>
-    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
     /// <returns>The revision number of the updated entry</returns>
-    ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Update an entry in the bucket only if last update revision matches
+    /// </summary>
+    /// <param name="key">Key of the entry</param>
+    /// <param name="value">Value of the entry</param>
+    /// <param name="revision">Last revision number to match</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true). For a key that should never expire, use the <see cref="TimeSpan.MaxValue"/> constant.</param>
+    /// <param name="serializer">Serializer to use for the message type.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <typeparam name="T">Serialized value type</typeparam>
+    /// <returns>The revision number of the updated entry</returns>
+    ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Tries to update an entry in the bucket only if last update revision matches
@@ -88,7 +150,6 @@ public interface INatsKVStore
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
     /// <param name="revision">Last revision number to match</param>
-    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
@@ -96,7 +157,23 @@ public interface INatsKVStore
     /// <remarks>
     /// Use this method to avoid exceptions
     /// </remarks>
-    ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Tries to update an entry in the bucket only if last update revision matches
+    /// </summary>
+    /// <param name="key">Key of the entry</param>
+    /// <param name="value">Value of the entry</param>
+    /// <param name="revision">Last revision number to match</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true). For a key that should never expire, use the <see cref="TimeSpan.MaxValue"/> constant.</param>
+    /// <param name="serializer">Serializer to use for the message type.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <typeparam name="T">Serialized value type</typeparam>
+    /// <returns>A NatsResult object representing the revision number of the updated entry or an error.</returns>
+    /// <remarks>
+    /// Use this method to avoid exceptions
+    /// </remarks>
+    ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete an entry from the bucket

--- a/src/NATS.Client.KeyValueStore/INatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/INatsKVStore.cs
@@ -20,17 +20,19 @@ public interface INatsKVStore
     /// </summary>
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
     /// <returns>Revision number</returns>
-    ValueTask<ulong> PutAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<ulong> PutAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Tries to put a value into the bucket using the key
     /// </summary>
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
@@ -38,24 +40,26 @@ public interface INatsKVStore
     /// <remarks>
     /// Use this method to avoid exceptions
     /// </remarks>
-    ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a new entry in the bucket only if it doesn't exist
     /// </summary>
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
     /// <returns>The revision number of the entry</returns>
-    ValueTask<ulong> CreateAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<ulong> CreateAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Tries to create a new entry in the bucket only if it doesn't exist
     /// </summary>
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
@@ -63,7 +67,7 @@ public interface INatsKVStore
     /// <remarks>
     /// Use this method to avoid exceptions
     /// </remarks>
-    ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Update an entry in the bucket only if last update revision matches
@@ -71,11 +75,12 @@ public interface INatsKVStore
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
     /// <param name="revision">Last revision number to match</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
     /// <returns>The revision number of the updated entry</returns>
-    ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Tries to update an entry in the bucket only if last update revision matches
@@ -83,6 +88,7 @@ public interface INatsKVStore
     /// <param name="key">Key of the entry</param>
     /// <param name="value">Value of the entry</param>
     /// <param name="revision">Last revision number to match</param>
+    /// <param name="ttl">Time to live for the entry (requires the <see cref="NatsKVConfig.AllowMsgTTL"/> to be set to true)</param>
     /// <param name="serializer">Serializer to use for the message type.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="T">Serialized value type</typeparam>
@@ -90,7 +96,7 @@ public interface INatsKVStore
     /// <remarks>
     /// Use this method to avoid exceptions
     /// </remarks>
-    ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
+    ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete an entry from the bucket

--- a/src/NATS.Client.KeyValueStore/NatsKVConfig.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVConfig.cs
@@ -82,6 +82,11 @@ public record NatsKVConfig
     /// If true, the bucket will allow TTL on individual keys.
     /// </summary>
     public bool AllowMsgTTL { get; set; }
+
+    /// <summary>
+    /// Enables and sets a duration for adding server markers for delete, purge and max age limits.
+    /// </summary>
+    public TimeSpan SubjectDeleteMarkerTTL { get; set; }
 }
 
 /// <summary>

--- a/src/NATS.Client.KeyValueStore/NatsKVConfig.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVConfig.cs
@@ -77,6 +77,11 @@ public record NatsKVConfig
     /// Sources defines the configuration for sources of a KeyValue store.
     /// </summary>
     public ICollection<StreamSource>? Sources { get; set; }
+
+    /// <summary>
+    /// If true, the bucket will allow TTL on individual keys.
+    /// </summary>
+    public bool AllowMsgTTL { get; set; }
 }
 
 /// <summary>

--- a/src/NATS.Client.KeyValueStore/NatsKVContext.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVContext.cs
@@ -247,6 +247,7 @@ public class NatsKVContext : INatsKVContext
             Sources = sources,
             Retention = StreamConfigRetention.Limits, // from ADR-8
             AllowMsgTTL = config.AllowMsgTTL,
+            SubjectDeleteMarkerTTL = config.SubjectDeleteMarkerTTL,
         };
 
         return streamConfig;

--- a/src/NATS.Client.KeyValueStore/NatsKVContext.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVContext.cs
@@ -246,6 +246,7 @@ public class NatsKVContext : INatsKVContext
             MirrorDirect = mirrorDirect,
             Sources = sources,
             Retention = StreamConfigRetention.Limits, // from ADR-8
+            AllowMsgTTL = config.AllowMsgTTL,
         };
 
         return streamConfig;

--- a/src/NATS.Client.KeyValueStore/NatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVStore.cs
@@ -88,6 +88,9 @@ public class NatsKVStore : INatsKVStore
     public static NatsResult IsValidKey(string key) => TryValidateKey(key);
 
     /// <inheritdoc />
+    public ValueTask<ulong> PutAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default) => PutAsync<T>(key, value, default, serializer, cancellationToken);
+
+    /// <inheritdoc />
     public async ValueTask<ulong> PutAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
         var result = await TryPutAsync(key, value, ttl, serializer, cancellationToken);
@@ -99,6 +102,10 @@ public class NatsKVStore : INatsKVStore
         return result.Value;
     }
 
+    /// <inheritdoc />
+    public ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default) => TryPutAsync<T>(key, value, default, serializer, cancellationToken);
+
+    /// <inheritdoc />
     public async ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
         var keyValidResult = TryValidateKey(key);
@@ -138,6 +145,9 @@ public class NatsKVStore : INatsKVStore
     }
 
     /// <inheritdoc />
+    public ValueTask<ulong> CreateAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default) => CreateAsync<T>(key, value, default, serializer, cancellationToken);
+
+    /// <inheritdoc />
     public async ValueTask<ulong> CreateAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
         var result = await TryCreateAsync(key, value, ttl, serializer, cancellationToken);
@@ -148,6 +158,9 @@ public class NatsKVStore : INatsKVStore
 
         return result.Value;
     }
+
+    /// <inheritdoc />
+    public ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default) => TryCreateAsync<T>(key, value, default, serializer, cancellationToken);
 
     /// <inheritdoc />
     public async ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
@@ -185,6 +198,9 @@ public class NatsKVStore : INatsKVStore
     }
 
     /// <inheritdoc />
+    public ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default) => UpdateAsync(key, value, revision, default, serializer, cancellationToken);
+
+    /// <inheritdoc />
     public async ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
         var result = await TryUpdateAsync(key, value, revision, ttl, serializer, cancellationToken);
@@ -195,6 +211,9 @@ public class NatsKVStore : INatsKVStore
 
         return result.Value;
     }
+
+    /// <inheritdoc />
+    public ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default) => TryUpdateAsync(key, value, revision, default, serializer, cancellationToken);
 
     /// <inheritdoc />
     public async ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)

--- a/src/NATS.Client.KeyValueStore/NatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVStore.cs
@@ -112,7 +112,7 @@ public class NatsKVStore : INatsKVStore
         {
             headers = new NatsHeaders
             {
-                { NatsTtl, ttl == TimeSpan.MaxValue ? "never" : ttl.TotalSeconds.ToString("N0") },
+                { NatsTtl, ttl == TimeSpan.MaxValue ? "never" : $"{(int)ttl.TotalSeconds:D}" },
             };
         }
 
@@ -208,7 +208,7 @@ public class NatsKVStore : INatsKVStore
         var headers = new NatsHeaders { { NatsExpectedLastSubjectSequence, revision.ToString() } };
         if (ttl != default)
         {
-            headers.Add(NatsTtl, ttl == TimeSpan.MaxValue ? "never" : ttl.TotalSeconds.ToString("N0"));
+            headers.Add(NatsTtl, ttl == TimeSpan.MaxValue ? "never" : $"{(int)ttl.TotalSeconds:D}");
         }
 
         var publishResult = await JetStreamContext.TryPublishAsync(_kvBucket + key, value, headers: headers, serializer: serializer, cancellationToken: cancellationToken);

--- a/src/NATS.Client.KeyValueStore/NatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVStore.cs
@@ -43,6 +43,7 @@ public class NatsKVStore : INatsKVStore
     private const string NatsSubject = "Nats-Subject";
     private const string NatsSequence = "Nats-Sequence";
     private const string NatsTimeStamp = "Nats-Time-Stamp";
+    private const string NatsTtl = "Nats-TTL";
     private static readonly Regex ValidKeyRegex = new(pattern: @"\A[-/_=\.a-zA-Z0-9]+\z", RegexOptions.Compiled);
     private static readonly NatsKVException MissingSequenceHeaderException = new("Missing sequence header");
     private static readonly NatsKVException MissingTimestampHeaderException = new("Missing timestamp header");
@@ -87,9 +88,9 @@ public class NatsKVStore : INatsKVStore
     public static NatsResult IsValidKey(string key) => TryValidateKey(key);
 
     /// <inheritdoc />
-    public async ValueTask<ulong> PutAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
+    public async ValueTask<ulong> PutAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
-        var result = await TryPutAsync(key, value, serializer, cancellationToken);
+        var result = await TryPutAsync(key, value, ttl, serializer, cancellationToken);
         if (!result.Success)
         {
             ThrowException(result.Error);
@@ -98,7 +99,7 @@ public class NatsKVStore : INatsKVStore
         return result.Value;
     }
 
-    public async ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
+    public async ValueTask<NatsResult<ulong>> TryPutAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
         var keyValidResult = TryValidateKey(key);
         if (!keyValidResult.Success)
@@ -106,7 +107,16 @@ public class NatsKVStore : INatsKVStore
             return keyValidResult.Error;
         }
 
-        var publishResult = await JetStreamContext.TryPublishAsync(_kvBucket + key, value, serializer: serializer, cancellationToken: cancellationToken);
+        NatsHeaders? headers = default;
+        if (ttl != default)
+        {
+            headers = new NatsHeaders
+            {
+                { NatsTtl, ttl == TimeSpan.MaxValue ? "never" : ttl.TotalSeconds.ToString("N0") },
+            };
+        }
+
+        var publishResult = await JetStreamContext.TryPublishAsync(_kvBucket + key, value, serializer: serializer, headers: headers, cancellationToken: cancellationToken);
         if (publishResult.Success)
         {
             var ack = publishResult.Value;
@@ -128,9 +138,9 @@ public class NatsKVStore : INatsKVStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<ulong> CreateAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
+    public async ValueTask<ulong> CreateAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
-        var result = await TryCreateAsync(key, value, serializer, cancellationToken);
+        var result = await TryCreateAsync(key, value, ttl, serializer, cancellationToken);
         if (!result.Success)
         {
             ThrowException(result.Error);
@@ -140,7 +150,7 @@ public class NatsKVStore : INatsKVStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
+    public async ValueTask<NatsResult<ulong>> TryCreateAsync<T>(string key, T value, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
         var keyValidResult = TryValidateKey(key);
         if (!keyValidResult.Success)
@@ -149,7 +159,7 @@ public class NatsKVStore : INatsKVStore
         }
 
         // First try to create a new entry
-        var resultUpdate = await TryUpdateAsync(key, value, revision: 0, serializer, cancellationToken);
+        var resultUpdate = await TryUpdateAsync(key, value, revision: 0, ttl, serializer, cancellationToken);
         if (resultUpdate.Success)
         {
             return resultUpdate;
@@ -166,7 +176,7 @@ public class NatsKVStore : INatsKVStore
         else if (resultReadExisting.Error is NatsKVKeyDeletedException deletedException)
         {
             // If our previous call errored because the last entry is deleted, then that's ok, we update with the deleted revision
-            return await TryUpdateAsync(key, value, deletedException.Revision, serializer, cancellationToken);
+            return await TryUpdateAsync(key, value, deletedException.Revision, ttl, serializer, cancellationToken);
         }
         else
         {
@@ -175,9 +185,9 @@ public class NatsKVStore : INatsKVStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
+    public async ValueTask<ulong> UpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
-        var result = await TryUpdateAsync(key, value, revision, serializer, cancellationToken);
+        var result = await TryUpdateAsync(key, value, revision, ttl, serializer, cancellationToken);
         if (!result.Success)
         {
             ThrowException(result.Error);
@@ -187,7 +197,7 @@ public class NatsKVStore : INatsKVStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
+    public async ValueTask<NatsResult<ulong>> TryUpdateAsync<T>(string key, T value, ulong revision, TimeSpan ttl = default, INatsSerialize<T>? serializer = default, CancellationToken cancellationToken = default)
     {
         var keyValidResult = TryValidateKey(key);
         if (!keyValidResult.Success)
@@ -196,6 +206,10 @@ public class NatsKVStore : INatsKVStore
         }
 
         var headers = new NatsHeaders { { NatsExpectedLastSubjectSequence, revision.ToString() } };
+        if (ttl != default)
+        {
+            headers.Add(NatsTtl, ttl == TimeSpan.MaxValue ? "never" : ttl.TotalSeconds.ToString("N0"));
+        }
 
         var publishResult = await JetStreamContext.TryPublishAsync(_kvBucket + key, value, headers: headers, serializer: serializer, cancellationToken: cancellationToken);
         if (publishResult.Success)

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
@@ -459,7 +459,7 @@ public class KeyValueStoreTest
         }
     }
 
-    [Fact]
+    [SkipIfNatsServer(versionEarlierThan: "2.11")]
     public async Task TestMessageTTL()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -491,7 +491,7 @@ public class KeyValueStoreTest
         Assert.Equal(10ul, state.Info.State.LastSeq);
     }
 
-    [Fact]
+    [SkipIfNatsServer(versionEarlierThan: "2.11")]
     public async Task TestMessageNeverExpire()
     {
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
@@ -497,8 +497,8 @@ public class KeyValueStoreTest
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var cancellationToken = cts.Token;
 
-        await using var server = NatsServer.StartJS();
-        await using var nats = server.CreateClientConnection();
+        await using var server = await NatsServer.StartJSAsync();
+        await using var nats = await server.CreateClientConnectionAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -514,8 +514,8 @@ public class KeyValueStoreTest
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var cancellationToken = cts.Token;
 
-        await using var server = NatsServer.StartJS();
-        await using var nats = server.CreateClientConnection();
+        await using var server = await NatsServer.StartJSAsync();
+        await using var nats = await server.CreateClientConnectionAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);


### PR DESCRIPTION
> [!NOTE]
> * to be merged into #733 

* Adds support to set the `AllowMsgTTL` flag for KV streams
* Adds a `Timestamp ttl` optional parameter to the `PutAsync<T>` method on `INatsKVStore`
  * Note that this does break API backwards compatibility if users are using their own serializers, but that's seems to be how it's done in Go client, so it's up to you if you want to create a separate overload for each method that can accept a TTL value
* Added a single test to test the TTL functionality. This currently requires the tests to have access to the latest nightly binary

TODO:
* More exhaustive tests
* Add support to the `CreateAsync/UpdateAsync` API methods

see also [ADR-43](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-43.md)