### PR TITLE
Add NatsPayloadTooLargeException

### DIFF
--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -323,7 +323,7 @@ internal sealed class CommandWriter : IAsyncDisposable
             var size = payloadBuffer.WrittenMemory.Length + (headersBuffer?.WrittenMemory.Length ?? 0);
             if (_connection.ServerInfo is { } info && size > info.MaxPayload)
             {
-                throw new NatsException($"Payload size {size} exceeds server's maximum payload size {info.MaxPayload}");
+                throw new NatsPayloadTooLargeException($"Payload size {size} exceeds server's maximum payload size {info.MaxPayload}");
             }
         }
         catch

--- a/src/NATS.Client.Core/NatsException.cs
+++ b/src/NATS.Client.Core/NatsException.cs
@@ -50,3 +50,12 @@ public sealed class NatsServerException : NatsException
 
     public bool IsAuthError { get; }
 }
+
+
+public sealed class NatsPayloadTooLargeException : NatsException
+{
+    public NatsPayloadTooLargeException(string error)
+        : base(error)
+    {
+    }
+}


### PR DESCRIPTION
Add a `NatsPayloadTooLargeException` class derived from `NatsException`, to allow handling the exception more explicitly on client call.

#759 