### PR TITLE
Make the parameter-less StreamConfig constructor public

### DIFF
--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -10,7 +10,7 @@ public record StreamConfig
         Subjects = subjects;
     }
 
-    internal StreamConfig()
+    public StreamConfig()
     {
     }
 


### PR DESCRIPTION
Simple change to make the StreamConfig class available for external (de)serialization, e.g. for advisory messages such as  StreamSnapshotResponse.