### PR TITLE
Stopped testing with net6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ async enumerables and channels, and leverages advanced .NET memory, buffer and I
 **Additionally check out [NATS by example](https://natsbyexample.com) - An evolving collection of runnable, cross-client reference examples for NATS.**
 
 > [!NOTE]
+> **We are not testing with .NET 6.0 target anymore** even though it is still targeted by the library.
+> This is to reduce the number of test runs and speed up the CI process as well as to prepare for
+> the next major version, possibly dropping .NET 6.0 support.
+
+> [!NOTE]
 > **Don't confuse NuGet packages!**
 > NATS .NET package on NuGet is called [NATS.Net](https://www.nuget.org/packages/NATS.Net).
 > There is another package called `NATS.Client` which is the older version of the client library


### PR DESCRIPTION
We've stopped testing with .NET 6.0:
* This is to reduce the burden on CI (both running and maintenance)
* [.NET 6 reached End of Support on November 2024](https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/)
* See also Microsoft's [.NET Support Policy](https://dotnet.microsoft.com/en-us/platform/support/policy))
* It's relatively easy for applications to update to later versions
* We are still targeting .NET 6 not to disturb any applications but thinking about eventually dropping .NET 6 support completely to reduce maintenance cost.


[no ci]