### PR TITLE
(preview) Update ClusterInfo with new 2.12-preview Fields

### DIFF
--- a/src/NATS.Client.JetStream/Models/ClusterInfo.cs
+++ b/src/NATS.Client.JetStream/Models/ClusterInfo.cs
@@ -30,8 +30,39 @@ public record ClusterInfo
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public ICollection<PeerInfo>? Replicas { get; set; }
 
-    // TODO: These are 2.12 specific
-    // LeaderSince *time.Time  `json:"leader_since,omitempty"`
-    // SystemAcc   bool        `json:"system_account,omitempty"`
-    // TrafficAcc  string      `json:"traffic_account,omitempty"`
+    /// <summary>
+    /// Represents the duration of time since the cluster leader was elected.
+    /// </summary>
+    /// <remarks>Supported by server v2.12</remarks>
+    [System.Text.Json.Serialization.JsonPropertyName("leader_since")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+#if NET6_0
+    public DateTimeOffset LeaderSince { get; set; }
+#else
+    public DateTimeOffset LeaderSince { get; init; }
+#endif
+
+    /// <summary>
+    /// Indicates whether the account is a system account.
+    /// </summary>
+    /// <remarks>Supported by server v2.12</remarks>
+    [System.Text.Json.Serialization.JsonPropertyName("system_account")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+#if NET6_0
+    public bool SystemAccount { get; set; }
+#else
+    public bool SystemAccount { get; init; }
+#endif
+
+    /// <summary>
+    /// The traffic account associated with the cluster.
+    /// </summary>
+    /// <remarks>Supported by server v2.12</remarks>
+    [System.Text.Json.Serialization.JsonPropertyName("traffic_account")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+#if NET6_0
+    public string? TrafficAccount { get; set; }
+#else
+    public string? TrafficAccount { get; init; }
+#endif
 }

--- a/src/NATS.Client.JetStream/Models/ClusterInfo.cs
+++ b/src/NATS.Client.JetStream/Models/ClusterInfo.cs
@@ -10,6 +10,13 @@ public record ClusterInfo
     public string? Name { get; set; }
 
     /// <summary>
+    /// RAFT group name
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("raft_group")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public string? RaftGroup { get; set; }
+
+    /// <summary>
     /// The server name of the RAFT leader
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("leader")]
@@ -22,4 +29,9 @@ public record ClusterInfo
     [System.Text.Json.Serialization.JsonPropertyName("replicas")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public ICollection<PeerInfo>? Replicas { get; set; }
+
+    // TODO: These are 2.12 specific
+    // LeaderSince *time.Time  `json:"leader_since,omitempty"`
+    // SystemAcc   bool        `json:"system_account,omitempty"`
+    // TrafficAcc  string      `json:"traffic_account,omitempty"`
 }

--- a/src/NATS.Client.JetStream/Models/ClusterInfo.cs
+++ b/src/NATS.Client.JetStream/Models/ClusterInfo.cs
@@ -3,35 +3,35 @@ namespace NATS.Client.JetStream.Models;
 public record ClusterInfo
 {
     /// <summary>
-    /// The cluster name
+    /// The cluster name.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("name")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public string? Name { get; set; }
 
     /// <summary>
-    /// RAFT group name
+    /// In clustered environments the name of the Raft group managing the asset.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("raft_group")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public string? RaftGroup { get; set; }
 
     /// <summary>
-    /// The server name of the RAFT leader
+    /// The server name of the RAFT leader.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("leader")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public string? Leader { get; set; }
 
     /// <summary>
-    /// The members of the RAFT cluster
+    /// The members of the RAFT cluster.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("replicas")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public ICollection<PeerInfo>? Replicas { get; set; }
 
     /// <summary>
-    /// Represents the duration of time since the cluster leader was elected.
+    /// The time that it was elected as leader (in RFC3339 format in JSON), absent when not the leader.
     /// </summary>
     /// <remarks>Supported by server v2.12</remarks>
     [System.Text.Json.Serialization.JsonPropertyName("leader_since")]
@@ -43,7 +43,8 @@ public record ClusterInfo
 #endif
 
     /// <summary>
-    /// Indicates whether the account is a system account.
+    /// Indicates if the TrafficAccount is the system account.
+    /// When true, replication traffic goes over the system account.
     /// </summary>
     /// <remarks>Supported by server v2.12</remarks>
     [System.Text.Json.Serialization.JsonPropertyName("system_account")]
@@ -55,7 +56,7 @@ public record ClusterInfo
 #endif
 
     /// <summary>
-    /// The traffic account associated with the cluster.
+    /// The account where the replication traffic goes over.
     /// </summary>
     /// <remarks>Supported by server v2.12</remarks>
     [System.Text.Json.Serialization.JsonPropertyName("traffic_account")]

--- a/tests/NATS.Client.TestUtilities/Utils.cs
+++ b/tests/NATS.Client.TestUtilities/Utils.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Text.RegularExpressions;
 
 #if NATS_CORE2_TEST
 using NATS.Client.Core2.Tests.ExtraUtils.FrameworkPolyfillExtensions;
@@ -166,5 +167,25 @@ public static class ServiceUtils
         }
 
         return responses;
+    }
+}
+
+public static class ServerVersionUtils
+{
+    public static bool ServerVersionIsGreaterThenOrEqualTo(this NatsConnection nats, int major, int minor)
+    {
+        var m = Regex.Match(nats.ServerInfo!.Version, @"^(\d+)\.(\d+)");
+        if (m.Success && m.Groups.Count == 3)
+        {
+            if (int.TryParse(m.Groups[1].Value, out var serverMajor) && int.TryParse(m.Groups[2].Value, out var serverMinor))
+            {
+                if (serverMajor > major)
+                    return true;
+                if (serverMajor == major && serverMinor >= minor)
+                    return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/NATS.Slow.Tests/ClusterTests2.cs
+++ b/tests/NATS.Slow.Tests/ClusterTests2.cs
@@ -37,39 +37,25 @@ public class ClusterTests2
     public async Task Check_JetStream_cluster_related_fields()
     {
         var started = DateTimeOffset.Now;
-        var stopwatch = Stopwatch.StartNew();
         await using var cluster = new NatsCluster(
             new NullOutputHelper(),
             TransportType.Tcp,
             (i, b) =>
             {
-                _output.WriteLine($"{stopwatch.Elapsed} Configuring node {i}");
                 b.WithServerName($"n{i}");
                 b.WithClusterName("C1");
                 b.UseJetStream();
             });
         await cluster.StartAsync();
-        // await using var nats = await cluster.Server1.CreateClientConnectionAsync();
-        await using var nats = new NatsConnection(new NatsOpts
-        {
-            Url = cluster.Server1.ClientUrl,
-            // Url = "127.0.0.1",
-            // Url = "127.0.0.1:4229",
-            // AuthOpts = new NatsAuthOpts { Username = "sys", Password = "sys" }
-        });
-
+        await using var nats = await cluster.Server1.CreateClientConnectionAsync();
         await nats.ConnectRetryAsync();
-        _output.WriteLine($"{stopwatch.Elapsed} url: {cluster.Server1.ClientUrl}");
-        _output.WriteLine($"{stopwatch.Elapsed} server version: {nats.ServerInfo!.Version}");
 
         // Wait for the cluster to form
         for (var i = 0; i < 10; i++)
         {
             try
             {
-                var info = await nats.RequestAsync<string>("$JS.API.INFO");
-                _output.WriteLine($"{stopwatch.Elapsed} ({i + 1}) js cluster formed");
-                _output.WriteLine($"{stopwatch.Elapsed} js api info: {info.Data}");
+                await nats.RequestAsync<string>("$JS.API.INFO");
                 break;
             }
             catch (NatsException)
@@ -78,9 +64,26 @@ public class ClusterTests2
         }
 
         var js = nats.CreateJetStreamContext();
-        var s1 = await js.CreateStreamAsync(new StreamConfig { Name = "s1", Subjects = ["s1"], NumReplicas = 3, });
-        // _output.WriteLine($"{stopwatch.Elapsed} cluster name: {s1.Info.Cluster.Name}");
-        // _output.WriteLine($"{stopwatch.Elapsed} cluster info: {s1.Info.Cluster}");
+        INatsJSStream s1 = null!;
+
+        // Wait until stream can be created
+        for (var i = 0; i < 10; i++)
+        {
+            try
+            {
+                s1 = await js.CreateStreamAsync(new StreamConfig
+                {
+                    Name = "s1",
+                    Subjects = ["s1"],
+                    NumReplicas = 3,
+                });
+                break;
+            }
+            catch (NatsException)
+            {
+            }
+        }
+
         Assert.Equal("C1", s1.Info.Cluster!.Name);
         Assert.True(s1.Info.Cluster.Replicas!.Count > 0);
         Assert.NotNull(s1.Info.Cluster.Leader);
@@ -88,21 +91,13 @@ public class ClusterTests2
         Assert.NotNull(s1.Info.Cluster.RaftGroup);
         Assert.True(s1.Info.Cluster.RaftGroup.Length > 0);
 
-        // 2.12
         if (nats.ServerVersionIsGreaterThenOrEqualTo(2, 12))
         {
-            _output.WriteLine($"{stopwatch.Elapsed} 2.12+");
-            _output.WriteLine($"{stopwatch.Elapsed} LeaderSince: {s1.Info.Cluster.LeaderSince}");
-            _output.WriteLine($"{stopwatch.Elapsed} TrafficAccount: {s1.Info.Cluster.TrafficAccount}");
-            _output.WriteLine($"{stopwatch.Elapsed} SystemAccount: {s1.Info.Cluster.SystemAccount}");
-
             var tolerance = TimeSpan.FromSeconds(10);
             Assert.True(s1.Info.Cluster.LeaderSince > started - tolerance);
             Assert.True(s1.Info.Cluster.LeaderSince < DateTimeOffset.Now + tolerance);
             Assert.Equal("$SYS", s1.Info.Cluster.TrafficAccount);
             Assert.True(s1.Info.Cluster.SystemAccount);
         }
-
-        _output.WriteLine($"{stopwatch.Elapsed} Done");
     }
 }

--- a/tests/NATS.Slow.Tests/ClusterTests2.cs
+++ b/tests/NATS.Slow.Tests/ClusterTests2.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics;
 using NATS.Client.Core.Tests;
+using NATS.Client.JetStream.Models;
 using NATS.Client.TestUtilities;
 using NATS.Client.TestUtilities2;
+using NATS.Net;
 
 namespace NATS.Client.JetStream.Tests;
 
@@ -28,5 +31,78 @@ public class ClusterTests2
             _output.WriteLine(url);
             Assert.Matches(@"127\.0\.0\.1", url);
         }
+    }
+
+    [Fact]
+    public async Task Check_JetStream_cluster_related_fields()
+    {
+        var started = DateTimeOffset.Now;
+        var stopwatch = Stopwatch.StartNew();
+        await using var cluster = new NatsCluster(
+            new NullOutputHelper(),
+            TransportType.Tcp,
+            (i, b) =>
+            {
+                _output.WriteLine($"{stopwatch.Elapsed} Configuring node {i}");
+                b.WithServerName($"n{i}");
+                b.WithClusterName("C1");
+                b.UseJetStream();
+            });
+        await cluster.StartAsync();
+        // await using var nats = await cluster.Server1.CreateClientConnectionAsync();
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = cluster.Server1.ClientUrl,
+            // Url = "127.0.0.1",
+            // Url = "127.0.0.1:4229",
+            // AuthOpts = new NatsAuthOpts { Username = "sys", Password = "sys" }
+        });
+
+        await nats.ConnectRetryAsync();
+        _output.WriteLine($"{stopwatch.Elapsed} url: {cluster.Server1.ClientUrl}");
+        _output.WriteLine($"{stopwatch.Elapsed} server version: {nats.ServerInfo!.Version}");
+
+        // Wait for the cluster to form
+        for (var i = 0; i < 10; i++)
+        {
+            try
+            {
+                var info = await nats.RequestAsync<string>("$JS.API.INFO");
+                _output.WriteLine($"{stopwatch.Elapsed} ({i + 1}) js cluster formed");
+                _output.WriteLine($"{stopwatch.Elapsed} js api info: {info.Data}");
+                break;
+            }
+            catch (NatsException)
+            {
+            }
+        }
+
+        var js = nats.CreateJetStreamContext();
+        var s1 = await js.CreateStreamAsync(new StreamConfig { Name = "s1", Subjects = ["s1"], NumReplicas = 3, });
+        // _output.WriteLine($"{stopwatch.Elapsed} cluster name: {s1.Info.Cluster.Name}");
+        // _output.WriteLine($"{stopwatch.Elapsed} cluster info: {s1.Info.Cluster}");
+        Assert.Equal("C1", s1.Info.Cluster!.Name);
+        Assert.True(s1.Info.Cluster.Replicas!.Count > 0);
+        Assert.NotNull(s1.Info.Cluster.Leader);
+        Assert.Matches("n[123]", s1.Info.Cluster.Leader);
+        Assert.NotNull(s1.Info.Cluster.RaftGroup);
+        Assert.True(s1.Info.Cluster.RaftGroup.Length > 0);
+
+        // 2.12
+        if (nats.ServerVersionIsGreaterThenOrEqualTo(2, 12))
+        {
+            _output.WriteLine($"{stopwatch.Elapsed} 2.12+");
+            _output.WriteLine($"{stopwatch.Elapsed} LeaderSince: {s1.Info.Cluster.LeaderSince}");
+            _output.WriteLine($"{stopwatch.Elapsed} TrafficAccount: {s1.Info.Cluster.TrafficAccount}");
+            _output.WriteLine($"{stopwatch.Elapsed} SystemAccount: {s1.Info.Cluster.SystemAccount}");
+
+            var tolerance = TimeSpan.FromSeconds(10);
+            Assert.True(s1.Info.Cluster.LeaderSince > started - tolerance);
+            Assert.True(s1.Info.Cluster.LeaderSince < DateTimeOffset.Now + tolerance);
+            Assert.Equal("$SYS", s1.Info.Cluster.TrafficAccount);
+            Assert.True(s1.Info.Cluster.SystemAccount);
+        }
+
+        _output.WriteLine($"{stopwatch.Elapsed} Done");
     }
 }

