### PR TITLE
Implement Lame Duck Mode Event Handler

### DIFF
--- a/src/NATS.Client.Core/INatsConnection.cs
+++ b/src/NATS.Client.Core/INatsConnection.cs
@@ -28,7 +28,7 @@ public interface INatsConnection : INatsClient
     /// <summary>
     /// Event that is raised when server goes into Lame Duck Mode.
     /// </summary>
-    public event AsyncEventHandler<NatsEventArgs>? LameDuckModeActivated;
+    public event AsyncEventHandler<NatsLameDuckModeActivatedEventArgs>? LameDuckModeActivated;
 
     /// <summary>
     /// Server information received from the NATS server.

--- a/src/NATS.Client.Core/INatsConnection.cs
+++ b/src/NATS.Client.Core/INatsConnection.cs
@@ -26,6 +26,11 @@ public interface INatsConnection : INatsClient
     event AsyncEventHandler<NatsMessageDroppedEventArgs>? MessageDropped;
 
     /// <summary>
+    /// Event that is raised when server goes into Lame Duck Mode.
+    /// </summary>
+    public event AsyncEventHandler<NatsEventArgs>? LameDuckModeActivated;
+
+    /// <summary>
     /// Server information received from the NATS server.
     /// </summary>
     INatsServerInfo? ServerInfo { get; }

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -24,14 +24,13 @@ internal enum NatsEvent
     ConnectionDisconnected,
     ReconnectFailed,
     MessageDropped,
+    LameDuckModeActivated,
 }
 
 public partial class NatsConnection : INatsConnection
 {
 #pragma warning disable SA1401
     internal readonly ConnectionStatsCounter Counter; // allow to call from external sources
-    internal volatile ServerInfo? WritableServerInfo;
-
 #pragma warning restore SA1401
     private readonly object _gate = new object();
     private readonly ILogger<NatsConnection> _logger;
@@ -44,6 +43,7 @@ public partial class NatsConnection : INatsConnection
     private readonly ClientOpts _clientOpts;
     private readonly SubscriptionManager _subscriptionManager;
 
+    private ServerInfo? _writableServerInfo;
     private int _pongCount;
     private int _connectionState;
     private int _isDisposed;
@@ -109,6 +109,8 @@ public partial class NatsConnection : INatsConnection
 
     public event AsyncEventHandler<NatsMessageDroppedEventArgs>? MessageDropped;
 
+    public event AsyncEventHandler<NatsEventArgs>? LameDuckModeActivated;
+
     public INatsConnection Connection => this;
 
     public NatsOpts Opts { get; }
@@ -133,6 +135,21 @@ public partial class NatsConnection : INatsConnection
     public Func<(string Host, int Port), ValueTask<(string Host, int Port)>>? OnConnectingAsync { get; set; }
 
     public Func<ISocketConnection, ValueTask<ISocketConnection>>? OnSocketAvailableAsync { get; set; }
+
+    internal ServerInfo? WritableServerInfo
+    {
+        get => Interlocked.CompareExchange(ref _writableServerInfo, null, null);
+        set
+        {
+            var current = Interlocked.CompareExchange(ref _writableServerInfo, null, null);
+            if (current?.LameDuckMode == false && value?.LameDuckMode == true)
+            {
+                _eventChannel.Writer.TryWrite((NatsEvent.LameDuckModeActivated, new NatsEventArgs(string.Empty)));
+            }
+
+            Interlocked.Exchange(ref _writableServerInfo, value);
+        }
+    }
 
     internal bool IsDisposed
     {
@@ -761,6 +778,9 @@ public partial class NatsConnection : INatsConnection
                         break;
                     case NatsEvent.MessageDropped when MessageDropped != null && args is NatsMessageDroppedEventArgs error:
                         await MessageDropped.InvokeAsync(this, error).ConfigureAwait(false);
+                        break;
+                    case NatsEvent.LameDuckModeActivated when LameDuckModeActivated != null:
+                        await LameDuckModeActivated.InvokeAsync(this, args).ConfigureAwait(false);
                         break;
                     }
                 }

--- a/src/NATS.Client.Core/NatsEventArgs.cs
+++ b/src/NATS.Client.Core/NatsEventArgs.cs
@@ -33,3 +33,11 @@ public class NatsMessageDroppedEventArgs : NatsEventArgs
 
     public object? Data { get; }
 }
