### PR TITLE
Remove warning log on dropped message

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -207,7 +207,6 @@ public partial class NatsConnection : INatsConnection
     public void OnMessageDropped<T>(NatsSubBase natsSub, int pending, NatsMsg<T> msg)
     {
         var subject = msg.Subject;
-        _logger.LogWarning("Dropped message from {Subject} with {Pending} pending messages", subject, pending);
         _eventChannel.Writer.TryWrite((NatsEvent.MessageDropped, new NatsMessageDroppedEventArgs(natsSub, pending, subject, msg.ReplyTo, msg.Headers, msg.Data)));
     }
 


### PR DESCRIPTION
Dropped messages can occur regularly. Depending on configuration / use case, this is even expected behavior. Logging a warning in the core NatsConnection potentially floods the logs with warnings and makes it difficult for clients to override. Logging on or otherwise handling dropped messages is better left for the user (i.e. by adding a custom MessageDropped event handler).