### PR TITLE
Don't suppress SystemExceptions in NatsSubBase.ReceiveAsync

### DIFF
--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -301,7 +301,7 @@ public abstract class NatsSubBase
             // interested in the messages anymore. Hence we ignore any messages being
             // fed into the channel and rejected.
         }
-        catch (Exception e)
+        catch (Exception e) when (!(e is SystemException))
         {
             _logger.LogError(NatsLogEvents.Subscription, e, "Error while processing message");
 


### PR DESCRIPTION
We just experienced an issue where our application stopped processing messages because an OutOfMemoryException was thrown and swallowed in ReceiveAsync. Framework docs explicitly state:

> Because [SystemException](https://learn.microsoft.com/en-us/dotnet/api/system.systemexception?view=net-9.0) serves as the base class of a variety of exception types, your code should not throw a [SystemException](https://learn.microsoft.com/en-us/dotnet/api/system.systemexception?view=net-9.0) exception, nor should it attempt to handle a [SystemException](https://learn.microsoft.com/en-us/dotnet/api/system.systemexception?view=net-9.0) exception unless you intend to re-throw the original exception.