### PR TITLE
Add persist mode support

### DIFF
--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -276,9 +276,9 @@ public record StreamConfig
     /// </summary>
     /// <remarks>Supported by server v2.12</remarks>
     [System.Text.Json.Serialization.JsonPropertyName("persist_mode")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
 #if NET6_0
     [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigPersistMode>))]
 #endif
-    public StreamConfigPersistMode PersistMode { get; set; } = StreamConfigPersistMode.Default;
+    public StreamConfigPersistMode? PersistMode { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfig.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfig.cs
@@ -270,4 +270,15 @@ public record StreamConfig
     [System.Text.Json.Serialization.JsonPropertyName("allow_msg_counter")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public bool AllowMsgCounter { get; set; }
+
+    /// <summary>
+    /// PersistMode allows to opt-in to different persistence mode settings.
+    /// </summary>
+    /// <remarks>Supported by server v2.12</remarks>
+    [System.Text.Json.Serialization.JsonPropertyName("persist_mode")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+#if NET6_0
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<StreamConfigPersistMode>))]
+#endif
+    public StreamConfigPersistMode PersistMode { get; set; } = StreamConfigPersistMode.Default;
 }

--- a/src/NATS.Client.JetStream/Models/StreamConfigPersistMode.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConfigPersistMode.cs
@@ -1,0 +1,7 @@
+namespace NATS.Client.JetStream.Models;
+
+public enum StreamConfigPersistMode
+{
+    Default = 0,
+    Async = 1,
+}

--- a/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
@@ -102,6 +102,7 @@ internal partial class NatsJSJsonSerializerContext : JsonSerializerContext
             new JsonStringEnumConverter<StreamConfigDiscard>(JsonNamingPolicy.SnakeCaseLower),
             new JsonStringEnumConverter<StreamConfigRetention>(JsonNamingPolicy.SnakeCaseLower),
             new JsonStringEnumConverter<StreamConfigStorage>(JsonNamingPolicy.SnakeCaseLower),
+            new JsonStringEnumConverter<StreamConfigPersistMode>(JsonNamingPolicy.SnakeCaseLower),
             new JsonStringEnumConverter<ConsumerCreateAction>(JsonNamingPolicy.SnakeCaseLower),
         },
     });
@@ -220,6 +221,17 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
                 return (TEnum)(object)ConsumerCreateAction.Update;
             default:
                 return (TEnum)(object)ConsumerCreateAction.CreateOrUpdate;
+            }
+        }
+
+        if (typeToConvert == typeof(StreamConfigPersistMode))
+        {
+            switch (stringValue)
+            {
+            case "default":
+                return (TEnum)(object)StreamConfigPersistMode.Default;
+            case "async":
+                return (TEnum)(object)StreamConfigPersistMode.Async;
             }
         }
 
@@ -342,6 +354,18 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
                 return;
             case ConsumerCreateAction.Update:
                 writer.WriteStringValue("update");
+                return;
+            }
+        }
+        else if (value is StreamConfigPersistMode streamConfigPersistMode)
+        {
+            switch (streamConfigPersistMode)
+            {
+            case StreamConfigPersistMode.Default:
+                writer.WriteStringValue("default");
+                return;
+            case StreamConfigPersistMode.Async:
+                writer.WriteStringValue("async");
                 return;
             }
         }

--- a/tests/NATS.Client.JetStream.Tests/EnumJsonTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/EnumJsonTests.cs
@@ -167,4 +167,89 @@ public class EnumJsonTests
         Assert.NotNull(result);
         Assert.Equal(value, result.Action);
     }
