### PR TITLE
Use TimeSpan for backoff consumer config

### DIFF
--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -223,7 +223,8 @@ public record ConsumerConfig
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("backoff")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    public ICollection<long>? Backoff { get; set; }
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonNullableCollectionNanosecondsConverter))]
+    public ICollection<TimeSpan>? Backoff { get; set; }
 
     /// <summary>
     /// When set do not inherit the replica count from the stream but specifically set it to this amount

--- a/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
@@ -396,6 +396,57 @@ internal class NatsJSJsonNullableNanosecondsConverter : JsonConverter<TimeSpan?>
     }
 }
 
+internal class NatsJSJsonNullableCollectionNanosecondsConverter : JsonConverter<ICollection<TimeSpan>?>
+{
+    private readonly NatsJSJsonNanosecondsConverter _converter = new();
+
+    public override ICollection<TimeSpan>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new InvalidOperationException("Expected start of array");
+        }
+
+        var result = new List<TimeSpan>();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                return result;
+            }
+
+            result.Add(_converter.Read(ref reader, typeof(TimeSpan), options));
+        }
+
+        throw new InvalidOperationException("Expected end of array");
+    }
+
+    public override void Write(Utf8JsonWriter writer, ICollection<TimeSpan>? value, JsonSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            writer.WriteStartArray();
+
+            foreach (var timeSpan in value)
+            {
+                _converter.Write(writer, timeSpan, options);
+            }
+
+            writer.WriteEndArray();
+        }
+    }
+}
+
 internal class NatsJSJsonDateTimeOffsetConverter : JsonConverter<DateTimeOffset>
 {
     public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)


### PR DESCRIPTION
Proposed enhancement for #422.

This change introduces a breaking change that all existing definition is required to be replaced with TimeSpan type.