### PR TITLE
Fix JetStream publish retry defaults

### DIFF
--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -238,12 +238,25 @@ public record NatsJSPubOpts : NatsPubOpts
     // lss *uint64 // Expected last sequence per subject
     public ulong? ExpectedLastSubjectSequence { get; init; }
 
-    // Publish retries for NoResponders err.
-    // rwait time.Duration // Retry wait between attempts
+    /// <summary>
+    /// Specifies the duration to wait between retry attempts for a failed publish operation.
+    /// See <see cref="RetryAttempts"/> for the number of retry attempts.
+    /// </summary>
     public TimeSpan RetryWaitBetweenAttempts { get; init; } = TimeSpan.FromMilliseconds(250);
 
-    // rnum  int           // Retry attempts
-    public int RetryAttempts { get; init; } = 2;
+    /// <summary>
+    /// Specifies the number of retry attempts to publish a message when a "NoResponders" error occurs.
+    /// The value defines how many additional attempts will be made after the initial publish attempt.
+    /// Default is not to retry (one attempt total).
+    /// </summary>
+    /// <remarks>
+    /// By default, this is set to 1, meaning that if the first publish attempt fails with a "NoResponders" error,
+    /// no more attempts will be made. Setting this to a higher value allows for more retries in case of transient issues.
+    /// Coupled with <see cref="RetryWaitBetweenAttempts"/>, this provides a mechanism to handle temporary unavailability of responders,
+    /// however, for more robust handling of such scenarios, consider implementing an exponential backoff strategy in your application logic,
+    /// or use an extension that supports it.
+    /// </remarks>
+    public int RetryAttempts { get; init; } = 1;
 }
 
 /// <summary>


### PR DESCRIPTION
Decision to retry JetStream publish requests should be left to the application since it depends on the delivery and durability requirements of their solution.

PS This will go into next minor release 2.7.x with other minor braking changes