### PR TITLE
Add support for initial connection retry

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -37,6 +37,7 @@ public partial class NatsConnection : INatsConnection
     private readonly ILogger<NatsConnection> _logger;
     private readonly ObjectPool _pool;
     private readonly CancellationTokenSource _disposedCts;
+    private readonly CancellationTokenSource _initialConnectCts;
     private readonly string _name;
     private readonly TimeSpan _socketComponentDisposeTimeout = TimeSpan.FromSeconds(5);
     private readonly BoundedChannelOptions _defaultSubscriptionChannelOpts;
@@ -78,6 +79,7 @@ public partial class NatsConnection : INatsConnection
         ConnectionState = NatsConnectionState.Closed;
         _waitForOpenConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _disposedCts = new CancellationTokenSource();
+        _initialConnectCts = new CancellationTokenSource();
         _pool = new ObjectPool(opts.ObjectPoolSize);
         _name = opts.Name;
         Counter = new ConnectionStatsCounter();
@@ -170,36 +172,57 @@ public partial class NatsConnection : INatsConnection
     /// </summary>
     public async ValueTask ConnectAsync()
     {
-        if (ConnectionState == NatsConnectionState.Open)
-            return;
-
-        TaskCompletionSource? waiter = null;
-        lock (_gate)
+        while (true)
         {
-            ThrowIfDisposed();
-            if (ConnectionState != NatsConnectionState.Closed)
+            try
             {
-                waiter = _waitForOpenConnection;
+                if (ConnectionState == NatsConnectionState.Open)
+                    return;
+
+                TaskCompletionSource? waiter = null;
+                lock (_gate)
+                {
+                    ThrowIfDisposed();
+                    if (ConnectionState != NatsConnectionState.Closed)
+                    {
+                        waiter = _waitForOpenConnection;
+                    }
+                    else
+                    {
+                        // when closed, change state to connecting and only first connection try-to-connect.
+                        ConnectionState = NatsConnectionState.Connecting;
+                    }
+                }
+
+                if (waiter != null)
+                {
+                    await waiter.Task.ConfigureAwait(false);
+                    return;
+                }
+
+                // Only Closed(initial) state, can run initial connect.
+                await InitialConnectAsync().ConfigureAwait(false);
+
+                if (Opts.RequestReplyMode == NatsRequestReplyMode.Direct)
+                {
+                    await _subscriptionManager.InitializeInboxSubscriptionAsync(_disposedCts.Token).ConfigureAwait(false);
+                }
             }
-            else
+            catch (NatsException)
             {
-                // when closed, change state to connecting and only first connection try-to-connect.
-                ConnectionState = NatsConnectionState.Connecting;
+                if (!Opts.RetryOnInitialConnect)
+                {
+                    throw;
+                }
+
+                try
+                {
+                    await WaitWithJitterAsync(_initialConnectCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                }
             }
-        }
-
-        if (waiter != null)
-        {
-            await waiter.Task.ConfigureAwait(false);
-            return;
-        }
-
-        // Only Closed(initial) state, can run initial connect.
-        await InitialConnectAsync().ConfigureAwait(false);
-
-        if (Opts.RequestReplyMode == NatsRequestReplyMode.Direct)
-        {
-            await _subscriptionManager.InitializeInboxSubscriptionAsync(_disposedCts.Token).ConfigureAwait(false);
         }
     }
 
@@ -254,8 +277,10 @@ public partial class NatsConnection : INatsConnection
             _waitForOpenConnection.TrySetCanceled();
 #if NET8_0_OR_GREATER
             await _disposedCts.CancelAsync().ConfigureAwait(false);
+            await _initialConnectCts.CancelAsync().ConfigureAwait(false);
 #else
             _disposedCts.Cancel();
+            _initialConnectCts.Cancel();
 #endif
         }
     }
@@ -410,6 +435,9 @@ public partial class NatsConnection : INatsConnection
             _pingTimerCancellationTokenSource = new CancellationTokenSource();
             StartPingTimer(_pingTimerCancellationTokenSource.Token);
             _waitForOpenConnection.TrySetResult();
+#pragma warning disable VSTHRD103
+            _initialConnectCts.Cancel();
+#pragma warning restore VSTHRD103
             _reconnectLoopTask = Task.Run(ReconnectLoop);
             _eventChannel.Writer.TryWrite((NatsEvent.ConnectionOpened, new NatsEventArgs(url?.ToString() ?? string.Empty)));
         }
@@ -713,7 +741,7 @@ public partial class NatsConnection : INatsConnection
                     _logger.LogDebug(NatsLogEvents.Connection, "Reconnect wait with jitter [{ReconnectCount}]", reconnectCount);
                 }
 
-                await WaitWithJitterAsync().ConfigureAwait(false);
+                await WaitWithJitterAsync(_disposedCts.Token).ConfigureAwait(false);
 
                 if (debug)
                 {
@@ -861,7 +889,7 @@ public partial class NatsConnection : INatsConnection
         return uri;
     }
 
-    private async Task WaitWithJitterAsync()
+    private async Task WaitWithJitterAsync(CancellationToken cancellationToken)
     {
         bool stop;
         int retry;
@@ -910,7 +938,7 @@ public partial class NatsConnection : INatsConnection
         if (waitTime != TimeSpan.Zero)
         {
             _logger.LogTrace(NatsLogEvents.Connection, "Waiting {WaitMs}ms to reconnect", waitTime.TotalMilliseconds);
-            await Task.Delay(waitTime).ConfigureAwait(false);
+            await Task.Delay(waitTime, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -183,6 +183,29 @@ public sealed record NatsOpts
     /// <seealso cref="INatsTlsUpgradeableSocketConnection"/>
     public INatsSocketConnectionFactory? SocketConnectionFactory { get; init; }
 
+    /// <summary>
+    /// Determines whether the client should retry connecting to the server during the initial connection
+    /// attempt if the connection fails. (default: <c>false</c>)
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property controls the behavior of the initial connection process.
+    /// </para>
+    /// <para>
+    /// When set to <c>true</c>, the client will periodically retry connecting to the server based on the
+    /// configured retry intervals until a successful connection is established or the operation is explicitly canceled.
+    /// </para>
+    /// <para>
+    /// When set to <c>false</c> (default behavior), the client will not retry and will throw an exception
+    /// if the connection cannot be established initially.
+    /// </para>
+    /// <para>
+    /// The retry intervals are influenced by options such as <see cref="ReconnectWaitMin"/> and <see cref="ReconnectWaitMax"/>, with the potential addition of <see cref="ReconnectJitter"/> for randomized delays between retries.
+    /// This property is particularly useful in scenarios where transient network failures or server unavailability are expected during the first connection attempt.
+    /// </para>
+    /// </remarks>
+    public bool RetryOnInitialConnect { get; init; }
+
     internal NatsUri[] GetSeedUris(bool suppressRandomization = false)
     {
         var urls = Url.Split(',');


### PR DESCRIPTION
Introduced `RetryOnInitialConnect` option in `NatsOpts` for retrying on failed initial connection attempts.