--- a/tests/NATS.Slow.Tests/NatsServerOpts.cs
+++ b/tests/NATS.Slow.Tests/NatsServerOpts.cs
@@ -22,6 +22,7 @@ public sealed class NatsServerOptsBuilder
     private bool _tlsVerify;
     private bool _enableJetStream;
     private string? _serverName;
+    private string? _clusterName;
     private string? _tlsServerCertFile;
     private string? _tlsServerKeyFile;
     private string? _tlsClientCertFile;
@@ -42,6 +43,7 @@ public sealed class NatsServerOptsBuilder
         TlsVerify = _tlsVerify,
         EnableJetStream = _enableJetStream,
         ServerName = _serverName,
+        ClusterName = _clusterName ?? "nats",
         ClientUrlUserName = _clientUrlUserName,
         ClientUrlPassword = _clientUrlPassword,
         TlsServerCertFile = _tlsServerCertFile,
@@ -111,6 +113,12 @@ public sealed class NatsServerOptsBuilder
     public NatsServerOptsBuilder WithServerName(string serverName)
     {
         _serverName = serverName;
+        return this;
+    }
+
+    public NatsServerOptsBuilder WithClusterName(string clusterName)
+    {
+        _clusterName = clusterName;
         return this;
     }
 
@@ -188,6 +196,8 @@ public sealed class NatsServerOpts : IDisposable
     public bool EnableJetStream { get; init; }
 
     public string? ServerName { get; init; }
