### PR TITLE
Add Prioritized Priority Consumer Policy

### DIFF
--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -272,7 +272,7 @@ public record ConsumerConfig
 #endif
 
     /// <summary>
-    /// Specifies the priority policy for consumer message selection, such as prioritizing <c>overflow</c> or <c>pinned_client</c>.
+    /// Specifies the priority policy for consumer message selection, such as prioritizing <c>prioritized</c>, <c>overflow</c>, or <c>pinned_client</c>.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("priority_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]

--- a/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfig.cs
@@ -272,16 +272,15 @@ public record ConsumerConfig
 #endif
 
     /// <summary>
-    /// Specifies the priority policy for consumer message selection, such as prioritizing <c>prioritized</c>, <c>overflow</c>, or <c>pinned_client</c>.
+    /// Specifies the priority policy for consumer message selection.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("priority_policy")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
-    [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
-    [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^.*>]+$")]
 #if NET6_0
-    public string? PriorityPolicy { get; set; }
+    [System.Text.Json.Serialization.JsonConverter(typeof(NatsJSJsonStringEnumConverter<ConsumerConfigPriorityPolicy>))]
+    public ConsumerConfigPriorityPolicy? PriorityPolicy { get; set; }
 #else
-    public string? PriorityPolicy { get; init; }
+    public ConsumerConfigPriorityPolicy? PriorityPolicy { get; init; }
 #endif
 
     /// <summary>

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigPriorityPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigPriorityPolicy.cs
@@ -1,0 +1,22 @@
+namespace NATS.Client.JetStream.Models;
+
+/// <summary>
+/// The priority policy for consumer message selection.
+/// </summary>
+public enum ConsumerConfigPriorityPolicy
+{
+    /// <summary>
+    /// No priority policy is set.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Messages are delivered based on priority level.
+    /// </summary>
+    Prioritized = 1,
+
+    /// <summary>
+    /// Messages overflow to the next available consumer.
+    /// </summary>
+    Overflow = 2,
+}

--- a/src/NATS.Client.JetStream/Models/ConsumerGetnextRequest.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerGetnextRequest.cs
@@ -82,4 +82,17 @@ public record ConsumerGetnextRequest
     [System.Text.Json.Serialization.JsonPropertyName("id")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public string? Id { get; set; }
+
+    /// <summary>
+    /// Priority for message delivery when using prioritized priority policy.
+    /// </summary>
+    /// <remarks>
+    /// Lower values indicate higher priority (0 is the highest priority).
+    /// Maximum priority value is 9. This field is only used when the consumer
+    /// has PriorityPolicy set to "prioritized".
+    /// </remarks>
+    [System.Text.Json.Serialization.JsonPropertyName("priority")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    [System.ComponentModel.DataAnnotations.Range(0, 9)]
+    public byte Priority { get; set; }
 }

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -336,6 +336,7 @@ public class NatsJSConsumer : INatsJSConsumer
                 Group = opts.PriorityGroup?.Group,
                 MinPending = opts.PriorityGroup?.MinPending ?? 0,
                 MinAckPending = opts.PriorityGroup?.MinAckPending ?? 0,
+                Priority = opts.PriorityGroup?.Priority ?? 0,
             },
             cancellationToken).ConfigureAwait(false);
 
@@ -438,6 +439,7 @@ public class NatsJSConsumer : INatsJSConsumer
                     Group = opts.PriorityGroup?.Group,
                     MinPending = opts.PriorityGroup?.MinPending ?? 0,
                     MinAckPending = opts.PriorityGroup?.MinAckPending ?? 0,
+                    Priority = opts.PriorityGroup?.Priority ?? 0,
                 }
                 : new ConsumerGetnextRequest
                 {
@@ -449,6 +451,7 @@ public class NatsJSConsumer : INatsJSConsumer
                     Group = opts.PriorityGroup?.Group,
                     MinPending = opts.PriorityGroup?.MinPending ?? 0,
                     MinAckPending = opts.PriorityGroup?.MinAckPending ?? 0,
+                    Priority = opts.PriorityGroup?.Priority ?? 0,
                 },
             cancellationToken).ConfigureAwait(false);
 

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -269,9 +269,9 @@ public partial class NatsJSContext : INatsJSContext
         }
 
         // TODO: enum these values?
