### PR TITLE
Add JetStream calls API Level support

### DIFF
--- a/src/NATS.Client.JetStream/INatsJSContext.cs
+++ b/src/NATS.Client.JetStream/INatsJSContext.cs
@@ -362,6 +362,7 @@ public interface INatsJSContext
     /// </summary>
     /// <param name="subject">The JetStream API subject to send the request to.</param>
     /// <param name="request">The request message object.</param>
+    /// <param name="apiLevel">Asserts whether the JetStream server that's responding supports this API level.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     /// <typeparam name="TRequest">The type of the request message.</typeparam>
     /// <typeparam name="TResponse">The type of the response message.</typeparam>
@@ -369,6 +370,7 @@ public interface INatsJSContext
     ValueTask<TResponse> JSRequestResponseAsync<TRequest, TResponse>(
         string subject,
         TRequest? request,
+        NatsJSApiLevel apiLevel = default,
         CancellationToken cancellationToken = default)
         where TRequest : class
         where TResponse : class;

--- a/src/NATS.Client.JetStream/NatsJSApiLevel.cs
+++ b/src/NATS.Client.JetStream/NatsJSApiLevel.cs
@@ -1,0 +1,17 @@
+﻿namespace NATS.Client.JetStream;
+
+public readonly struct NatsJSApiLevel
+{
+    public const string Header = "Nats-Required-Api-Level";
+    public static readonly NatsJSApiLevel None = default;
+    public static readonly NatsJSApiLevel V1 = new(1);
+    public static readonly NatsJSApiLevel V2 = new(2);
+
+    private readonly int _level = 0;
+
+    private NatsJSApiLevel(int level) => _level = level;
+
+    public bool IsSet() => _level > 0;
+
+    public string GetHeaderValue() => _level.ToString();
+}

--- a/src/NATS.Client.JetStream/NatsJSApiLevel.cs
+++ b/src/NATS.Client.JetStream/NatsJSApiLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace NATS.Client.JetStream;
+namespace NATS.Client.JetStream;
 
 public readonly struct NatsJSApiLevel
 {

--- a/src/NATS.Client.JetStream/NatsJSApiLevel.cs
+++ b/src/NATS.Client.JetStream/NatsJSApiLevel.cs
@@ -9,7 +9,7 @@ public readonly struct NatsJSApiLevel
 
     private readonly int _level = 0;
 
-    private NatsJSApiLevel(int level) => _level = level;
+    internal NatsJSApiLevel(int level) => _level = level;
 
     public bool IsSet() => _level > 0;
 

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -289,6 +289,7 @@ public class NatsJSConsumer : INatsJSConsumer
         Info = await _context.JSRequestResponseAsync<object, ConsumerInfo>(
             subject: $"{_context.Opts.Prefix}.CONSUMER.INFO.{_stream}.{_consumer}",
             request: null,
+            apiLevel: default,
             cancellationToken).ConfigureAwait(false);
 
     internal async ValueTask<NatsJSConsume<T>> ConsumeInternalAsync<T>(INatsDeserialize<T>? serializer = default, NatsJSConsumeOpts? opts = default, CancellationToken cancellationToken = default)

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -70,6 +70,7 @@ public partial class NatsJSContext : INatsJSContext
         var response = await JSRequestResponseAsync<object, ConsumerInfo>(
             subject: $"{Opts.Prefix}.CONSUMER.INFO.{stream}.{consumer}",
             request: null,
+            apiLevel: default,
             cancellationToken);
         return new NatsJSConsumer(this, response);
     }
@@ -86,6 +87,7 @@ public partial class NatsJSContext : INatsJSContext
             var response = await JSRequestResponseAsync<ConsumerListRequest, ConsumerListResponse>(
                 subject: $"{Opts.Prefix}.CONSUMER.LIST.{stream}",
                 new ConsumerListRequest { Offset = offset },
+                apiLevel: default,
                 cancellationToken);
 
             if (response.Consumers.Count == 0)
