### PR TITLE
Add 2.11 to test matrix

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         config:
           - branch: 'v2.10'
+          - branch: 'v2.11'
           - branch: 'latest'
           - branch: 'main'
     runs-on: ubuntu-latest

--- a/.github/workflows/test_linux_core.yml
+++ b/.github/workflows/test_linux_core.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         config:
           - branch: 'v2.10'
+          - branch: 'v2.11'
           - branch: 'latest'
           - branch: 'main'
     runs-on: ubuntu-latest

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         config:
           - branch: 'v2.10'
+          - branch: 'v2.11'
           - branch: 'latest'
           - branch: 'main'
     runs-on: windows-latest


### PR DESCRIPTION
This pull request updates the CI workflow configurations to include testing against now older 2.11 server since latest is 2.12.