### PR TITLE
Fix subscriptions dispose exception handling

### DIFF
--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -239,6 +239,8 @@ public abstract class NatsSubBase
         _idleTimeoutTimer?.Dispose();
         _startUpTimeoutTimer?.Dispose();
 
+        _tokenRegistration.Dispose();
+
         if (Exception != null)
         {
             if (Exception is NatsSubException { Exception: not null } nse)
@@ -248,8 +250,6 @@ public abstract class NatsSubBase
 
             throw Exception;
         }
-
-        _tokenRegistration.Dispose();
 
         return unsubscribeAsync;
     }

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -190,16 +190,22 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
     public override async ValueTask DisposeAsync()
     {
         Interlocked.Exchange(ref _disposed, 1);
-        await base.DisposeAsync().ConfigureAwait(false);
-        await _pullTask.ConfigureAwait(false);
-#if NETSTANDARD2_0
-        _timer.Dispose();
-#else
-        await _timer.DisposeAsync().ConfigureAwait(false);
-#endif
-        if (_notificationChannel != null)
+        try
         {
-            await _notificationChannel.DisposeAsync();
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await _pullTask.ConfigureAwait(false);
+#if NETSTANDARD2_0
+            _timer.Dispose();
+#else
+            await _timer.DisposeAsync().ConfigureAwait(false);
+#endif
+            if (_notificationChannel != null)
+            {
+                await _notificationChannel.DisposeAsync();
+            }
         }
     }
 

--- a/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
@@ -160,17 +160,23 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
     public override async ValueTask DisposeAsync()
     {
         Interlocked.Exchange(ref _disposed, 1);
-        await base.DisposeAsync().ConfigureAwait(false);
-#if NETSTANDARD2_0
-        _hbTimer.Dispose();
-        _expiresTimer.Dispose();
-#else
-        await _hbTimer.DisposeAsync().ConfigureAwait(false);
-        await _expiresTimer.DisposeAsync().ConfigureAwait(false);
-#endif
-        if (_notificationChannel != null)
+        try
         {
-            await _notificationChannel.DisposeAsync();
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+#if NETSTANDARD2_0
+            _hbTimer.Dispose();
+            _expiresTimer.Dispose();
+#else
+            await _hbTimer.DisposeAsync().ConfigureAwait(false);
+            await _expiresTimer.DisposeAsync().ConfigureAwait(false);
+#endif
+            if (_notificationChannel != null)
+            {
+                await _notificationChannel.DisposeAsync();
+            }
         }
     }
 

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
@@ -136,14 +136,19 @@ internal class NatsJSOrderedConsume<TMsg> : NatsSubBase
         Interlocked.Exchange(ref _disposed, 1);
 
         _context.Connection.ConnectionDisconnected -= ConnectionOnConnectionDisconnected;
-
-        await base.DisposeAsync().ConfigureAwait(false);
-        await _pullTask.ConfigureAwait(false);
+        try
+        {
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            await _pullTask.ConfigureAwait(false);
 #if NETSTANDARD2_0
-        _timer.Dispose();
+            _timer.Dispose();
 #else
-        await _timer.DisposeAsync().ConfigureAwait(false);
+            await _timer.DisposeAsync().ConfigureAwait(false);
 #endif
+        }
     }
 
     internal override ValueTask WriteReconnectCommandsAsync(CommandWriter commandWriter, int sid)


### PR DESCRIPTION
There are cases where exception is thrown when disposing the base subscription which leaves timers undisposed in which case they go on firing even though the subscription object is long gone.