### PR TITLE
Fix `Storage` type in`AccountStats` model.

### DIFF
--- a/src/NATS.Client.JetStream/Models/AccountStats.cs
+++ b/src/NATS.Client.JetStream/Models/AccountStats.cs
@@ -7,16 +7,16 @@ public record AccountStats
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("memory")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Memory { get; set; }
+    [System.ComponentModel.DataAnnotations.Range(0, ulong.MaxValue)]
+    public ulong Memory { get; set; }
 
     /// <summary>
     /// File Storage being used for Stream Message storage
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("storage")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Storage { get; set; }
+    [System.ComponentModel.DataAnnotations.Range(0, ulong.MaxValue)]
+    public ulong Storage { get; set; }
 
     /// <summary>
     /// Number of active Streams

--- a/src/NATS.Client.JetStream/Models/Tier.cs
+++ b/src/NATS.Client.JetStream/Models/Tier.cs
@@ -7,16 +7,16 @@ public record Tier
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("memory")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Memory { get; set; }
+    [System.ComponentModel.DataAnnotations.Range(0, ulong.MaxValue)]
+    public ulong Memory { get; set; }
 
     /// <summary>
     /// File Storage being used for Stream Message storage
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("storage")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
-    [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)]
-    public int Storage { get; set; }
+    [System.ComponentModel.DataAnnotations.Range(0, ulong.MaxValue)]
+    public ulong Storage { get; set; }
 
     /// <summary>
     /// Reserved Memory for Stream Message storage


### PR DESCRIPTION
Needs to be `uint64` (`ulong`): https://github.com/nats-io/nats-server/blob/7e62ecbc85e56ccfd225b933c5f4936a642968ef/server/jetstream.go#L78

fixes #889 