+
+    public string ClusterName { get; init; } = "nats";
 
     public string? ServerHost { get; init; } = "127.0.0.1";
 
@@ -287,7 +297,7 @@ public sealed class NatsServerOpts : IDisposable
             if (EnableClustering)
             {
                 sb.AppendLine("cluster {");
-                sb.AppendLine("  name: nats");
+                sb.AppendLine($"  name: {ClusterName}");
                 sb.AppendLine($"  listen: {ServerHost}:{ClusteringPort}");
                 sb.AppendLine($"  routes: [{_routes}]");
                 sb.AppendLine("}");


### PR DESCRIPTION
**Note: This is a prerelease update. It might change in future releases.**

This pull request adds support for new JetStream cluster-related fields and improves cluster configuration and testing. The main changes include extending the `ClusterInfo` model with additional properties, updating server configuration options to allow custom cluster names, and adding a comprehensive test to verify the new fields. Additionally, a utility for comparing server versions was introduced to facilitate conditional testing logic.

### JetStream Cluster Model Enhancements
* Added new properties to `ClusterInfo`: `RaftGroup`, `LeaderSince`, `SystemAccount`, and `TrafficAccount`, with appropriate serialization attributes and conditional logic for .NET versions. These properties allow for richer cluster metadata and are supported in server v2.12 and above. [[1]](diffhunk://#diff-1d07a986007b2cdcaf8090fb82622b77dbc6d1c005980a19ea557a8ecf570f2eR12-R18) [[2]](diffhunk://#diff-1d07a986007b2cdcaf8090fb82622b77dbc6d1c005980a19ea557a8ecf570f2eR32-R67)

### Server Configuration Improvements
* Updated `NatsServerOptsBuilder` and `NatsServerOpts` to support specifying a custom cluster name via the new `WithClusterName` method and related property changes, ensuring cluster configuration can be customized in tests. [[1]](diffhunk://#diff-90b920cffccb0db4f3d66cc3421107df68464dfa1a85173cabbcbf0fdfd0703fR25) [[2]](diffhunk://#diff-90b920cffccb0db4f3d66cc3421107df68464dfa1a85173cabbcbf0fdfd0703fR46) [[3]](diffhunk://#diff-90b920cffccb0db4f3d66cc3421107df68464dfa1a85173cabbcbf0fdfd0703fR119-R124) [[4]](diffhunk://#diff-90b920cffccb0db4f3d66cc3421107df68464dfa1a85173cabbcbf0fdfd0703fR200-R201) [[5]](diffhunk://#diff-90b920cffccb0db4f3d66cc3421107df68464dfa1a85173cabbcbf0fdfd0703fL290-R300)

### Testing Enhancements
* Added a new test `Check_JetStream_cluster_related_fields` to `ClusterTests2.cs` that verifies the presence and correctness of the new cluster fields, including conditional checks for server v2.12+ features.
* Introduced a utility extension method `ServerVersionIsGreaterThenOrEqualTo` to facilitate version-dependent test logic.
* Minor import addition for `Regex` to support version parsing.