@@ -112,6 +114,7 @@ public partial class NatsJSContext : INatsJSContext
             var response = await JSRequestResponseAsync<ConsumerNamesRequest, ConsumerNamesResponse>(
                 subject: $"{Opts.Prefix}.CONSUMER.NAMES.{stream}",
                 new ConsumerNamesRequest { Offset = offset },
+                apiLevel: default,
                 cancellationToken);
 
             if (response.Consumers.Count == 0)
@@ -141,6 +144,7 @@ public partial class NatsJSContext : INatsJSContext
         var response = await JSRequestResponseAsync<object, ConsumerDeleteResponse>(
             subject: $"{Opts.Prefix}.CONSUMER.DELETE.{stream}.{consumer}",
             request: null,
+            apiLevel: default,
             cancellationToken);
         return response.Success;
     }
@@ -163,6 +167,7 @@ public partial class NatsJSContext : INatsJSContext
         var response = await JSRequestResponseAsync<ConsumerPauseRequest, ConsumerPauseResponse>(
             subject: $"{Opts.Prefix}.CONSUMER.PAUSE.{stream}.{consumer}",
             request: new ConsumerPauseRequest { PauseUntil = pauseUntil },
+            apiLevel: default,
             cancellationToken);
         return response;
     }
@@ -184,6 +189,7 @@ public partial class NatsJSContext : INatsJSContext
         var response = await JSRequestResponseAsync<object, ConsumerPauseResponse>(
             subject: $"{Opts.Prefix}.CONSUMER.PAUSE.{stream}.{consumer}",
             request: null,
+            apiLevel: default,
             cancellationToken);
         return !response.IsPaused;
     }
@@ -234,6 +240,7 @@ public partial class NatsJSContext : INatsJSContext
         return JSRequestResponseAsync<ConsumerCreateRequest, ConsumerInfo>(
             subject: subject,
             request,
+            apiLevel: default,
             cancellationToken);
     }
 
@@ -282,6 +289,7 @@ public partial class NatsJSContext : INatsJSContext
                 Config = config,
                 Action = action,
             },
+            apiLevel: default,
             cancellationToken);
 
         return new NatsJSConsumer(this, response);

--- a/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
@@ -55,6 +55,7 @@ public partial class NatsJSContext
         var response = await JSRequestResponseAsync<StreamConfig, StreamInfo>(
             subject: $"{Opts.Prefix}.STREAM.CREATE.{config.Name}",
             config,
+            apiLevel: default,
             cancellationToken);
         return new NatsJSStream(this, response);
     }
@@ -75,6 +76,7 @@ public partial class NatsJSContext
         var response = await JSRequestAsync<StreamConfig, StreamUpdateResponse>(
             subject: $"{Opts.Prefix}.STREAM.UPDATE.{config.Name}",
             request: config,
+            apiLevel: default,
             cancellationToken);
 
         if (response.Error is { Code: 404 })
@@ -104,6 +106,7 @@ public partial class NatsJSContext
         var response = await JSRequestResponseAsync<object, StreamMsgDeleteResponse>(
             subject: $"{Opts.Prefix}.STREAM.DELETE.{stream}",
             request: null,
+            apiLevel: default,
             cancellationToken);
         return response.Success;
     }
@@ -128,6 +131,7 @@ public partial class NatsJSContext
         var response = await JSRequestResponseAsync<StreamPurgeRequest, StreamPurgeResponse>(
             subject: $"{Opts.Prefix}.STREAM.PURGE.{stream}",
             request: request,
+            apiLevel: default,
             cancellationToken);
         return response;
     }
@@ -152,6 +156,7 @@ public partial class NatsJSContext
         var response = await JSRequestResponseAsync<StreamMsgDeleteRequest, StreamMsgDeleteResponse>(
             subject: $"{Opts.Prefix}.STREAM.MSG.DELETE.{stream}",
             request: request,
+            apiLevel: default,
             cancellationToken);
         return response;
     }
@@ -176,6 +181,7 @@ public partial class NatsJSContext
         var response = await JSRequestResponseAsync<StreamInfoRequest, StreamInfoResponse>(
             subject: $"{Opts.Prefix}.STREAM.INFO.{stream}",
             request: request,
+            apiLevel: default,
             cancellationToken);
         return new NatsJSStream(this, response);
     }
