### PR TITLE
fix: handle 408 Requests Pending responses for fetch requests

### DIFF
--- a/src/NATS.Client.Core/NatsHeaderParser.cs
+++ b/src/NATS.Client.Core/NatsHeaderParser.cs
@@ -119,6 +119,11 @@ public class NatsHeaderParser
                 headers.Message = NatsHeaders.Messages.MessageSizeExceedsMaxBytes;
                 headers.MessageText = NatsHeaders.MessageMessageSizeExceedsMaxBytesStr;
             }
+            else if (headerLine.SequenceEqual(NatsHeaders.MessageRequestsPendingBytes))
+            {
+                headers.Message = NatsHeaders.Messages.RequestsPending;
+                headers.MessageText = NatsHeaders.MessageRequestsPendingStr;
+            }
             else
             {
                 headers.Message = NatsHeaders.Messages.Text;

--- a/src/NATS.Client.Core/NatsHeaders.cs
+++ b/src/NATS.Client.Core/NatsHeaders.cs
@@ -27,6 +27,7 @@ public class NatsHeaders : IDictionary<string, StringValues>
         NoMessages,
         RequestTimeout,
         MessageSizeExceedsMaxBytes,
+        RequestsPending,
     }
 
     // Uses C# compiler's optimization for static byte[] data
@@ -57,6 +58,10 @@ public class NatsHeaders : IDictionary<string, StringValues>
     // Message Size Exceeds MaxBytes
     internal static ReadOnlySpan<byte> MessageMessageSizeExceedsMaxBytes => new byte[] { 77, 101, 115, 115, 97, 103, 101, 32, 83, 105, 122, 101, 32, 69, 120, 99, 101, 101, 100, 115, 32, 77, 97, 120, 66, 121, 116, 101, 115 };
     internal static readonly string MessageMessageSizeExceedsMaxBytesStr = "Message Size Exceeds MaxBytes";
+
+    // Requests Pending
+    internal static ReadOnlySpan<byte> MessageRequestsPendingBytes => new byte[] { 82, 101, 113, 117, 101, 115, 116, 115, 32, 80, 101, 110, 100, 105, 110, 103 };
+    internal static readonly string MessageRequestsPendingStr = "Requests Pending";
 
     private static readonly string[] EmptyKeys = Array.Empty<string>();
     private static readonly StringValues[] EmptyValues = Array.Empty<StringValues>();

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -22,6 +22,7 @@ public enum NatsSubEndReason
     Cancelled,
     Exception,
     JetStreamError,
+    RequestsPending,
 }
 
 /// <summary>

--- a/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
@@ -220,6 +220,10 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
                     {
                         EndSubscription(NatsSubEndReason.NoMsgs);
                     }
+                    else if (headers is { Code: 408, Message: NatsHeaders.Messages.RequestsPending })
+                    {
+                        EndSubscription(NatsSubEndReason.RequestsPending);
+                    }
                     else if (headers is { Code: 408, Message: NatsHeaders.Messages.RequestTimeout })
                     {
                         EndSubscription(NatsSubEndReason.Timeout);
@@ -238,6 +242,7 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
                     }
                     else
                     {
+                        Console.WriteLine("HOLY SHIT");
                         _notificationChannel?.Notify(new NatsJSProtocolNotification("Unhandled protocol message", headers.Code, headers.MessageText));
                         _logger.LogWarning(NatsJSLogEvents.ProtocolMessage, "Unhandled protocol message: {Code} {Description}", headers.Code, headers.MessageText);
                     }

--- a/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
@@ -242,7 +242,6 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
                     }
                     else
                     {
-                        Console.WriteLine("HOLY SHIT");
                         _notificationChannel?.Notify(new NatsJSProtocolNotification("Unhandled protocol message", headers.Code, headers.MessageText));
                         _logger.LogWarning(NatsJSLogEvents.ProtocolMessage, "Unhandled protocol message: {Code} {Description}", headers.Code, headers.MessageText);
                     }


### PR DESCRIPTION
Fixes #967

[This](https://github.com/nats-io/nats-server/blob/7726cba45cca93c8f1f760d50bdf74e20aea5934/server/consumer.go#L4216-L4235) is the relevant piece of source code in the NATS server codebase that's yielding that error.

This error type was added 4 years ago as part of [this PR](https://github.com/nats-io/nats-server/pull/2776), and [specifically here](https://github.com/nats-io/nats-server/commit/5592d923c4ab9d496866a75e5859d1ce26152a47#diff-c6e9a3ce0d55948f2e7ea75a4de309986654f2ab11e0f8750625b88b28bd9ebfR2127-R2129).

Support for this error type was added to the NATS Go client as part of [this PR](https://github.com/nats-io/nats.go/pull/967).

Now with this PR, the .NET client begins to explicitly recognize this error type and replicate the same behavior in the other `408` case in a `NatsJSFetch`, which is ending the subscription (since it [means no messages will be sent for that request](https://github.com/nats-io/nats.go/pull/967#discussion_r863251083)); thereby resolving the defect described in #967.