### PR TITLE
Fix JetStream test flappers

### DIFF
--- a/tests/NATS.Client.Core.Tests/ClusterTests.cs
+++ b/tests/NATS.Client.Core.Tests/ClusterTests.cs
@@ -1,3 +1,5 @@
+using NATS.Client.TestUtilities2;
+
 namespace NATS.Client.Core.Tests;
 
 public class ClusterTests(ITestOutputHelper output)
@@ -47,6 +49,7 @@ public class ClusterTests(ITestOutputHelper output)
             NoRandomize = true,
             Url = $"{url1},{url2}",
         });
+        await nats.ConnectRetryAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 

--- a/tests/NATS.Client.Core.Tests/TlsClientTest.cs
+++ b/tests/NATS.Client.Core.Tests/TlsClientTest.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.Core.Tests;
 
@@ -78,6 +79,7 @@ public class TlsClientTest
         var clientOpts = server.ClientOpts(NatsOpts.Default);
         clientOpts = clientOpts with { TlsOpts = clientOpts.TlsOpts with { CertFile = null, KeyFile = null } };
         await using var nats = new NatsConnection(clientOpts);
+        await nats.ConnectRetryAsync();
 
         var exceptionTask = Assert.ThrowsAsync<NatsException>(async () => await nats.ConnectAsync());
 

--- a/tests/NATS.Client.Core.Tests/TlsClientTest.cs
+++ b/tests/NATS.Client.Core.Tests/TlsClientTest.cs
@@ -79,7 +79,6 @@ public class TlsClientTest
         var clientOpts = server.ClientOpts(NatsOpts.Default);
         clientOpts = clientOpts with { TlsOpts = clientOpts.TlsOpts with { CertFile = null, KeyFile = null } };
         await using var nats = new NatsConnection(clientOpts);
-        await nats.ConnectRetryAsync();
 
         var exceptionTask = Assert.ThrowsAsync<NatsException>(async () => await nats.ConnectAsync());
 

--- a/tests/NATS.Client.JetStream.Tests/ClusterTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/ClusterTests.cs
@@ -1,4 +1,5 @@
 using NATS.Client.Core.Tests;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
 
@@ -15,7 +16,7 @@ public class ClusterTests
         await cluster.StartAsync();
         await using var nats = await cluster.Server1.CreateClientConnectionAsync();
 
-        await nats.PingAsync();
+        await nats.ConnectRetryAsync();
 
         var urls = nats.ServerInfo!.ClientConnectUrls!.ToList();
 

--- a/tests/NATS.Client.JetStream.Tests/CustomSerializerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/CustomSerializerTest.cs
@@ -1,29 +1,44 @@
 using System.Buffers;
 using NATS.Client.Core.Tests;
+using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
 
