### PR TITLE
Add Atomic Publish Support

### DIFF
--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -262,4 +262,11 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("metadata")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public IDictionary<string, string>? Metadata { get; set; }
+
+    /// <summary>
+    /// AllowAtomicPublish allows atomic batch publishing into the stream.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("allow_atomic")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public bool AllowAtomicPublish { get; set; }
 }

--- a/tests/NATS.Client.JetStream.Tests/ManageStreamTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageStreamTest.cs
@@ -2,6 +2,7 @@ using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
 using NATS.Client.Platform.Windows.Tests;
+using NATS.Client.TestUtilities;
 using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
@@ -218,5 +219,43 @@ public class ManageStreamTest
 
         await js.CreateOrUpdateStreamAsync(streamConfig, cts.Token);
         await Assert.ThrowsAsync<NatsJSApiException>(async () => await js.CreateOrUpdateStreamAsync(streamConfigForUpdated, cts.Token));
+    }
+
+    [SkipIfNatsServer(versionEarlierThan: "2.12")]
+    public async Task AllowAtomicPublish_property_should_be_set_on_stream()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var prefix = _server.GetNextId();
+        await nats.ConnectRetryAsync();
+
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // Create a stream with AllowAtomicPublish enabled
+        var streamConfig = new StreamConfig($"{prefix}atomic", [$"{prefix}atomic.*"])
+        {
+            AllowAtomicPublish = true,
+        };
+
+        var stream = await js.CreateStreamAsync(streamConfig, cts.Token);
+
+        // Verify the property is set on the created stream
+        Assert.True(stream.Info.Config.AllowAtomicPublish);
+
+        // Get the stream and verify the property is persisted
+        var retrievedStream = await js.GetStreamAsync($"{prefix}atomic", cancellationToken: cts.Token);
+        Assert.True(retrievedStream.Info.Config.AllowAtomicPublish);
+
+        // Update stream with AllowAtomicPublish disabled
+        var updatedConfig = streamConfig with { AllowAtomicPublish = false };
+        var updatedStream = await js.UpdateStreamAsync(updatedConfig, cts.Token);
+
+        // Verify the property is updated
+        Assert.False(updatedStream.Info.Config.AllowAtomicPublish);
+
+        // Get the stream and verify the update is persisted
+        var reRetrievedStream = await js.GetStreamAsync($"{prefix}atomic", cancellationToken: cts.Token);
+        Assert.False(reRetrievedStream.Info.Config.AllowAtomicPublish);
     }
 }


### PR DESCRIPTION
This pull request adds support for the new AllowAtomicPublish property in the JetStream stream configuration as described in [ADR-50](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-50.md), allowing atomic batch publishing into streams. It also includes comprehensive tests to verify the correct behavior of this property when creating, updating, and retrieving streams.

JetStream Stream Configuration Enhancements:

* Added the `AllowAtomicPublish` property to the `StreamConfig` class, enabling atomic batch publishing for streams. This property is serialized to JSON as `allow_atomic` and is ignored when set to its default value.

Testing Improvements:

* Introduced a new test, `AllowAtomicPublish_property_should_be_set_on_stream`, in `ManageStreamTest.cs` to verify that the `AllowAtomicPublish` property is correctly set, updated, and persisted on streams. The test is conditionally skipped for NATS server versions earlier than 2.12.
* Added a missing `using` directive for `NATS.Client.TestUtilities` in the test file to support the new test.