### PR TITLE
Fix pending message reset logic in NatsJSConsume

### DIFF
--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -352,21 +352,13 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
                     {
                         _logger.LogDebug(NatsJSLogEvents.LeadershipChange, "Leadership Change");
                         _notificationChannel?.Notify(NatsJSLeadershipChangeNotification.Default);
-                        lock (_pendingGate)
-                        {
-                            _pendingBytes = 0;
-                            _pendingMsgs = 0;
-                        }
+                        ResetPending();
                     }
                     else if (headers.Code == 503)
                     {
                         _logger.LogDebug(NatsJSLogEvents.NoResponders, "503 no responders");
                         _notificationChannel?.Notify(NatsJSNoRespondersNotification.Default);
-                        lock (_pendingGate)
-                        {
-                            _pendingBytes = 0;
-                            _pendingMsgs = 0;
-                        }
+                        ResetPending();
                     }
                     else if (headers.HasTerminalJSError())
                     {


### PR DESCRIPTION
This pull request refactors how pending message and byte counters are reset in the `ReceiveInternalAsync` method of `NatsJSConsume`. Instead of manually resetting these counters within a lock block, the code now calls a dedicated method, `ResetPending`, which improves code readability and maintainability and does the right thing instead of setting them to zero.

* Fixes #927 