### PR TITLE
make headers buffer non-nullable

### DIFF
--- a/src/NATS.Client.Core/Internal/InboxSub.cs
+++ b/src/NATS.Client.Core/Internal/InboxSub.cs
@@ -23,11 +23,11 @@ internal class InboxSub : NatsSubBase
     }
 
     // Avoid base class error handling since inboxed subscribers will be responsible for that.
-    public override ValueTask ReceiveAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer) =>
+    public override ValueTask ReceiveAsync(string subject, string? replyTo, ReadOnlySequence<byte> headersBuffer, ReadOnlySequence<byte> payloadBuffer) =>
         _inbox.ReceivedAsync(subject, replyTo, headersBuffer, payloadBuffer, _connection);
 
     // Not used. Dummy implementation to keep base happy.
-    protected override ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+    protected override ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte> headersBuffer, ReadOnlySequence<byte> payloadBuffer)
         => default;
 
     protected override void TryComplete()
@@ -119,7 +119,7 @@ internal class InboxSubBuilder : INatsSubscriptionManager
         return sub.ReadyAsync();
     }
 
-    public async ValueTask ReceivedAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer, NatsConnection connection)
+    public async ValueTask ReceivedAsync(string subject, string? replyTo, ReadOnlySequence<byte> headersBuffer, ReadOnlySequence<byte> payloadBuffer, NatsConnection connection)
     {
         if (!_bySubject.TryGetValue(subject, out var subTable))
         {

--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -196,7 +196,7 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
                                 buffer = buffer.Slice(buffer.GetPosition(3, positionBeforePayload.Value));
                             }
 
-                            await _connection.PublishToClientHandlersAsync(subject, replyTo, sid, null, ReadOnlySequence<byte>.Empty).ConfigureAwait(false);
+                            await _connection.PublishToClientHandlersAsync(subject, replyTo, sid, ReadOnlySequence<byte>.Empty, ReadOnlySequence<byte>.Empty).ConfigureAwait(false);
                         }
                         else
                         {
@@ -217,7 +217,7 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
 
                             buffer = buffer.Slice(buffer.GetPosition(2, payloadSlice.End)); // payload + \r\n
 
-                            await _connection.PublishToClientHandlersAsync(subject, replyTo, sid, null, payloadSlice).ConfigureAwait(false);
+                            await _connection.PublishToClientHandlersAsync(subject, replyTo, sid, ReadOnlySequence<byte>.Empty, payloadSlice).ConfigureAwait(false);
                         }
                     }
                     else if (code == ServerOpCodes.HMsg)

--- a/src/NATS.Client.Core/Internal/SubscriptionManager.cs
+++ b/src/NATS.Client.Core/Internal/SubscriptionManager.cs
@@ -85,7 +85,7 @@ internal sealed class SubscriptionManager : INatsSubscriptionManager, IAsyncDisp
         return SubscribeInternalAsync(sub.Subject, sub.QueueGroup, sub.Opts, sub, cancellationToken);
     }
 
