### PR TITLE
Added an ability to specify pool size with a callback using IServiceProvider

### DIFF
--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
@@ -10,7 +10,7 @@ public class NatsBuilder
 {
     private readonly IServiceCollection _services;
 
-    private int _poolSize = 1;
+    private Func<IServiceProvider, int> _poolSizeConfigurer = _ => 1;
     private Func<IServiceProvider, NatsOpts, NatsOpts>? _configureOpts;
     private Action<IServiceProvider, NatsConnection>? _configureConnection;
     private object? _diKey = null;
@@ -20,7 +20,14 @@ public class NatsBuilder
 
     public NatsBuilder WithPoolSize(int size)
     {
-        _poolSize = Math.Max(size, 1);
+        _poolSizeConfigurer = _ => Math.Max(size, 1);
+
+        return this;
+    }
+
+    public NatsBuilder WithPoolSize(Func<IServiceProvider, int> sizeConfigurer)
+    {
+        _poolSizeConfigurer = sp => Math.Max(sizeConfigurer(sp), 1);
 
         return this;
     }
@@ -80,39 +87,21 @@ public class NatsBuilder
 
     internal IServiceCollection Build()
     {
-        if (_poolSize != 1)
+        if (_diKey == null)
         {
-            if (_diKey == null)
-            {
-                _services.TryAddSingleton<NatsConnectionPool>(provider => PoolFactory(provider));
-                _services.TryAddSingleton<INatsConnectionPool>(static provider => provider.GetRequiredService<NatsConnectionPool>());
-                _services.TryAddTransient<NatsConnection>(static provider => PooledConnectionFactory(provider, null));
-                _services.TryAddTransient<INatsConnection>(static provider => provider.GetRequiredService<NatsConnection>());
-            }
-            else
-            {
-#if NET8_0_OR_GREATER
-                _services.TryAddKeyedSingleton<NatsConnectionPool>(_diKey, PoolFactory);
-                _services.TryAddKeyedSingleton<INatsConnectionPool>(_diKey, static (provider, key) => provider.GetRequiredKeyedService<NatsConnectionPool>(key));
-                _services.TryAddKeyedTransient(_diKey, PooledConnectionFactory);
-                _services.TryAddKeyedTransient<INatsConnection>(_diKey, static (provider, key) => provider.GetRequiredKeyedService<NatsConnection>(key));
-#endif
-            }
+            _services.TryAddSingleton<NatsConnectionPool>(provider => PoolFactory(provider));
+            _services.TryAddSingleton<INatsConnectionPool>(static provider => provider.GetRequiredService<NatsConnectionPool>());
+            _services.TryAddTransient<NatsConnection>(static provider => PooledConnectionFactory(provider, null));
+            _services.TryAddTransient<INatsConnection>(static provider => provider.GetRequiredService<NatsConnection>());
         }
         else
         {
-            if (_diKey == null)
-            {
-                _services.TryAddSingleton<NatsConnection>(provider => SingleConnectionFactory(provider));
-                _services.TryAddSingleton<INatsConnection>(static provider => provider.GetRequiredService<NatsConnection>());
-            }
-            else
-            {
 #if NET8_0_OR_GREATER
-                _services.TryAddKeyedSingleton(_diKey, SingleConnectionFactory);
-                _services.TryAddKeyedSingleton<INatsConnection>(_diKey, static (provider, key) => provider.GetRequiredKeyedService<NatsConnection>(key));
+            _services.TryAddKeyedSingleton<NatsConnectionPool>(_diKey, PoolFactory);
+            _services.TryAddKeyedSingleton<INatsConnectionPool>(_diKey, static (provider, key) => provider.GetRequiredKeyedService<NatsConnectionPool>(key));
+            _services.TryAddKeyedTransient(_diKey, PooledConnectionFactory);
+            _services.TryAddKeyedTransient<INatsConnection>(_diKey, static (provider, key) => provider.GetRequiredKeyedService<NatsConnection>(key));
 #endif
-            }
         }
 
         return _services;
@@ -136,17 +125,6 @@ public class NatsBuilder
         var options = NatsOpts.Default with { LoggerFactory = provider.GetRequiredService<ILoggerFactory>() };
         options = _configureOpts?.Invoke(provider, options) ?? options;
 
-        return new NatsConnectionPool(_poolSize, options, con => _configureConnection?.Invoke(provider, con));
-    }
-
-    private NatsConnection SingleConnectionFactory(IServiceProvider provider, object? diKey = null)
-    {
-        var options = NatsOpts.Default with { LoggerFactory = provider.GetRequiredService<ILoggerFactory>() };
-        options = _configureOpts?.Invoke(provider, options) ?? options;
-
-        var conn = new NatsConnection(options);
-        _configureConnection?.Invoke(provider, conn);
-
-        return conn;
+        return new NatsConnectionPool(_poolSizeConfigurer(provider), options, con => _configureConnection?.Invoke(provider, con));
     }
 }