-        if (config.PriorityPolicy != null && config.PriorityPolicy != "none" && config.PriorityPolicy != "overflow" && config.PriorityPolicy != "pinned_client")
+        if (config.PriorityPolicy != null && config.PriorityPolicy != "none" && config.PriorityPolicy != "overflow" && config.PriorityPolicy != "pinned_client" && config.PriorityPolicy != "prioritized")
         {
-            throw new NatsJSException("Cannot create consumers with priority policy other than 'overflow', 'pinned_client', or 'none'.");
+            throw new NatsJSException("Cannot create consumers with priority policy other than 'overflow', 'pinned_client', 'prioritized', or 'none'.");
         }
 
         var response = await JSRequestResponseAsync<ConsumerCreateRequest, ConsumerInfo>(

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -263,17 +263,6 @@ public partial class NatsJSContext : INatsJSContext
             throw new NatsJSException("Cannot create consumers with multiple priority groups.");
         }
 
-        if (config.PriorityPolicy is "pinned_client")
-        {
-            throw new NotImplementedException("Pinned clients are not supported yet.");
-        }
-
-        // TODO: enum these values?
-        if (config.PriorityPolicy != null && config.PriorityPolicy != "none" && config.PriorityPolicy != "overflow" && config.PriorityPolicy != "pinned_client" && config.PriorityPolicy != "prioritized")
-        {
-            throw new NatsJSException("Cannot create consumers with priority policy other than 'overflow', 'pinned_client', 'prioritized', or 'none'.");
-        }
-
         var response = await JSRequestResponseAsync<ConsumerCreateRequest, ConsumerInfo>(
             subject: subject,
             new ConsumerCreateRequest

--- a/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
@@ -103,6 +103,7 @@ internal partial class NatsJSJsonSerializerContext : JsonSerializerContext
             new JsonStringEnumConverter<StreamConfigRetention>(JsonNamingPolicy.SnakeCaseLower),
             new JsonStringEnumConverter<StreamConfigStorage>(JsonNamingPolicy.SnakeCaseLower),
             new JsonStringEnumConverter<ConsumerCreateAction>(JsonNamingPolicy.SnakeCaseLower),
+            new JsonStringEnumConverter<ConsumerConfigPriorityPolicy>(JsonNamingPolicy.SnakeCaseLower),
         },
     });
 #endif
@@ -220,6 +221,19 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
                 return (TEnum)(object)ConsumerCreateAction.Update;
             default:
                 return (TEnum)(object)ConsumerCreateAction.CreateOrUpdate;
+            }
+        }
+
+        if (typeToConvert == typeof(ConsumerConfigPriorityPolicy))
+        {
+            switch (stringValue)
+            {
+            case "none":
+                return (TEnum)(object)ConsumerConfigPriorityPolicy.None;
+            case "prioritized":
+                return (TEnum)(object)ConsumerConfigPriorityPolicy.Prioritized;
+            case "overflow":
+                return (TEnum)(object)ConsumerConfigPriorityPolicy.Overflow;
             }
         }
 
@@ -342,6 +356,21 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
                 return;
             case ConsumerCreateAction.Update:
                 writer.WriteStringValue("update");
+                return;
+            }
+        }
+        else if (value is ConsumerConfigPriorityPolicy consumerConfigPriorityPolicy)
+        {
+            switch (consumerConfigPriorityPolicy)
+            {
+            case ConsumerConfigPriorityPolicy.None:
+                writer.WriteStringValue("none");
+                return;
+            case ConsumerConfigPriorityPolicy.Prioritized:
+                writer.WriteStringValue("prioritized");
+                return;
+            case ConsumerConfigPriorityPolicy.Overflow:
+                writer.WriteStringValue("overflow");
                 return;
             }
         }

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -265,4 +265,14 @@ public record NatsJSPriorityGroupOpts
     /// When specified, this Pull request will only receive messages when the consumer has at least this many ack pending messages.
     /// </summary>
     public long MinAckPending { get; set; }
+
+    /// <summary>
+    /// Priority for message delivery when using prioritized priority policy.
+    /// </summary>
+    /// <remarks>
+    /// Lower values indicate higher priority (0 is the highest priority).
+    /// Maximum priority value is 9. This field is only used when the consumer
+    /// has PriorityPolicy set to "prioritized".
+    /// </remarks>
+    public byte Priority { get; init; }
 }

--- a/tests/NATS.Client.JetStream.Tests/EnumJsonTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/EnumJsonTests.cs
@@ -167,4 +167,39 @@ public class EnumJsonTests
         Assert.NotNull(result);
         Assert.Equal(value, result.Action);
     }
