### PR TITLE
Fix CommandWriter.cs dispose

### DIFF
--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -158,8 +158,13 @@ internal sealed class CommandWriter : IAsyncDisposable
 
 #if NET8_0_OR_GREATER
         await _cts.CancelAsync().ConfigureAwait(false);
+        if (_ctsReader != null)
+        {
+            await _ctsReader.CancelAsync().ConfigureAwait(false);
+        }
 #else
         _cts.Cancel();
+        _ctsReader?.Cancel();
 #endif
 
         _channelLock.Writer.TryComplete();


### PR DESCRIPTION
This pull request updates the `DisposeAsync` method in `CommandWriter.cs` to ensure that both `_cts` and `_ctsReader` cancellation tokens are properly canceled during disposal, improving resource cleanup and preventing potential hangs.