+
+    [Fact]
+    public void StreamConfigPersistMode_null_not_serialized()
+    {
+        var serializer = NatsJSJsonSerializer<StreamConfig>.Default;
+
+        // When PersistMode is null (not explicitly set), it should not be included in JSON
+        var bw = new NatsBufferWriter<byte>();
+        var config = new StreamConfig { PersistMode = null };
+        serializer.Serialize(bw, config);
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan.ToArray());
+        Assert.DoesNotContain("persist_mode", json);
+
+        // Deserialize and verify it remains null
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Null(result.PersistMode);
+    }
+
+    [Theory]
+    [InlineData(StreamConfigPersistMode.Default, "\"persist_mode\":\"default\"")]
+    [InlineData(StreamConfigPersistMode.Async, "\"persist_mode\":\"async\"")]
+    public void StreamConfigPersistMode_explicit_value_serialized(StreamConfigPersistMode value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<StreamConfig>.Default;
+
+        // When PersistMode is explicitly set (even to Default), it should be included in JSON
+        var bw = new NatsBufferWriter<byte>();
+        var config = new StreamConfig { PersistMode = value };
+        serializer.Serialize(bw, config);
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan.ToArray());
+        Assert.Contains(expected, json);
+
+        // Deserialize and verify the value is preserved
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.PersistMode);
+    }
+
+    [Fact]
+    public void StreamConfigPersistMode_roundtrip_preserves_server_values()
+    {
+        var serializer = NatsJSJsonSerializer<StreamConfig>.Default;
+
+        // Test case 1: Server returns "default" - should preserve it
+        var jsonWithDefault = "{\"persist_mode\":\"default\",\"retention\":\"limits\",\"storage\":\"file\"}";
+        var bytes = Encoding.UTF8.GetBytes(jsonWithDefault);
+        var configFromServer = serializer.Deserialize(new ReadOnlySequence<byte>(bytes));
+        Assert.NotNull(configFromServer);
+        Assert.Equal(StreamConfigPersistMode.Default, configFromServer.PersistMode);
+
+        // When we serialize it again, it should include persist_mode
+        var bw1 = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw1, configFromServer);
+        var jsonOut1 = Encoding.UTF8.GetString(bw1.WrittenSpan.ToArray());
+        Assert.Contains("\"persist_mode\":\"default\"", jsonOut1);
+
+        // Test case 2: Server returns "async" - should preserve it
+        var jsonWithAsync = "{\"persist_mode\":\"async\",\"retention\":\"limits\",\"storage\":\"file\"}";
+        bytes = Encoding.UTF8.GetBytes(jsonWithAsync);
+        configFromServer = serializer.Deserialize(new ReadOnlySequence<byte>(bytes));
+        Assert.NotNull(configFromServer);
+        Assert.Equal(StreamConfigPersistMode.Async, configFromServer.PersistMode);
+
+        // When we serialize it again, it should include persist_mode
+        var bw2 = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw2, configFromServer);
+        var jsonOut2 = Encoding.UTF8.GetString(bw2.WrittenSpan.ToArray());
+        Assert.Contains("\"persist_mode\":\"async\"", jsonOut2);
+
+        // Test case 3: Server doesn't return persist_mode - should remain null
+        var jsonWithoutPersistMode = "{\"retention\":\"limits\",\"storage\":\"file\"}";
+        bytes = Encoding.UTF8.GetBytes(jsonWithoutPersistMode);
+        configFromServer = serializer.Deserialize(new ReadOnlySequence<byte>(bytes));
+        Assert.NotNull(configFromServer);
+        Assert.Null(configFromServer.PersistMode);
+
+        // When we serialize it again, it should NOT include persist_mode
+        var bw3 = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw3, configFromServer);
+        var jsonOut3 = Encoding.UTF8.GetString(bw3.WrittenSpan.ToArray());
+        Assert.DoesNotContain("persist_mode", jsonOut3);
+    }
 }


### PR DESCRIPTION
This pull request adds support for the new `PersistMode` property to the JetStream `StreamConfig`, enabling users to specify different persistence modes for streams (supported from server v2.12). It introduces a new enum for persist modes, updates serialization/deserialization logic, and adds comprehensive tests to ensure correct behavior and error handling.

**PersistMode property support in StreamConfig:**

* Added a new `PersistMode` property of type `StreamConfigPersistMode` to the `StreamConfig` class, allowing configuration of stream persistence mode. This property is serialized as `"persist_mode"` and defaults to `Default`.
* Introduced the `StreamConfigPersistMode` enum with values `Default` and `Async`.

**Serialization and deserialization updates:**

* Updated the custom JSON serializer to handle `StreamConfigPersistMode` using snake_case string values for both reading and writing. [[1]](diffhunk://#diff-4758e1bd67591932510100d50b0b8b3a36aee2c93112f4147997ec58872f4d26R105) [[2]](diffhunk://#diff-4758e1bd67591932510100d50b0b8b3a36aee2c93112f4147997ec58872f4d26R227-R237) [[3]](diffhunk://#diff-4758e1bd67591932510100d50b0b8b3a36aee2c93112f4147997ec58872f4d26R360-R371)

**Testing enhancements:**

* Added a test to verify that the `PersistMode` property is correctly set, persisted, and validated on stream creation, and that updating the property results in the expected server error.
* Minor test import cleanup.