+
+public class NatsLameDuckModeActivatedEventArgs : NatsEventArgs
+{
+    public NatsLameDuckModeActivatedEventArgs(Uri uri)
+        : base("Lame duck mode activated") => Uri = uri;
+
+    public Uri Uri { get; }
+}

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -506,7 +506,7 @@ public abstract partial class NatsConnectionTest
         disconnectedCount.ShouldBe(1);
     }
 
-    [Fact]
+    [SkipIfNatsServer(versionEarlierThan: "2.10")]
     public async Task LameDuckModeActivated_EventHandlerShouldBeInvokedWhenInfoWithLDMReceived()
     {
         await using var natsServer = NatsServer.Start(

--- a/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
+++ b/tests/NATS.Client.Core.Tests/NatsConnectionTest.cs
@@ -552,9 +552,9 @@ public abstract partial class NatsConnectionTest
         var subject = $"$SYS.REQ.SERVER.{connection.ServerInfo!.Id}.LDM";
 
         // Act
-        var response = await connection.RequestAsync<string, string>(
+        await connection.RequestAsync<string, string>(
             subject: subject,
-            data: "{}");
+            data: $$"""{"cid":{{connection.ServerInfo!.ClientId}}}""");
         await ldmSignal;
 
         // Assert

--- a/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
@@ -93,7 +93,7 @@ public class NatsJSContextFactoryTest
 
         public event AsyncEventHandler<NatsMessageDroppedEventArgs>? MessageDropped;
 
-        public event AsyncEventHandler<NatsEventArgs>? LameDuckModeActivated;
+        public event AsyncEventHandler<NatsLameDuckModeActivatedEventArgs>? LameDuckModeActivated;
 #pragma warning restore CS0067
 
         public INatsServerInfo? ServerInfo { get; } = null;

--- a/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
@@ -92,6 +92,8 @@ public class NatsJSContextFactoryTest
         public event AsyncEventHandler<NatsEventArgs>? ReconnectFailed;
 
         public event AsyncEventHandler<NatsMessageDroppedEventArgs>? MessageDropped;
+
+        public event AsyncEventHandler<NatsEventArgs>? LameDuckModeActivated;
 #pragma warning restore CS0067
 
         public INatsServerInfo? ServerInfo { get; } = null;

--- a/tests/NATS.Client.TestUtilities/NatsServer.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServer.cs
@@ -438,34 +438,6 @@ public class NatsServer : IAsyncDisposable
         }
     }
 
-    public void SignalLameDuckMode()
-    {
-        if (ServerProcess == null || ServerProcess.HasExited)
-        {
-            throw new Exception("Cannot signal LDM, server process is not running.");
-        }
-
-        var signalProcess = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = NatsServerPath,
-                Arguments = $"--signal ldm={ServerProcess.Id}",
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-            },
-        };
-
-        signalProcess.Start();
-        signalProcess.WaitForExit();
-
-        if (signalProcess.ExitCode != 0)
-        {
-            var error = signalProcess.StandardError.ReadToEnd();
-            throw new Exception($"Failed to signal lame duck mode: {error}");
-        }
-    }
-
     private static (string configFileName, string config, string cmd) GetCmd(NatsServerOpts opts)
     {
         var configFileName = Path.GetTempFileName();

--- a/tests/NATS.Client.TestUtilities/NatsServer.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServer.cs
@@ -438,6 +438,34 @@ public class NatsServer : IAsyncDisposable
         }
     }
 
+    public void SignalLameDuckMode()
+    {
+        if (ServerProcess == null || ServerProcess.HasExited)
+        {
+            throw new Exception("Cannot signal LDM, server process is not running.");
+        }
+
+        var signalProcess = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = NatsServerPath,
+                Arguments = $"--signal ldm={ServerProcess.Id}",
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            },
+        };
+
+        signalProcess.Start();
+        signalProcess.WaitForExit();
+
+        if (signalProcess.ExitCode != 0)
+        {
+            var error = signalProcess.StandardError.ReadToEnd();
+            throw new Exception($"Failed to signal lame duck mode: {error}");
+        }
+    }
+
     private static (string configFileName, string config, string cmd) GetCmd(NatsServerOpts opts)
     {
         var configFileName = Path.GetTempFileName();


### PR DESCRIPTION
Resolves #23 

I had two ideas for approaching this issue:
- Make `WritableServerInfo` property and add setter, that will check if LDM has changed to `true`
- Add a trigger method that writes the event to a channel in `NatsConnection` and invoke it directly from `NatsReadProtocolProcessor` after recieving INFO from server with LDM.

I decided to go with first option.

There is one thing i am not sure of: should anything be passed as argument to the `LameDuckModeActivated` event? Currently, it is an empty string.