### PR TITLE
Counter support for server v2.12

### DIFF
--- a/src/NATS.Client.JetStream/Models/PubAckResponse.cs
+++ b/src/NATS.Client.JetStream/Models/PubAckResponse.cs
@@ -39,4 +39,12 @@ public record PubAckResponse
     [System.Text.Json.Serialization.JsonPropertyName("domain")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public string? Domain { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value.
+    /// </summary>
+    /// <remarks>Supported by server v2.12</remarks>
+    [System.Text.Json.Serialization.JsonPropertyName("val")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public string? Value { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/PubAckResponse.cs
+++ b/src/NATS.Client.JetStream/Models/PubAckResponse.cs
@@ -41,7 +41,8 @@ public record PubAckResponse
     public string? Domain { get; set; }
 
     /// <summary>
-    /// Gets or sets the value.
+    /// Contains the current counter value when publishing messages with counter headers.
+    /// This property is used in the context of the message counter feature.
     /// </summary>
     /// <remarks>Supported by server v2.12</remarks>
     [System.Text.Json.Serialization.JsonPropertyName("val")]

--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -268,6 +268,6 @@ public record StreamConfig
     /// </summary>
     /// <remarks>Supported by server v2.12</remarks>
     [System.Text.Json.Serialization.JsonPropertyName("allow_msg_counter")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public bool AllowMsgCounter { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -262,4 +262,12 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("metadata")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public IDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// Allow message counter.
+    /// </summary>
+    /// <remarks>Supported by server v2.12</remarks>
+    [System.Text.Json.Serialization.JsonPropertyName("allow_msg_counter")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
+    public bool AllowMsgCounter { get; set; }
 }

--- a/tests/NATS.Client.JetStream.Tests/CounterTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/CounterTest.cs
@@ -118,7 +118,7 @@ public class CounterTest
         // When counter is disabled, the server returns an error
         Assert.NotNull(ack.Error);
         Assert.Equal(10168, ack.Error.ErrCode); // Error code for "message counters is disabled"
-        Assert.Contains("message counters is disabled", ack.Error.Description);
+        Assert.Contains("message counters are disabled", ack.Error.Description);
         Assert.Null(ack.Value); // Value should be null when counter is not enabled
         _output.WriteLine($"Error as expected: {ack.Error.Description}");
     }

--- a/tests/NATS.Client.JetStream.Tests/CounterTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/CounterTest.cs
@@ -1,0 +1,125 @@
+using NATS.Client.Core2.Tests;
+using NATS.Client.JetStream.Models;
+using NATS.Client.TestUtilities;
+
+namespace NATS.Client.JetStream.Tests;
+
+[Collection("nats-server")]
+public class CounterTest
+{
+    private readonly ITestOutputHelper _output;
+    private readonly NatsServerFixture _server;
+
+    public CounterTest(ITestOutputHelper output, NatsServerFixture server)
+    {
+        _output = output;
+        _server = server;
+    }
+
+    [SkipIfNatsServer(versionEarlierThan: "2.12")]
+    public async Task Counter_functionality_test()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var prefix = _server.GetNextId();
+        var js = new NatsJSContext(nats);
+
+        // Create a stream with counter support enabled
+        var streamConfig = new StreamConfig
+        {
+            Name = $"{prefix}counter-stream",
+            Subjects = new[] { $"{prefix}counter.>" },
+            AllowMsgCounter = true,
+        };
+
+        await js.CreateStreamAsync(streamConfig);
+
+        // Publish a message with the counter header
+        var headers = new NatsHeaders
+        {
+            { "Nats-Incr", "+5" },
+        };
+
+        var ack = await js.PublishAsync($"{prefix}counter.test", data: Array.Empty<byte>(), headers: headers);
+
+        Assert.Null(ack.Error);
+        Assert.NotNull(ack.Value);
+        Assert.Equal("5", ack.Value);
+        _output.WriteLine($"First publish - Value: {ack.Value}");
+
+        // Publish another message to increment the counter
+        headers = new NatsHeaders
+        {
+            { "Nats-Incr", "+3" },
+        };
+
+        ack = await js.PublishAsync($"{prefix}counter.test", data: Array.Empty<byte>(), headers: headers);
+
+        Assert.Null(ack.Error);
+        Assert.NotNull(ack.Value);
+        Assert.Equal("8", ack.Value);
+        _output.WriteLine($"Second publish - Value: {ack.Value}");
+
+        // Test subtract operation
+        headers = new NatsHeaders
+        {
+            { "Nats-Incr", "-2" },
+        };
+
+        ack = await js.PublishAsync($"{prefix}counter.test", data: Array.Empty<byte>(), headers: headers);
+
+        Assert.Null(ack.Error);
+        Assert.NotNull(ack.Value);
+        Assert.Equal("6", ack.Value);
+        _output.WriteLine($"Third publish (subtract) - Value: {ack.Value}");
+
+        // Test a different counter (different subject)
+        headers = new NatsHeaders
+        {
+            { "Nats-Incr", "+10" },
+        };
+
+        ack = await js.PublishAsync($"{prefix}counter.test2", data: Array.Empty<byte>(), headers: headers);
+
+        Assert.Null(ack.Error);
+        Assert.NotNull(ack.Value);
+        Assert.Equal("10", ack.Value);
+        _output.WriteLine($"Different counter - Value: {ack.Value}");
+
+        // Verify the stream message count
+        var stream = await js.GetStreamAsync($"{prefix}counter-stream");
+        Assert.Equal(4u, stream.Info.State.Messages);
+    }
+
+    [SkipIfNatsServer(versionEarlierThan: "2.12")]
+    public async Task Counter_without_AllowMsgCounter_should_return_error()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var prefix = _server.GetNextId();
+        var js = new NatsJSContext(nats);
+
+        // Create a stream without counter support
+        var streamConfig = new StreamConfig
+        {
+            Name = $"{prefix}no-counter-stream",
+            Subjects = new[] { $"{prefix}nocounter.>" },
+            AllowMsgCounter = false, // Explicitly disable counter
+        };
+
+        await js.CreateStreamAsync(streamConfig);
+
+        // Publish a message with counter headers (should return an error)
+        var headers = new NatsHeaders
+        {
+            { "Nats-Incr", "+5" },
+        };
+
+        var ack = await js.PublishAsync($"{prefix}nocounter.test", data: Array.Empty<byte>(), headers: headers);
+
+        // When counter is disabled, the server returns an error
+        Assert.NotNull(ack.Error);
+        Assert.Equal(10168, ack.Error.ErrCode); // Error code for "message counters is disabled"
+        Assert.Contains("message counters is disabled", ack.Error.Description);
+        Assert.Null(ack.Value); // Value should be null when counter is not enabled
+        _output.WriteLine($"Error as expected: {ack.Error.Description}");
+    }
+}

--- a/tests/NATS.Client.JetStream.Tests/CounterTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/CounterTest.cs
@@ -118,7 +118,7 @@ public class CounterTest
         // When counter is disabled, the server returns an error
         Assert.NotNull(ack.Error);
         Assert.Equal(10168, ack.Error.ErrCode); // Error code for "message counters is disabled"
-        Assert.Contains("message counters are disabled", ack.Error.Description);
+        Assert.Contains("message counters is disabled", ack.Error.Description);
         Assert.Null(ack.Value); // Value should be null when counter is not enabled
         _output.WriteLine($"Error as expected: {ack.Error.Description}");
     }


### PR DESCRIPTION
Support implementation of [ADR-49](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-49.md)

This pull request adds support for the JetStream message counter feature introduced in NATS server v2.12. It introduces a new property to enable message counters in stream configurations, updates the publish acknowledgment response to include the counter value, and adds comprehensive tests to verify the new functionality and error handling.

**JetStream message counter support:**

* Added the `AllowMsgCounter` property to the `StreamConfig` model, allowing streams to enable or disable message counters. This property is serialized as `allow_msg_counter` and is supported from server v2.12.
* Updated the `PubAckResponse` model to include an optional `Value` property (serialized as `val`), which returns the current counter value when publishing messages with counter headers.

**Testing:**

* Added a new `CounterTest` class to verify message counter functionality, including incrementing, decrementing, using multiple counters, and ensuring proper error handling when the feature is disabled.