### PR TITLE
Add support for message schedules

### DIFF
--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -270,4 +270,11 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("allow_msg_counter")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public bool AllowMsgCounter { get; set; }
+
+    /// <summary>
+    /// AllowMsgSchedules enables the scheduling of messages.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("allow_msg_schedules")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public bool AllowMsgSchedules { get; set; }
 }


### PR DESCRIPTION
This pull request introduces support for the new `AllowMsgSchedules` property in the JetStream `StreamConfig`, enabling the scheduling of messages as described in [ADR-51](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-51.md). It also adds a corresponding test to verify correct behavior when creating and updating streams with this property.

JetStream StreamConfig enhancements:

* Added the `AllowMsgSchedules` boolean property to the `StreamConfig` class, allowing message scheduling to be enabled or disabled for streams.

Testing improvements:

* Introduced a new test, `AllowMsgSchedules_property_should_be_set_on_stream`, which verifies that the `AllowMsgSchedules` property is correctly set, persisted, and enforces that disabling it after enabling returns the expected error.
* Added missing import for `NATS.Client.TestUtilities` in `ManageStreamTest.cs` to support the new test.