@@ -198,6 +204,7 @@ public partial class NatsJSContext
         var response = await JSRequestResponseAsync<StreamConfig, StreamUpdateResponse>(
             subject: $"{Opts.Prefix}.STREAM.UPDATE.{request.Name}",
             request: request,
+            apiLevel: default,
             cancellationToken);
         return new NatsJSStream(this, response);
     }
@@ -224,6 +231,7 @@ public partial class NatsJSContext
                     Offset = offset,
                     Subject = subject,
                 },
+                apiLevel: default,
                 cancellationToken);
 
             if (response.Streams.Count == 0)
@@ -254,6 +262,7 @@ public partial class NatsJSContext
                     Subject = subject,
                     Offset = offset,
                 },
+                apiLevel: default,
                 cancellationToken);
 
             if (response.Streams == null || response.Streams.Count == 0)

--- a/src/NATS.Client.JetStream/NatsJSStream.cs
+++ b/src/NATS.Client.JetStream/NatsJSStream.cs
@@ -169,6 +169,7 @@ public class NatsJSStream : INatsJSStream
         Info = await _context.JSRequestResponseAsync<object, StreamInfoResponse>(
             subject: $"{_context.Opts.Prefix}.STREAM.INFO.{_name}",
             request: null,
+            apiLevel: default,
             cancellationToken).ConfigureAwait(false);
 
     public ValueTask<NatsMsg<T>> GetDirectAsync<T>(StreamMsgGetRequest request, INatsDeserialize<T>? serializer = default, CancellationToken cancellationToken = default)
@@ -185,6 +186,7 @@ public class NatsJSStream : INatsJSStream
         _context.JSRequestResponseAsync<StreamMsgGetRequest, StreamMsgGetResponse>(
             subject: $"{_context.Opts.Prefix}.STREAM.MSG.GET.{_name}",
             request: request,
+            apiLevel: default,
             cancellationToken);
 
     private void ThrowIfDeleted()

--- a/src/NATS.Client.KeyValueStore/NatsKVContext.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVContext.cs
@@ -65,7 +65,7 @@ public class NatsKVContext : INatsKVContext
 
         if (config.LimitMarkerTTL > TimeSpan.Zero)
         {
-            var info = await JetStreamContext.JSRequestResponseAsync<object, AccountInfoResponse>("$JS.API.INFO", null, cancellationToken);
+            var info = await JetStreamContext.JSRequestResponseAsync<object, AccountInfoResponse>("$JS.API.INFO", null, apiLevel: default, cancellationToken);
             if (info.Api.Level < 1)
             {
                 throw new NatsKVException("API doesn't support LimitMarkerTTL");

--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text.Json;
 using NATS.Client.Core;
-using NATS.Client.Core.Internal;
 using NATS.Client.JetStream;
 using NATS.Client.JetStream.Internal;
 using NATS.Client.JetStream.Models;
@@ -289,6 +288,7 @@ public class NatsObjStore : INatsObjStore
                     {
                         Filter = GetChunkSubject(info.Nuid),
                     },
+                    apiLevel: default,
                     cancellationToken);
             }
             catch (NatsJSApiException e)
@@ -431,6 +431,7 @@ public class NatsObjStore : INatsObjStore
         var info = await JetStreamContext.JSRequestResponseAsync<object, StreamInfoResponse>(
             subject: $"{JetStreamContext.Opts.Prefix}.STREAM.INFO.{_stream.Info.Config.Name}",
             request: null,
+            apiLevel: default,
             cancellationToken).ConfigureAwait(false);
 
         var config = info.Config;
@@ -439,6 +440,7 @@ public class NatsObjStore : INatsObjStore
         var response = await JetStreamContext.JSRequestResponseAsync<StreamConfig, StreamUpdateResponse>(
             subject: $"{JetStreamContext.Opts.Prefix}.STREAM.UPDATE.{_stream.Info.Config.Name}",
             request: config,
+            apiLevel: default,
             cancellationToken);
 
         if (!response.Config.Sealed)

