### PR TITLE
fix: `NatsInstrumentationOptions.Default` gets reset each time

### DIFF
--- a/src/NATS.Client.Core/Internal/SubscriptionManager.cs
+++ b/src/NATS.Client.Core/Internal/SubscriptionManager.cs
@@ -53,7 +53,7 @@ internal sealed class SubscriptionManager : INatsSubscriptionManager, IAsyncDisp
     {
         if (Telemetry.HasListeners())
         {
-            using var activity = Telemetry.StartSendActivity($"{_connection.SpanDestinationName(sub.Subject)} {Telemetry.Constants.SubscribeActivityName}", _connection, sub.Subject, null, null);
+            using var activity = Telemetry.StartSendActivity($"{_connection.SpanDestinationName(sub.Subject)} {Telemetry.Constants.SubscribeActivityName}", _connection, sub.Subject, null);
             try
             {
                 if (IsInboxSubject(sub.Subject))

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -17,7 +17,7 @@ internal static class Telemetry
         INatsConnection? connection,
         string subject,
         string? replyTo,
-        ActivityContext? parentContext = null)
+        ActivityContext parentContext = default)
     {
         if (!NatsActivities.HasListeners())
             return null;
@@ -78,7 +78,7 @@ internal static class Telemetry
         var activity = NatsActivities.StartActivity(
             name,
             kind: ActivityKind.Producer,
-            parentContext: parentContext ?? default,
+            parentContext: parentContext,
             tags: tags);
 
         if (activity is not null)

--- a/src/NATS.Client.Core/NatsInstrumentationContext.cs
+++ b/src/NATS.Client.Core/NatsInstrumentationContext.cs
@@ -10,4 +10,4 @@ public readonly record struct NatsInstrumentationContext(
     long? BodySize,
     long? Size,
     INatsConnection? Connection,
-    ActivityContext? ParentContext);
+    ActivityContext ParentContext);

--- a/src/NATS.Client.Core/NatsInstrumentationOptions.cs
+++ b/src/NATS.Client.Core/NatsInstrumentationOptions.cs
@@ -7,7 +7,7 @@ namespace NATS.Client.Core;
 /// </summary>
 public sealed class NatsInstrumentationOptions
 {
-    public static NatsInstrumentationOptions Default => new();
+    public static NatsInstrumentationOptions Default { get; } = new();
 
     /// <summary>
     /// Gets or sets a filter function that determines whether or not to collect telemetry on a per request basis.

--- a/src/NATS.Client.Core/NatsMsgTelemetryExtensions.cs
+++ b/src/NATS.Client.Core/NatsMsgTelemetryExtensions.cs
@@ -22,11 +22,11 @@ public static class NatsMsgTelemetryExtensions
         return Telemetry.NatsActivities.StartActivity(
             name,
             kind: ActivityKind.Internal,
-            parentContext: GetActivityContext(in msg),
+            parentContext: msg.Headers.GetActivityContext(),
             tags: tags);
     }
 
-    /// <summary>Gets the activity context associated with the NatsMsg.</summary>
-    public static ActivityContext GetActivityContext<T>(this in NatsMsg<T> msg) =>
-        msg.Headers?.Activity?.Context ?? default;
+    /// <summary>Gets the activity context carried by the NatsHeaders.</summary>
+    public static ActivityContext GetActivityContext(this NatsHeaders? headers) =>
+        headers?.Activity?.Context ?? default;
 }

--- a/src/NATS.Client.JetStream/NatsJSTelemetryExtensions.cs
+++ b/src/NATS.Client.JetStream/NatsJSTelemetryExtensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using NATS.Client.Core;
 using NATS.Client.Core.Internal;
 
 namespace NATS.Client.JetStream;
@@ -22,9 +23,7 @@ public static class NatsJSTelemetryExtensions
         return Telemetry.NatsActivities.StartActivity(
             name,
             kind: ActivityKind.Internal,
-            parentContext: GetActivityContext(in msg),
+            parentContext: msg.Headers.GetActivityContext(),
             tags: tags);
     }
-
-    internal static ActivityContext GetActivityContext<T>(this in NatsJSMsg<T> msg) => msg.Headers?.Activity?.Context ?? default;
 }


### PR DESCRIPTION
`public static NatsInstrumentationOptions Default => new();` meant that any time `NatsInstrumentationOptions.Default` was accessed it would return a new instance and essentially all settings would get reset, defeating the whole purpose. It's weird this wasn't caught in #859! 😅

Also, made `GetActivityContext` an extension on `NatsHeaders` so that it can also be used in the context of `NatsJSMsg`s and even when you only have a `NatsHeaders` instance in scope.

Found out also that `NatsInstrumentationContext.ActivityContext` didn't need to be made nullabe; in fact, that would've been things confusing.