--- a/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/NatsHostingExtensionsTests.cs
+++ b/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/NatsHostingExtensionsTests.cs
@@ -39,6 +39,21 @@ public class NatsHostingExtensionsTests
     }
 
     [Fact]
+    public void AddNatsClient_RegistersNatsConnectionAsTransient_WhenPoolSizeFuncIsGreaterThanOne()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+        services.AddNatsClient(nats => nats.WithPoolSize(_ => 2));
+
+        var provider = services.BuildServiceProvider();
+        var natsConnection1 = provider.GetRequiredService<INatsConnection>();
+        var natsConnection2 = provider.GetRequiredService<INatsConnection>();
+
+        Assert.NotNull(natsConnection1);
+        Assert.NotSame(natsConnection1, natsConnection2); // Transient should return different instances
+    }
+
+    [Fact]
     public async Task AddNatsClient_WithJsonSerializer()
     {
         await using var server = NatsServer.Start();
@@ -168,6 +183,56 @@ public class NatsHostingExtensionsTests
 
         services.AddNatsClient(builder => builder.WithPoolSize(2).WithKey(key1));
         services.AddNatsClient(builder => builder.WithPoolSize(2).WithKey(key2));
+        var provider = services.BuildServiceProvider();
+
+        Dictionary<string, List<object>> connections = new();
+        foreach (var key in new[] { key1, key2 })
+        {
+            var nats1 = provider.GetKeyedService<INatsConnection>(key);
+            Assert.NotNull(nats1);
+            var nats2 = provider.GetKeyedService<INatsConnection>(key);
+            Assert.NotNull(nats2);
+            var nats3 = provider.GetKeyedService<INatsConnection>(key);
+            Assert.NotNull(nats3);
+            var nats4 = provider.GetKeyedService<INatsConnection>(key);
+            Assert.NotNull(nats4);
+
+            // relying on the fact that the pool size is 2 and connections are returned in a round-robin fashion
+            Assert.NotSame(nats1, nats2);
+            Assert.Same(nats1, nats3);
+            Assert.NotSame(nats2, nats3);
+            Assert.Same(nats2, nats4);
+
+            if (!connections.TryGetValue(key, out var list))
+            {
+                list = new List<object>();
+                connections.Add(key, list);
+            }
+
+            list.Add(nats1);
+            list.Add(nats2);
+            list.Add(nats3);
+            list.Add(nats4);
+        }
+
+        foreach (var obj1 in connections[key1])
+        {
+            foreach (var obj2 in connections[key2])
+                Assert.NotSame(obj1, obj2);
+        }
+    }
+
+    [Fact]
+    public void AddNats_RegistersKeyedNatsConnection_WhenKeyIsProvided_pooledFunc()
+    {
+        var key1 = "TestKey1";
+        var key2 = "TestKey2";
+
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+
+        services.AddNatsClient(builder => builder.WithPoolSize(_ => 2).WithKey(key1));
+        services.AddNatsClient(builder => builder.WithPoolSize(_ => 2).WithKey(key2));
         var provider = services.BuildServiceProvider();
 
         Dictionary<string, List<object>> connections = new();


### PR DESCRIPTION
When initializing NATS using `IServiceCollection.AddNatsClient` one has to specify a pool size in a callback, which doesn't support passing `IServiceProvider`. This involves setting pool size upfront as a constant or reading it from `IConfiguration` directly with something like `IConfiguration.GetSection(...).Get<...>()`.
This PR retains an ability to specify pool size constantly as it is now without breaking changes. And also adds an ability to use `IServiceProvider` which helps in cases where pool size is defined in one of app options. Something like:
```
.WithPoolSize(sp => sp.GetService<IOptions<AppOption>>().Value.NATSPoolSize)
```
But because of this there will be no more `SingleConnectionFactory` and `PooledConnectionFactory` will be always used even if pool size is 1.
This might come with a performance impact in very high load cases since there is another layer of delegates added.
But it should be negligible.