--- a/tests/NATS.Client.JetStream.Tests/JetStreamApiSerializerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/JetStreamApiSerializerTest.cs
@@ -89,7 +89,7 @@ public class JetStreamApiSerializerTest
         // Fake JS API requester
         for (var i = 0; i < 100; i++)
         {
-            await js.TryJSRequestAsync<object, AccountInfoResponse>(apiSubject, null, cts.Token);
+            await js.TryJSRequestAsync<object, AccountInfoResponse>(apiSubject, null, apiLevel: default, cts.Token);
         }
 
         ctsDone.Cancel();

--- a/tests/NATS.Client.JetStream.Tests/JetStreamTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/JetStreamTest.cs
@@ -228,6 +228,7 @@ public class JetStreamTest
         }
 
         // Server would error if API level is not supported
+        if (nats.ServerInfo.VersionMajorMinorIsGreaterThenOrEqualTo(2, 12))
         {
             await proxy.FlushFramesAsync(nats, clear: true, CancellationToken.None);
             var exception = await Assert.ThrowsAsync<NatsJSApiException>(async () => await js.JSRequestResponseAsync<StreamNamesRequest, StreamNamesResponse>(

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
@@ -518,7 +518,7 @@ public class KeyValueStoreTest
         Assert.Equal("This store does not support TTL", exception.Message);
 
         // Check API version
-        var info = await js.JSRequestResponseAsync<object, AccountInfoResponse>("$JS.API.INFO", null, cancellationToken);
+        var info = await js.JSRequestResponseAsync<object, AccountInfoResponse>("$JS.API.INFO", null, apiLevel: default, cancellationToken);
         Assert.True(info.Api.Level >= 1);
 
         // Config validation

--- a/tests/NATS.Client.KeyValueStore.Tests/NatsKVContextFactoryTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/NatsKVContextFactoryTest.cs
@@ -95,7 +95,7 @@ public class NatsKVContextFactoryTest
 
         public string NewBaseInbox() => throw new NotImplementedException();
 
-        public ValueTask<TResponse> JSRequestResponseAsync<TRequest, TResponse>(string subject, TRequest? request, CancellationToken cancellationToken = default)
+        public ValueTask<TResponse> JSRequestResponseAsync<TRequest, TResponse>(string subject, TRequest? request, NatsJSApiLevel apiLevel = default, CancellationToken cancellationToken = default)
             where TRequest : class
             where TResponse : class
             => throw new NotImplementedException();

--- a/tests/NATS.Client.ObjectStore.Tests/NatsObjContextFactoryTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/NatsObjContextFactoryTest.cs
@@ -95,7 +95,7 @@ public class NatsObjContextFactoryTest
 
         public string NewBaseInbox() => throw new NotImplementedException();
 
-        public ValueTask<TResponse> JSRequestResponseAsync<TRequest, TResponse>(string subject, TRequest? request, CancellationToken cancellationToken = default)
+        public ValueTask<TResponse> JSRequestResponseAsync<TRequest, TResponse>(string subject, TRequest? request, NatsJSApiLevel apiLevel = default, CancellationToken cancellationToken = default)
             where TRequest : class
             where TResponse : class
             => throw new NotImplementedException();

--- a/tests/NATS.Client.TestUtilities/Utils.cs
+++ b/tests/NATS.Client.TestUtilities/Utils.cs
@@ -174,18 +174,49 @@ public static class ServerVersionUtils
 {
     public static bool ServerVersionIsGreaterThenOrEqualTo(this NatsConnection nats, int major, int minor)
     {
+        var serverVersion = nats.GetServerVersion();
+
+        if (serverVersion.Major > major)
+            return true;
+
+        if (serverVersion.Major == major && serverVersion.Minor >= minor)
+            return true;
+
+        return false;
+    }
+
+    public static bool ServerVersionIsLessThen(this NatsConnection nats, int major, int minor)
+    {
+        var serverVersion = nats.GetServerVersion();
+
+        if (serverVersion.Major < major)
+            return true;
+
+        if (serverVersion.Major == major && serverVersion.Minor < minor)
+            return true;
+
+        return false;
+    }
+
+    public static bool ServerVersionIs(this NatsConnection nats, int major, int minor)
+    {
+        var serverVersion = nats.GetServerVersion();
+        return serverVersion.Major == major && serverVersion.Minor == minor;
+    }
+
+    public static (int Major, int Minor) GetServerVersion(this NatsConnection nats)
+    {
         var m = Regex.Match(nats.ServerInfo!.Version, @"^(\d+)\.(\d+)");
+
         if (m.Success && m.Groups.Count == 3)
         {
             if (int.TryParse(m.Groups[1].Value, out var serverMajor) && int.TryParse(m.Groups[2].Value, out var serverMinor))
             {
-                if (serverMajor > major)
-                    return true;
-                if (serverMajor == major && serverMinor >= minor)
-                    return true;
+                return (serverMajor, serverMinor);
             }
         }
 
-        return false;
+        throw new Exception("Failed to parse server version");
     }
+
 }

--- a/tests/NATS.Client.TestUtilities/Utils.cs
+++ b/tests/NATS.Client.TestUtilities/Utils.cs
@@ -218,5 +218,4 @@ public static class ServerVersionUtils
 
         throw new Exception("Failed to parse server version");
     }
-
 }


### PR DESCRIPTION
Prepare for jetstream batch update and related functions.

This pull request introduces support for specifying a required JetStream API level in request methods, allowing clients to assert that the server supports a minimum API version for certain operations. The main changes involve adding an `apiLevel` parameter to relevant methods, implementing the `NatsJSApiLevel` struct, and ensuring the appropriate request headers are set. Most usages default to no required API level for backward compatibility.

### JetStream API Level Support

* Added a new `NatsJSApiLevel` struct in `NatsJSApiLevel.cs` to represent JetStream API levels and provide header value generation.
* Updated all JetStream request methods (e.g., `JSRequestResponseAsync`, `JSRequestAsync`, and related consumer/stream methods) to accept an optional `apiLevel` parameter, defaulting to no required level. [[1]](diffhunk://#diff-1bfc88b919e6aaa762a149e259f49e7e228506f4585b2dacb871dea9ca2baa87R365-R373) [[2]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86R341-R346) [[3]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86R378-R383) [[4]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86R395) [[5]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86R406-R415) [[6]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86L410-R424) [[7]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86L451-R465) [[8]](diffhunk://#diff-c13f88be37e7f154bab245a644075c446bc5f4f56d3f9a982d7531c06e421d90R292) [[9]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5R73) [[10]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5R90) [[11]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5R117) [[12]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5R147) [[13]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5R170) [[14]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5R192) [[15]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5R243) [[16]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5R292) [[17]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R58) [[18]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R79) [[19]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R109) [[20]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R134) [[21]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R159) [[22]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R184) [[23]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R207) [[24]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R234) [[25]](diffhunk://#diff-0ad6d8479defb75e034d860f997edc726b09c301762afdaf1e28cfeee404cab0R265) [[26]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86R48) [[27]](diffhunk://#diff-5d6800eedb4b1c584bd67f27d3ba3eae4dd03dd894277e429baa3aa2afb608ceR172) [[28]](diffhunk://#diff-5d6800eedb4b1c584bd67f27d3ba3eae4dd03dd894277e429baa3aa2afb608ceR189) [[29]](diffhunk://#diff-2b0acf8528acd7ec687094c79aad03fb9208f823550f7debb31b95bdd2275d24L68-R68)
* Modified request logic to include the `Nats-Required-Api-Level` header when an API level is set, ensuring the server is aware of the client's requirements. [[1]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86R406-R415) [[2]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86L410-R424) [[3]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86L451-R465)

### Codebase Maintenance

* Removed an unused internal import in `NatsObjStore.cs` for code cleanliness.

These changes collectively improve the library's ability to interact safely with JetStream servers of varying API levels and help future-proof client-server communication.