+
+    [Theory]
+    [InlineData(ConsumerConfigPriorityPolicy.None, "\"priority_policy\":\"none\"")]
+    [InlineData(ConsumerConfigPriorityPolicy.Prioritized, "\"priority_policy\":\"prioritized\"")]
+    [InlineData(ConsumerConfigPriorityPolicy.Overflow, "\"priority_policy\":\"overflow\"")]
+    public void ConsumerConfigPriorityPolicy_test(ConsumerConfigPriorityPolicy value, string expected)
+    {
+        var serializer = NatsJSJsonSerializer<ConsumerConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new ConsumerConfig { PriorityPolicy = value });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan.ToArray());
+        Assert.Contains(expected, json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Equal(value, result.PriorityPolicy);
+    }
+
+    [Fact]
+    public void ConsumerConfigPriorityPolicy_null_test()
+    {
+        var serializer = NatsJSJsonSerializer<ConsumerConfig>.Default;
+
+        var bw = new NatsBufferWriter<byte>();
+        serializer.Serialize(bw, new ConsumerConfig { PriorityPolicy = null });
+
+        var json = Encoding.UTF8.GetString(bw.WrittenSpan.ToArray());
+        Assert.DoesNotContain("priority_policy", json);
+
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(bw.WrittenMemory));
+        Assert.NotNull(result);
+        Assert.Null(result.PriorityPolicy);
+    }
 }

--- a/tests/NATS.Client.JetStream.Tests/PriorityGroupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PriorityGroupTest.cs
@@ -187,7 +187,8 @@ public class PriorityGroupTest
             await foreach (var msg in consumer.FetchAsync<int>(opts, cancellationToken: cts.Token))
             {
                 Assert.Equal(count++, msg.Data);
-                if (count == 3) break;
+                if (count == 3)
+                    break;
             }
 
             Assert.Equal(3, count);
@@ -205,7 +206,8 @@ public class PriorityGroupTest
             {
                 Assert.Equal(count + 3, msg.Data); // Should continue from where we left off
                 count++;
-                if (count == 2) break;
+                if (count == 2)
+                    break;
             }
 
             Assert.Equal(2, count);

--- a/tests/NATS.Client.JetStream.Tests/PriorityGroupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PriorityGroupTest.cs
@@ -34,7 +34,7 @@ public class PriorityGroupTest
             ack.EnsureSuccess();
         }
 
-        var consumerConfig = new ConsumerConfig($"{prefix}c1") { PriorityGroups = ["jobs"], PriorityPolicy = "overflow", };
+        var consumerConfig = new ConsumerConfig($"{prefix}c1") { PriorityGroups = ["jobs"], PriorityPolicy = ConsumerConfigPriorityPolicy.Overflow, };
         var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", consumerConfig, cancellationToken: cts.Token);
 
         // Err on no group
@@ -77,7 +77,7 @@ public class PriorityGroupTest
             ack.EnsureSuccess();
         }
 
-        var consumerConfig = new ConsumerConfig($"{prefix}c1") { PriorityGroups = ["jobs"], PriorityPolicy = "overflow", };
+        var consumerConfig = new ConsumerConfig($"{prefix}c1") { PriorityGroups = ["jobs"], PriorityPolicy = ConsumerConfigPriorityPolicy.Overflow, };
         var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", consumerConfig, cancellationToken: cts.Token);
 
         // Err on no group
@@ -123,7 +123,7 @@ public class PriorityGroupTest
             ack.EnsureSuccess();
         }
 
-        var consumerConfig = new ConsumerConfig($"{prefix}c1") { PriorityGroups = ["jobs"], PriorityPolicy = "overflow", };
+        var consumerConfig = new ConsumerConfig($"{prefix}c1") { PriorityGroups = ["jobs"], PriorityPolicy = ConsumerConfigPriorityPolicy.Overflow, };
         var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", consumerConfig, cancellationToken: cts.Token);
 
         // Err on no group
@@ -172,7 +172,7 @@ public class PriorityGroupTest
         var consumerConfig = new ConsumerConfig($"{prefix}c1")
         {
             PriorityGroups = ["jobs"],
-            PriorityPolicy = "prioritized",
+            PriorityPolicy = ConsumerConfigPriorityPolicy.Prioritized,
         };
         var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", consumerConfig, cancellationToken: cts.Token);
 
@@ -229,11 +229,11 @@ public class PriorityGroupTest
         var consumerConfig = new ConsumerConfig($"{prefix}c1")
         {
             PriorityGroups = ["jobs"],
-            PriorityPolicy = "prioritized",
+            PriorityPolicy = ConsumerConfigPriorityPolicy.Prioritized,
         };
 
         var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", consumerConfig, cancellationToken: cts.Token);
         Assert.NotNull(consumer);
-        Assert.Equal("prioritized", consumer.Info.Config.PriorityPolicy);
+        Assert.Equal(ConsumerConfigPriorityPolicy.Prioritized, consumer.Info.Config.PriorityPolicy);
     }
 }

--- a/tests/NATS.Client.JetStream.Tests/PriorityGroupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PriorityGroupTest.cs
@@ -151,4 +151,87 @@ public class PriorityGroupTest
             }
         }
     }