-    public ValueTask PublishToClientHandlersAsync(string subject, string? replyTo, int sid, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
+    public ValueTask PublishToClientHandlersAsync(string subject, string? replyTo, int sid, in ReadOnlySequence<byte> headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
     {
         if (_trace)
         {

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -270,7 +270,7 @@ public partial class NatsConnection : INatsConnection
 
     internal NatsStats GetStats() => Counter.ToStats();
 
-    internal ValueTask PublishToClientHandlersAsync(string subject, string? replyTo, int sid, in ReadOnlySequence<byte>? headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
+    internal ValueTask PublishToClientHandlersAsync(string subject, string? replyTo, int sid, in ReadOnlySequence<byte> headersBuffer, in ReadOnlySequence<byte> payloadBuffer)
     {
         return _subscriptionManager.PublishToClientHandlersAsync(subject, replyTo, sid, headersBuffer, payloadBuffer);
     }

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -314,7 +314,7 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
     internal static NatsMsg<T> Build(
         string subject,
         string? replyTo,
-        in ReadOnlySequence<byte>? headersBuffer,
+        in ReadOnlySequence<byte> headersBuffer,
         in ReadOnlySequence<byte> payloadBuffer,
         INatsConnection? connection,
         NatsHeaderParser headerParser,
@@ -332,21 +332,21 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
             }
         }
 
-        if (headersBuffer != null)
+        if (headersBuffer.Length > 0)
         {
             headers = new NatsHeaders();
 
             try
             {
                 // Parsing can also throw an exception.
-                if (!headerParser.ParseHeaders(new SequenceReader<byte>(headersBuffer.Value), headers))
+                if (!headerParser.ParseHeaders(new SequenceReader<byte>(headersBuffer), headers))
                 {
                     throw new NatsException("Error parsing headers");
                 }
             }
             catch (Exception e)
             {
-                headers.Error ??= new NatsHeaderParseException(headersBuffer.Value.ToArray(), e);
+                headers.Error ??= new NatsHeaderParseException(headersBuffer.ToArray(), e);
             }
         }
 
@@ -373,7 +373,7 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
 
         var size = subject.Length
                    + (replyTo?.Length ?? 0)
-                   + (headersBuffer?.Length ?? 0)
+                   + headersBuffer.Length
                    + payloadBuffer.Length;
 
         if (Telemetry.HasListeners())

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -32,7 +32,7 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
 
     private INatsDeserialize<T> Serializer { get; }
 
-    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+    protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte> headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
         var natsMsg = NatsMsg<T>.Build(
             subject,

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -262,7 +262,7 @@ public abstract class NatsSubBase
     /// <param name="replyTo">Reply subject received for this subscription.</param>
     /// <param name="headersBuffer">Headers buffer received for this subscription.</param>
     /// <param name="payloadBuffer">Payload buffer received for this subscription.</param>
-    public virtual async ValueTask ReceiveAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+    public virtual async ValueTask ReceiveAsync(string subject, string? replyTo, ReadOnlySequence<byte> headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
         ResetIdleTimeout();
 
@@ -300,9 +300,10 @@ public abstract class NatsSubBase
             payloadBuffer.CopyTo(payload.Span);
 
             Memory<byte> headers = default;
-            if (headersBuffer != null)
+            if (headersBuffer.Length > 0)
             {
-                headers = new Memory<byte>(new byte[headersBuffer.Value.Length]);
+                headers = new Memory<byte>(new byte[headersBuffer.Length]);
+                headersBuffer.CopyTo(headers.Span);
             }
 
             SetException(new NatsSubException($"Message error: {e.Message}", ExceptionDispatchInfo.Capture(e), payload, headers));
@@ -311,9 +312,9 @@ public abstract class NatsSubBase
         }
     }
 
-    internal static bool IsHeader503(ReadOnlySequence<byte>? headersBuffer) =>
+    internal static bool IsHeader503(ReadOnlySequence<byte> headersBuffer) =>
         headersBuffer is { Length: >= 12 }
-        && headersBuffer.Value.Slice(8, 4).ToSpan().SequenceEqual(NoRespondersHeaderSequence);
+        && headersBuffer.Slice(8, 4).ToSpan().SequenceEqual(NoRespondersHeaderSequence);
 
     internal void ClearException() => Interlocked.Exchange(ref _exception, null);
 
@@ -341,7 +342,7 @@ public abstract class NatsSubBase
     /// <param name="headersBuffer">Raw headers bytes. You can use <see cref="NatsConnection"/> <see cref="NatsHeaderParser"/> to decode them.</param>
     /// <param name="payloadBuffer">Raw payload bytes.</param>
     /// <returns></returns>
-    protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);
+    protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte> headersBuffer, ReadOnlySequence<byte> payloadBuffer);
 
     /// <summary>
     /// Sets the exception that caused the subscription to end.

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -248,17 +248,17 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
     protected override async ValueTask ReceiveInternalAsync(
         string subject,
         string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer,
+        ReadOnlySequence<byte> headersBuffer,
         ReadOnlySequence<byte> payloadBuffer)
     {
         ResetHeartbeatTimer();
 
         if (subject == Subject)
         {
-            if (headersBuffer.HasValue)
+            if (headersBuffer.Length > 0)
             {
                 var headers = new NatsHeaders();
-                if (Connection.HeaderParser.ParseHeaders(new SequenceReader<byte>(headersBuffer.Value), headers))
+                if (Connection.HeaderParser.ParseHeaders(new SequenceReader<byte>(headersBuffer), headers))
                 {
                     if (_maxBytes == 0 && headers.TryGetValue("Nats-Pending-Messages", out var natsPendingMsgs))
                     {
@@ -355,7 +355,7 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
                     _logger.LogError(
                         NatsJSLogEvents.Headers,
                         "Can't parse headers: {HeadersBuffer}",
-                        Encoding.ASCII.GetString(headersBuffer.Value.ToArray()));
+                        Encoding.ASCII.GetString(headersBuffer.ToArray()));
                     throw new NatsJSException("Can't parse headers");
                 }
             }

--- a/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
@@ -183,16 +183,16 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
     protected override async ValueTask ReceiveInternalAsync(
         string subject,
         string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer,
+        ReadOnlySequence<byte> headersBuffer,
         ReadOnlySequence<byte> payloadBuffer)
     {
         ResetHeartbeatTimer();
         if (subject == Subject)
         {
-            if (headersBuffer.HasValue)
+            if (headersBuffer.Length > 0)
             {
                 var headers = new NatsHeaders();
-                if (Connection.HeaderParser.ParseHeaders(new SequenceReader<byte>(headersBuffer.Value), headers))
+                if (Connection.HeaderParser.ParseHeaders(new SequenceReader<byte>(headersBuffer), headers))
                 {
                     if (headers is { Code: 404 })
                     {
@@ -225,7 +225,7 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
                     _logger.LogError(
                         NatsJSLogEvents.Headers,
                         "Can't parse headers: {HeadersBuffer}",
-                        Encoding.ASCII.GetString(headersBuffer.Value.ToArray()));
+                        Encoding.ASCII.GetString(headersBuffer.ToArray()));
                     throw new NatsJSException("Can't parse headers");
                 }
             }

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
@@ -155,17 +155,17 @@ internal class NatsJSOrderedConsume<TMsg> : NatsSubBase
     protected override async ValueTask ReceiveInternalAsync(
         string subject,
         string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer,
+        ReadOnlySequence<byte> headersBuffer,
         ReadOnlySequence<byte> payloadBuffer)
     {
         ResetHeartbeatTimer();
 
         if (subject == Subject)
         {
-            if (headersBuffer.HasValue)
+            if (headersBuffer.Length > 0)
             {
                 var headers = new NatsHeaders();
-                if (Connection.HeaderParser.ParseHeaders(new SequenceReader<byte>(headersBuffer.Value), headers))
+                if (Connection.HeaderParser.ParseHeaders(new SequenceReader<byte>(headersBuffer), headers))
                 {
                     if (_maxBytes == 0 && headers.TryGetValue("Nats-Pending-Messages", out var natsPendingMsgs))
                     {
@@ -261,7 +261,7 @@ internal class NatsJSOrderedConsume<TMsg> : NatsSubBase
                     _logger.LogError(
                         NatsJSLogEvents.Headers,
                         "Can't parse headers: {HeadersBuffer}",
-                        Encoding.ASCII.GetString(headersBuffer.Value.ToArray()));
+                        Encoding.ASCII.GetString(headersBuffer.ToArray()));
                     throw new NatsJSException("Can't parse headers");
                 }
             }

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
@@ -461,7 +461,7 @@ internal class NatsJSOrderedPushConsumerSub<T> : NatsSubBase
     protected override async ValueTask ReceiveInternalAsync(
         string subject,
         string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer,
+        ReadOnlySequence<byte> headersBuffer,
         ReadOnlySequence<byte> payloadBuffer)
     {
         var msg = new NatsJSMsg<T>(NatsMsg<T>.Build(subject, replyTo, headersBuffer, payloadBuffer, _nats, _headerParser, _serializer), _context);

--- a/src/NATS.Client.KeyValueStore/Internal/NatsKVWatchSub.cs
+++ b/src/NATS.Client.KeyValueStore/Internal/NatsKVWatchSub.cs
@@ -51,7 +51,7 @@ internal class NatsKVWatchSub<T> : NatsSubBase
     protected override async ValueTask ReceiveInternalAsync(
         string subject,
         string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer,
+        ReadOnlySequence<byte> headersBuffer,
         ReadOnlySequence<byte> payloadBuffer)
     {
         var msg = new NatsJSMsg<T>(NatsMsg<T>.Build(subject, replyTo, headersBuffer, payloadBuffer, _nats, _headerParser, _serializer), _context);

--- a/src/NATS.Client.Services/NatsSvcEndPoint.cs
+++ b/src/NATS.Client.Services/NatsSvcEndPoint.cs
@@ -183,7 +183,7 @@ public class NatsSvcEndpoint<T> : NatsSvcEndpointBase
     protected override ValueTask ReceiveInternalAsync(
         string subject,
         string? replyTo,
-        ReadOnlySequence<byte>? headersBuffer,
+        ReadOnlySequence<byte> headersBuffer,
         ReadOnlySequence<byte> payloadBuffer)
     {
         NatsMsg<T> msg;

--- a/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
+++ b/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
@@ -51,7 +51,7 @@ public class LowLevelApiTest
             _output = output;
         }
 
-        protected override ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+        protected override ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte> headersBuffer, ReadOnlySequence<byte> payloadBuffer)
         {
             if (subject.EndsWith(".sync"))
             {
@@ -63,17 +63,14 @@ public class LowLevelApiTest
             }
             else
             {
-                var headers = headersBuffer?.ToArray();
-                var payload = payloadBuffer.ToArray();
-
                 var sb = new StringBuilder();
                 sb.AppendLine($"Subject: {subject}");
                 sb.AppendLine($"Reply-To: {replyTo}");
-                sb.Append($"Headers: ");
-                if (headers != null)
-                    sb.Append(Encoding.ASCII.GetString(headers).Replace("\r\n", " "));
+                sb.Append("Headers: ");
+                if (headersBuffer.Length > 0)
+                    sb.Append(Encoding.ASCII.GetString(headersBuffer).Replace("\r\n", " "));
                 sb.AppendLine();
-                sb.AppendLine($"Payload: {Encoding.ASCII.GetString(payload)}");
+                sb.AppendLine($"Payload: {Encoding.ASCII.GetString(payloadBuffer)}");
 
                 _output.WriteLine(sb.ToString());
 

--- a/tests/NATS.Client.Core2.Tests/ProtocolTest.cs
+++ b/tests/NATS.Client.Core2.Tests/ProtocolTest.cs
@@ -485,7 +485,7 @@ public class ProtocolTest
             }
         }
 
-        protected override ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+        protected override ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte> headersBuffer, ReadOnlySequence<byte> payloadBuffer)
         {
             _callback(int.Parse(Encoding.UTF8.GetString(payloadBuffer.ToArray())));
             DecrementMaxMsgs();


### PR DESCRIPTION
Small optimization to stop wrapping headers buffer in `Nullable`

I think this may technically be a breaking change in its current state due to changing the signature in `NatsSubBase.ReceiveAsync`.  But that method is not part of `INatsSub`.  @mtmk do you know of any intended uses of `NatsSubBase.ReceiveAsync` outside of other projects in the solution?