### PR TITLE
Make sure we also install .net 6 for the tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup dotnet
+      - name: Setup dotnet 6
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.x'
+      
+      - name: Setup dotnet 8
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'


### PR DESCRIPTION
.NET 6 was missing so it didn't run those tests and failed the CI builds.