+
+    [SkipIfNatsServer(versionEarlierThan: "2.12")]
+    public async Task Fetch_from_prioritized_group_with_priority()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = new NatsJSContext(nats);
+        var prefix = _server.GetNextId();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.>"], cts.Token);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var ack = await js.PublishAsync($"{prefix}s1.{i}", i, cancellationToken: cts.Token);
+            ack.EnsureSuccess();
+        }
+
+        var consumerConfig = new ConsumerConfig($"{prefix}c1")
+        {
+            PriorityGroups = ["jobs"],
+            PriorityPolicy = "prioritized",
+        };
+        var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", consumerConfig, cancellationToken: cts.Token);
+
+        // Test with priority 5
+        {
+            var opts = new NatsJSFetchOpts
+            {
+                MaxMsgs = 3,
+                PriorityGroup = new NatsJSPriorityGroupOpts { Group = "jobs", Priority = 5 },
+            };
+            var count = 0;
+            await foreach (var msg in consumer.FetchAsync<int>(opts, cancellationToken: cts.Token))
+            {
+                Assert.Equal(count++, msg.Data);
+                if (count == 3) break;
+            }
+
+            Assert.Equal(3, count);
+        }
+
+        // Test with priority 0 (highest priority)
+        {
+            var opts = new NatsJSFetchOpts
+            {
+                MaxMsgs = 2,
+                PriorityGroup = new NatsJSPriorityGroupOpts { Group = "jobs", Priority = 0 },
+            };
+            var count = 0;
+            await foreach (var msg in consumer.FetchAsync<int>(opts, cancellationToken: cts.Token))
+            {
+                Assert.Equal(count + 3, msg.Data); // Should continue from where we left off
+                count++;
+                if (count == 2) break;
+            }
+
+            Assert.Equal(2, count);
+        }
+    }
+
+    [SkipIfNatsServer(versionEarlierThan: "2.12")]
+    public async Task Consumer_with_prioritized_policy_validation()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var js = new NatsJSContext(nats);
+        var prefix = _server.GetNextId();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.>"], cts.Token);
+
+        // Test that prioritized policy is accepted
+        var consumerConfig = new ConsumerConfig($"{prefix}c1")
+        {
+            PriorityGroups = ["jobs"],
+            PriorityPolicy = "prioritized",
+        };
+
+        var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", consumerConfig, cancellationToken: cts.Token);
+        Assert.NotNull(consumer);
+        Assert.Equal("prioritized", consumer.Info.Config.PriorityPolicy);
+    }
 }


### PR DESCRIPTION
This pull request adds support for the "prioritized" priority policy for JetStream consumers as described in [ADR-42](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-42.md#prioritized-policy), enabling message delivery prioritization based on a specified priority value. It updates the consumer configuration, request models, and fetch options to include a `Priority` field used when the "prioritized" policy is set. The changes are validated and tested with new unit tests.

***Breaking change:***

`PriorityPolicy` on consumer config is now implemented as an `enum` an it would break applications using this field as `string` before. Applications not using this field won't be affected.

**Support for prioritized priority policy:**

* Added "prioritized" as a valid value for `PriorityPolicy` in `ConsumerConfig`, and updated validation to accept it. [[1]](diffhunk://#diff-6745059eea806687da349c43cbb33b277414c624ac58aac99401cfa57c58b8beL275-R275) [[2]](diffhunk://#diff-d9f5b99f7a2826ef012daa0f19c51104ee5dbf76f694604d8e1356a7de9ca7f5L272-R274)
* Added a `Priority` property to `ConsumerGetnextRequest` and `NatsJSPriorityGroupOpts`, allowing clients to specify delivery priority (0-9, with 0 as highest). [[1]](diffhunk://#diff-46b1a8315556e0f43a431d4563b714652b1dfae1bdd8f09d97acab601f56c7c5R85-R97) [[2]](diffhunk://#diff-e242e6ed01deda89352c949c84b0aa1095c24326954fcf4b2d82346d59d63ce4R268-R277)
* Updated `NatsJSConsumer` to pass the `Priority` value from fetch options into the consumer request. [[1]](diffhunk://#diff-c13f88be37e7f154bab245a644075c446bc5f4f56d3f9a982d7531c06e421d90R339) [[2]](diffhunk://#diff-c13f88be37e7f154bab245a644075c446bc5f4f56d3f9a982d7531c06e421d90R442) [[3]](diffhunk://#diff-c13f88be37e7f154bab245a644075c446bc5f4f56d3f9a982d7531c06e421d90R454)

**Testing and validation:**

* Added unit tests to verify correct behavior when using the "prioritized" policy and priority values, and to ensure the policy is accepted in consumer creation.