### PR TITLE
Remove v2.9 testing from GitHub workflows

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.9'
           - branch: 'v2.10'
           - branch: 'latest'
           - branch: 'main'

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.9'
           - branch: 'v2.10'
           - branch: 'latest'
           - branch: 'main'

--- a/.github/workflows/test_linux_core.yml
+++ b/.github/workflows/test_linux_core.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.9'
           - branch: 'v2.10'
           - branch: 'latest'
           - branch: 'main'

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.9'
           - branch: 'v2.10'
           - branch: 'latest'
           - branch: 'main'


### PR DESCRIPTION
This pull request updates the CI workflow configuration by removing the NATS Server v2.9.x from the test and performance job matrices. This streamlines the workflows to only run against supported or current server versions.