### PR TITLE
Fix publish 503 test

### DIFF
--- a/tests/NATS.Client.JetStream.Tests/PublishTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PublishTest.cs
@@ -291,7 +291,7 @@ public class PublishTest
 
         // Default is two attempts
         await Assert.ThrowsAnyAsync<NatsJSPublishNoResponseException>(async () => await js.PublishAsync($"foo", 1, cancellationToken: cts.Token));
-        Assert.Equal(2, Volatile.Read(ref retryCount));
+        Assert.Equal(1, Volatile.Read(ref retryCount));
 
         // Set to multiple attempts
         var attempts = 5;


### PR DESCRIPTION
With 2.7.x we have made the default to not re-publish on failure.