+[Collection("nats-server")]
 public class CustomSerializerTest
 {
+    private readonly ITestOutputHelper _output;
+    private readonly NatsServerFixture _server;
+
+    public CustomSerializerTest(ITestOutputHelper output, NatsServerFixture server)
+    {
+        _output = output;
+        _server = server;
+    }
+
     [Fact]
     public async Task When_consuming_ack_should_be_serialized_normally_if_custom_serializer_used()
     {
-        await using var server = await NatsServer.StartJSAsync();
-        await using var nats = await server.CreateClientConnectionAsync(new NatsOpts
+        await using var nats = new NatsConnection(new NatsOpts
         {
+            Url = _server.Url,
             SerializerRegistry = new Level42SerializerRegistry(),
             RequestTimeout = TimeSpan.FromSeconds(10),
         });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
         var js = new NatsJSContext(nats);
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        await js.CreateStreamAsync($"{prefix}s1", new[] { $"{prefix}s1.*" }, cts.Token);
 
-        await js.PublishAsync("s1.1", new byte[] { 0 }, cancellationToken: cts.Token);
-        await js.PublishAsync("s1.2", new byte[] { 0 }, cancellationToken: cts.Token);
+        await js.PublishAsync($"{prefix}s1.1", new byte[] { 0 }, cancellationToken: cts.Token);
+        await js.PublishAsync($"{prefix}s1.2", new byte[] { 0 }, cancellationToken: cts.Token);
 
-        var consumer = await js.CreateOrUpdateConsumerAsync("s1", "c1", cancellationToken: cts.Token);
+        var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", $"{prefix}c1", cancellationToken: cts.Token);
 
         // single ack
         {

--- a/tests/NATS.Client.JetStream.Tests/ErrorHandlerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ErrorHandlerTest.cs
@@ -310,9 +310,16 @@ public class ErrorHandlerTest
 
         await Retry.Until("timed out", () => Volatile.Read(ref timeoutNotifications) > 0, timeout: TimeSpan.FromSeconds(30));
         consumeCts.Cancel();
-        await consume;
 
         Assert.True(Volatile.Read(ref timeoutNotifications) > 0);
+
+        try
+        {
+            await consume;
+        }
+        catch (OperationCanceledException)
+        {
+        }
     }
 
     [Fact]

--- a/tests/NATS.Client.JetStream.Tests/ErrorHandlerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ErrorHandlerTest.cs
@@ -245,7 +245,7 @@ public class ErrorHandlerTest
 
         var js = new NatsJSContext(nats);
 
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
         var stream = await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", new[] { $"{prefix}s1.*" }), cts.Token);
         var consumer = (NatsJSOrderedConsumer)await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
@@ -281,7 +281,7 @@ public class ErrorHandlerTest
         // Swallow heartbeats
         proxy.ServerInterceptors.Add(m => m?.Contains("Idle Heartbeat") ?? false ? null : m);
 
-        var consumeCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+        var consumeCts = new CancellationTokenSource();
         var consume = Task.Run(
             async () =>
             {
@@ -308,7 +308,7 @@ public class ErrorHandlerTest
             },
             cts.Token);
 
-        await Retry.Until("timed out", () => Volatile.Read(ref timeoutNotifications) > 0, timeout: TimeSpan.FromSeconds(20));
+        await Retry.Until("timed out", () => Volatile.Read(ref timeoutNotifications) > 0, timeout: TimeSpan.FromSeconds(30));
         consumeCts.Cancel();
         await consume;
 

--- a/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
@@ -41,7 +41,7 @@ public class ManageConsumerTest
     [Fact]
     public async Task List_delete_consumer()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         await using var server = await NatsServer.StartJSAsync();
         var nats = await server.CreateClientConnectionAsync();

--- a/tests/NATS.Client.JetStream.Tests/OrderedConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/OrderedConsumerTest.cs
@@ -1,33 +1,43 @@
 using System.Diagnostics;
 using NATS.Client.Core.Tests;
+using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
 
+[Collection("nats-server")]
 public class OrderedConsumerTest
 {
     private readonly ITestOutputHelper _output;
+    private readonly NatsServerFixture _server;
 
-    public OrderedConsumerTest(ITestOutputHelper output) => _output = output;
+    public OrderedConsumerTest(ITestOutputHelper output, NatsServerFixture server)
+    {
+        _output = output;
+        _server = server;
+    }
 
     [Fact]
     public async Task Consume_test()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await using var server = await NatsServer.StartJSAsync();
-        await using var nats = await server.CreateClientConnectionAsync();
+        await using var nats = _server.CreateNatsConnection();
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
         var js = new NatsJSContext(nats);
 
-        var stream = await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
 
         for (var i = 0; i < 10; i++)
         {
-            await js.PublishAsync("s1.foo", i, cancellationToken: cts.Token);
+            await js.PublishAsync($"{prefix}s1.foo", i, cancellationToken: cts.Token);
         }
 
         var consumer = await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
 
         var count = 0;
-        _output.WriteLine("Consuming...");
         var consumeOpts = new NatsJSConsumeOpts
         {
             MaxMsgs = 3,
@@ -35,7 +45,6 @@ public class OrderedConsumerTest
         };
         await foreach (var msg in consumer.ConsumeAsync<int>(opts: consumeOpts, cancellationToken: cts.Token))
         {
-            _output.WriteLine($"[RCV] {msg.Data}");
             Assert.Equal(count, msg.Data);
             if (++count == 10)
                 break;
@@ -51,7 +60,7 @@ public class OrderedConsumerTest
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-        var stream = await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        var stream = await js.CreateStreamAsync("s1", ["s1.*"], cts.Token);
 
         for (var i = 0; i < 50; i++)
         {
@@ -87,23 +96,25 @@ public class OrderedConsumerTest
     [Fact]
     public async Task Fetch_test()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await using var server = await NatsServer.StartJSAsync();
-        await using var nats = await server.CreateClientConnectionAsync();
+        await using var nats = _server.CreateNatsConnection();
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
         var js = new NatsJSContext(nats);
 
-        var stream = await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var stream = await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
 
         for (var i = 0; i < 10; i++)
         {
-            await js.PublishAsync("s1.foo", i, cancellationToken: cts.Token);
+            await js.PublishAsync($"{prefix}s1.foo", i, cancellationToken: cts.Token);
         }
 
         var consumer = await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
 
         for (var i = 0; i < 10;)
         {
-            _output.WriteLine("Fetching...");
             var fetchOpts = new NatsJSFetchOpts
             {
                 MaxMsgs = 3,
@@ -111,7 +122,6 @@ public class OrderedConsumerTest
             };
             await foreach (var msg in consumer.FetchAsync<int>(opts: fetchOpts, cancellationToken: cts.Token))
             {
-                _output.WriteLine($"[RCV] {msg.Data}");
                 Assert.Equal(i, msg.Data);
                 i++;
             }
@@ -121,12 +131,15 @@ public class OrderedConsumerTest
     [Fact]
     public async Task Fetch_no_wait_test()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await using var server = await NatsServer.StartJSAsync();
-        await using var nats = await server.CreateClientConnectionAsync();
+        await using var nats = _server.CreateNatsConnection();
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
         var js = new NatsJSContext(nats);
 
-        var stream = await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
 
         var consumer = await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
 
@@ -140,16 +153,14 @@ public class OrderedConsumerTest
 
         stopwatch.Stop();
 
-        _output.WriteLine($"stopwatch.Elapsed: {stopwatch.Elapsed}");
-
         Assert.Equal(0, count);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(3));
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
 
         // Where there is less than we want to fetch, we should get all the messages
         // without waiting for the timeout.
         for (var i = 0; i < 10; i++)
         {
-            await js.PublishAsync("s1.foo", i, cancellationToken: cts.Token);
+            await js.PublishAsync($"{prefix}s1.foo", i, cancellationToken: cts.Token);
         }
 
         stopwatch.Restart();
@@ -159,7 +170,6 @@ public class OrderedConsumerTest
             var currentCount = 0;
             await foreach (var msg in consumer.FetchNoWaitAsync<int>(opts: new NatsJSFetchOpts { MaxMsgs = 6 }, cancellationToken: cts.Token))
             {
-                _output.WriteLine($"[RCV][{iterationCount}] {msg.Data}");
                 Assert.Equal(count, msg.Data);
                 count++;
                 currentCount++;
@@ -178,29 +188,31 @@ public class OrderedConsumerTest
 
         Assert.Equal(2, iterationCount);
         Assert.Equal(10, count);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(3));
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
     }
 
     [Fact]
     public async Task Next_test()
     {
-        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        await using var server = await NatsServer.StartJSAsync();
-        await using var nats = await server.CreateClientConnectionAsync();
+        await using var nats = _server.CreateNatsConnection();
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
         var js = new NatsJSContext(nats);
 
-        var stream = await js.CreateStreamAsync("s1", new[] { "s1.*" }, cts.Token);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
 
         for (var i = 0; i < 10; i++)
         {
-            await js.PublishAsync("s1.foo", i, cancellationToken: cts.Token);
+            await js.PublishAsync($"{prefix}s1.foo", i, cancellationToken: cts.Token);
         }
 
         var consumer = await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
 
         for (var i = 0; i < 10;)
         {
-            _output.WriteLine("Next...");
             var nextOpts = new NatsJSNextOpts
             {
                 Expires = TimeSpan.FromSeconds(3),
@@ -209,7 +221,6 @@ public class OrderedConsumerTest
 
             if (next is { } msg)
             {
-                _output.WriteLine($"[RCV] {msg.Data}");
                 Assert.Equal(i, msg.Data);
                 i++;
             }

--- a/tests/NATS.Client.JetStream.Tests/Utils.cs
+++ b/tests/NATS.Client.JetStream.Tests/Utils.cs
@@ -1,3 +1,5 @@
+using NATS.Client.Core.Tests;
+using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
 
 namespace NATS.Client.JetStream.Tests;
@@ -9,4 +11,21 @@ public static class Utils
 
     public static ValueTask<INatsJSStream> CreateStreamAsync(this NatsJSContext context, string stream, string[] subjects, CancellationToken cancellationToken = default)
         => context.CreateStreamAsync(new StreamConfig { Name = stream, Subjects = subjects }, cancellationToken);
+
+    public static NatsProxy CreateProxy(this NatsServerFixture server)
+        => new(new Uri(server.Url).Port);
+
+    public static NatsConnection CreateNatsConnection(this NatsProxy proxy)
+        => new(new NatsOpts
+        {
+            Url = $"nats://127.0.0.1:{proxy.Port}",
+            ConnectTimeout = TimeSpan.FromSeconds(10),
+        });
+
+    public static NatsConnection CreateNatsConnection(this NatsServerFixture server)
+        => new(new NatsOpts
+        {
+            Url = server.Url,
+            ConnectTimeout = TimeSpan.FromSeconds(10),
+        });
 }

--- a/tests/NATS.Client.TestUtilities/NatsProxy.cs
+++ b/tests/NATS.Client.TestUtilities/NatsProxy.cs
@@ -158,7 +158,13 @@ public class NatsProxy : IDisposable
 
         await Retry.Until(
             "flush sync frame",
-            () => AllFrames.Any(f => f.Message == $"PUB {subject} 0␍␊"));
+            async () =>
+            {
+                await nats.PublishAsync(subject);
+                return AllFrames.Any(f => f.Message == $"PUB {subject} 0␍␊");
+            },
+            retryDelay: TimeSpan.FromSeconds(1),
+            timeout: TimeSpan.FromSeconds(60));
 
         lock (_frames)
             _frames.Clear();

--- a/tests/NATS.Client.TestUtilities/NatsProxy.cs
+++ b/tests/NATS.Client.TestUtilities/NatsProxy.cs
@@ -121,7 +121,7 @@ public class NatsProxy : IDisposable
         }
     }
 
-    public IReadOnlyList<Frame> ClientFrames => Frames.Where(f => f.Origin == "C").ToList();
+    public IReadOnlyList<Frame> ClientFrames => Frames.Where(f => f.Origin == "C" && !f.Message.Contains("__PROXY_SIGNAL_SYNC__")).ToList();
 
     public IReadOnlyList<Frame> ServerFrames => Frames.Where(f => f.Origin == "S").ToList();
 
@@ -152,7 +152,7 @@ public class NatsProxy : IDisposable
 
     public async Task FlushFramesAsync(NatsConnection nats)
     {
-        var subject = $"_SIGNAL_SYNC_{Interlocked.Increment(ref _syncCount)}";
+        var subject = $"__PROXY_SIGNAL_SYNC__{Interlocked.Increment(ref _syncCount)}";
 
         await nats.PublishAsync(subject);
 

--- a/tests/NATS.Client.TestUtilities/NatsServer.cs
+++ b/tests/NATS.Client.TestUtilities/NatsServer.cs
@@ -308,9 +308,12 @@ public class NatsServer : IAsyncDisposable
         {
             _cancellationTokenSource?.Cancel(); // trigger of process kill.
             _cancellationTokenSource?.Dispose();
-            ServerProcess!.Kill();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            await ServerProcess!.WaitForExitAsync(cts.Token);
+            if (ServerProcess != null)
+            {
+                ServerProcess.Kill();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                await ServerProcess.WaitForExitAsync(cts.Token);
+            }
         }
         catch (OperationCanceledException)
         {
@@ -333,9 +336,12 @@ public class NatsServer : IAsyncDisposable
         {
             _cancellationTokenSource?.Cancel(); // trigger of process kill.
             _cancellationTokenSource?.Dispose();
-            ServerProcess!.Kill();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            await ServerProcess!.WaitForExitAsync(cts.Token);
+            if (ServerProcess != null)
+            {
+                ServerProcess.Kill();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                await ServerProcess.WaitForExitAsync(cts.Token)!;
+            }
         }
         catch (OperationCanceledException)
         {

--- a/tests/NATS.Client.TestUtilities/Utils.cs
+++ b/tests/NATS.Client.TestUtilities/Utils.cs
@@ -15,7 +15,7 @@ public static class Retry
 {
     public static async Task Until(string reason, Func<bool> condition, Func<Task>? action = null, TimeSpan? timeout = null, TimeSpan? retryDelay = null)
     {
-        timeout ??= TimeSpan.FromSeconds(10);
+        timeout ??= TimeSpan.FromSeconds(30);
         var delay1 = retryDelay ?? TimeSpan.FromSeconds(.1);
 
         var stopwatch = Stopwatch.StartNew();
@@ -33,7 +33,7 @@ public static class Retry
 
     public static async Task Until(string reason, Func<Task<bool>> condition, Func<Task>? action = null, TimeSpan? timeout = null, TimeSpan? retryDelay = null)
     {
-        timeout ??= TimeSpan.FromSeconds(10);
+        timeout ??= TimeSpan.FromSeconds(30);
         var delay1 = retryDelay ?? TimeSpan.FromSeconds(.1);
 
         var stopwatch = Stopwatch.StartNew();


### PR DESCRIPTION
* Added pre connect retry loop for clients to be ready
* moved a few test to use a single nats-server rather than spawning a new one in each test (look for `[Collection("nats-server")]` on test classes)
* fixed test proxy sync issues
* extended timeouts to 30s (this one probably not that helpful but my assumption is if they are running on really small VMs with a single CPU than the extra wait might help)