### PR TITLE
Add RequestTimeout option to NatsJSOpts for request operations

### DIFF
--- a/.github/workflows/signoffs.yml
+++ b/.github/workflows/signoffs.yml
@@ -16,7 +16,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           for commit in $(git rev-list "origin/${{ github.base_ref }}".."${{ github.event.pull_request.head.sha }}"); do
-            if ! git verify-commit --raw $commit 2>&1 | grep -q SIG; then
+            if ! git verify-commit --raw $commit 2>&1 | grep -iq SIG; then
               echo "--------------------------------------------------------------"
               echo "Error: Commit $commit is not signed using GPG, SSH, or S/MIME"
               echo "https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -181,7 +181,7 @@ public partial class NatsJSContext
                         requestSerializer: serializer,
                         replySerializer: NatsJSJsonSerializer<PubAckResponse>.Default,
                         requestOpts: opts,
-                        replyOpts: new NatsSubOpts { Timeout = Connection.Opts.RequestTimeout },
+                        replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout },
                         cancellationToken).ConfigureAwait(false);
                 }
                 catch (NatsNoReplyException)
@@ -223,7 +223,7 @@ public partial class NatsJSContext
                         // is a reconnect to the cluster between the request and waiting for a response,
                         // without the timeout the publish call will hang forever since the server
                         // which received the request won't be there to respond anymore.
-                        Timeout = Connection.Opts.RequestTimeout,
+                        Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout,
                     },
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -314,7 +314,7 @@ public partial class NatsJSContext
                         // is a reconnect to the cluster between the request and waiting for a response,
                         // without the timeout the publish call will hang forever since the server
                         // which received the request won't be there to respond anymore.
-                        Timeout = Connection.Opts.RequestTimeout,
+                        Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout,
 
                         // If JetStream is disabled, a no responders error will be returned
                         // No responders error might also happen when reconnecting to cluster
@@ -403,7 +403,7 @@ public partial class NatsJSContext
                     subject: subject,
                     data: request,
                     headers: null,
-                    replyOpts: new NatsSubOpts { Timeout = Connection.Opts.RequestTimeout },
+                    replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout },
                     requestSerializer: NatsJSJsonSerializer<TRequest>.Default,
                     replySerializer: NatsJSJsonDocumentSerializer<TResponse>.Default,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -444,7 +444,7 @@ public partial class NatsJSContext
                 subject: subject,
                 data: request,
                 headers: default,
-                replyOpts: new NatsSubOpts { Timeout = Connection.Opts.RequestTimeout },
+                replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout },
                 requestSerializer: NatsJSJsonSerializer<TRequest>.Default,
                 replySerializer: NatsJSJsonDocumentSerializer<TResponse>.Default,
                 cancellationToken: cancellationToken)

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -181,7 +181,7 @@ public partial class NatsJSContext
                         requestSerializer: serializer,
                         replySerializer: NatsJSJsonSerializer<PubAckResponse>.Default,
                         requestOpts: opts,
-                        replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout },
+                        replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout },
                         cancellationToken).ConfigureAwait(false);
                 }
                 catch (NatsNoReplyException)
@@ -223,7 +223,7 @@ public partial class NatsJSContext
                         // is a reconnect to the cluster between the request and waiting for a response,
                         // without the timeout the publish call will hang forever since the server
                         // which received the request won't be there to respond anymore.
-                        Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout,
+                        Timeout = Opts.RequestTimeout,
                     },
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -314,7 +314,7 @@ public partial class NatsJSContext
                         // is a reconnect to the cluster between the request and waiting for a response,
                         // without the timeout the publish call will hang forever since the server
                         // which received the request won't be there to respond anymore.
-                        Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout,
+                        Timeout = Opts.RequestTimeout,
 
                         // If JetStream is disabled, a no responders error will be returned
                         // No responders error might also happen when reconnecting to cluster
@@ -403,7 +403,7 @@ public partial class NatsJSContext
                     subject: subject,
                     data: request,
                     headers: null,
-                    replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout },
+                    replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout },
                     requestSerializer: NatsJSJsonSerializer<TRequest>.Default,
                     replySerializer: NatsJSJsonDocumentSerializer<TResponse>.Default,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
@@ -444,7 +444,7 @@ public partial class NatsJSContext
                 subject: subject,
                 data: request,
                 headers: default,
-                replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout ?? Connection.Opts.RequestTimeout },
+                replyOpts: new NatsSubOpts { Timeout = Opts.RequestTimeout },
                 requestSerializer: NatsJSJsonSerializer<TRequest>.Default,
                 replySerializer: NatsJSJsonDocumentSerializer<TResponse>.Default,
                 cancellationToken: cancellationToken)

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -38,7 +38,7 @@ public record NatsJSOpts
     /// <summary>
     /// Timeout for JetStream API calls.
     /// </summary>
-    public TimeSpan? RequestTimeout { get; init; }
+    public TimeSpan RequestTimeout { get; }
 
     /// <summary>
     /// Ask server for an acknowledgment.

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -8,7 +8,7 @@ namespace NATS.Client.JetStream;
 /// </summary>
 public record NatsJSOpts
 {
-    public NatsJSOpts(NatsOpts opts, string? apiPrefix = default, string? domain = default, AckOpts? ackOpts = default)
+    public NatsJSOpts(NatsOpts opts, string? apiPrefix = default, string? domain = default, AckOpts? ackOpts = default, TimeSpan? requestTimeout = default)
     {
         if (apiPrefix != null && domain != null)
         {
@@ -17,6 +17,7 @@ public record NatsJSOpts
 
         ApiPrefix = apiPrefix ?? "$JS.API";
         Domain = domain;
+        RequestTimeout = requestTimeout ?? opts.RequestTimeout;
     }
 
     /// <summary>
@@ -33,6 +34,11 @@ public record NatsJSOpts
     /// JetStream domain to use in JetStream API subjects. (default: null)
     /// </summary>
     public string? Domain { get; }
+
+    /// <summary>
+    /// Timeout for JetStream API calls.
+    /// </summary>
+    public TimeSpan? RequestTimeout { get; init; }
 
     /// <summary>
     /// Ask server for an acknowledgment.


### PR DESCRIPTION
The previous implementation used the defaults from the connections NatsOpts RequestTimeout for JetStream specific request/reply operations.

This change allows setting a separate default value for JetStream operations from the core NatsOpts default.