### PR TITLE
Added verification of the consumer sequence number for pull ordered consumers

### DIFF
--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -79,6 +79,7 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
                 consumerName = consumer.Info.Name;
                 _logger.LogInformation(NatsJSLogEvents.NewConsumer, "Created {ConsumerName} with sequence {Seq}", consumerName, seq);
 
+                ulong cseq = 0;
                 NatsJSProtocolException? protocolException = default;
 
                 await using (var cc = await consumer.OrderedConsumeInternalAsync(serializer, opts, cancellationToken))
@@ -126,7 +127,15 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
                             if (msg.Metadata is not { } metadata)
                                 continue;
 
+                            var expected = cseq + 1;
+                            if (metadata.Sequence.Consumer != expected)
+                            {
+                                _logger.LogWarning(NatsJSLogEvents.Retry, $"Consumer sequence mismatch. Expected {expected}, was {metadata.Sequence.Consumer}  Retrying...");
+                                goto CONSUME_LOOP;
+                            }
+
                             seq = metadata.Sequence.Stream;
+                            cseq = metadata.Sequence.Consumer;
 
                             yield return msg;
                         }
@@ -180,23 +189,57 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken, cancellationToken).Token;
+        var processed = 0;
 
-        var consumer = await RecreateConsumer(_fetchConsumerName, _fetchSeq, cancellationToken);
-        _fetchConsumerName = consumer.Info.Name;
-
-        await foreach (var msg in consumer.FetchAsync(opts, serializer, cancellationToken))
+        while (!cancellationToken.IsCancellationRequested)
         {
-            if (msg.Metadata is not { } metadata)
-                continue;
+            if (processed >= opts.MaxMsgs)
+                yield break;
 
-            _fetchSeq = metadata.Sequence.Stream;
-            yield return msg;
+            var mismatch = false;
+            ulong cseq = 0;
+
+            var consumer = await RecreateConsumer(_fetchConsumerName, _fetchSeq, cancellationToken);
+            _fetchConsumerName = consumer.Info.Name;
+
+            try
+            {
+                var fetchOpts = opts with { MaxMsgs = opts.MaxMsgs - processed };
+
+                await foreach (var msg in consumer.FetchAsync(fetchOpts, serializer, cancellationToken))
+                {
+                    if (msg.Metadata is not { } metadata)
+                        continue;
+
+                    var expected = cseq + 1;
+                    if (metadata.Sequence.Consumer != expected)
+                    {
+                        _logger.LogWarning(NatsJSLogEvents.Retry, $"Consumer sequence mismatch. Expected {expected}, was {metadata.Sequence.Consumer}  Retrying...");
+                        mismatch = true;
+                        break;
+                    }
+
+                    _fetchSeq = metadata.Sequence.Stream;
+                    cseq = metadata.Sequence.Consumer;
+
+                    processed++;
+
+                    yield return msg;
+                }
+            }
+            finally
+            {
+                var deleted = await TryDeleteConsumer(_fetchConsumerName, cancellationToken);
+
+                if (deleted)
+                    _fetchConsumerName = string.Empty;
+            }
+
+            if (!mismatch)
+                yield break;
+
+            await Task.Delay(100, cancellationToken);
         }
-
-        var deleted = await TryDeleteConsumer(_fetchConsumerName, cancellationToken);
-
-        if (deleted)
-            _fetchConsumerName = string.Empty;
     }
 
     /// <inheritdoc />
@@ -206,26 +249,55 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken, cancellationToken).Token;
+        var processed = 0;
 
-        var consumer = await RecreateConsumer(_fetchConsumerName, _fetchSeq, cancellationToken);
-        _fetchConsumerName = consumer.Info.Name;
-        try
+        while (!cancellationToken.IsCancellationRequested)
         {
-            await foreach (var msg in consumer.FetchNoWaitAsync(opts, serializer, cancellationToken))
+            if (processed >= opts.MaxMsgs)
+                yield break;
+
+            var mismatch = false;
+            ulong cseq = 0;
+            var consumer = await RecreateConsumer(_fetchConsumerName, _fetchSeq, cancellationToken);
+            _fetchConsumerName = consumer.Info.Name;
+
+            try
             {
-                if (msg.Metadata is not { } metadata)
-                    continue;
+                var fetchOpts = opts with { MaxMsgs = opts.MaxMsgs - processed };
 
-                _fetchSeq = metadata.Sequence.Stream;
-                yield return msg;
+                await foreach (var msg in consumer.FetchNoWaitAsync(fetchOpts, serializer, cancellationToken))
+                {
+                    if (msg.Metadata is not { } metadata)
+                        continue;
+
+                    var expected = cseq + 1;
+                    if (metadata.Sequence.Consumer != expected)
+                    {
+                        _logger.LogWarning(NatsJSLogEvents.Retry, $"Consumer sequence mismatch. Expected {expected}, was {metadata.Sequence.Consumer}  Retrying...");
+                        mismatch = true;
+                        break;
+                    }
+
+                    _fetchSeq = metadata.Sequence.Stream;
+                    cseq = metadata.Sequence.Consumer;
+
+                    processed++;
+
+                    yield return msg;
+                }
             }
-        }
-        finally
-        {
-            var deleted = await TryDeleteConsumer(_fetchConsumerName, cancellationToken);
+            finally
+            {
+                var deleted = await TryDeleteConsumer(_fetchConsumerName, cancellationToken);
 
-            if (deleted)
-                _fetchConsumerName = string.Empty;
+                if (deleted)
+                    _fetchConsumerName = string.Empty;
+            }
+
+            if (!mismatch)
+                yield break;
+
+            await Task.Delay(100, cancellationToken);
         }
     }
 

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -190,10 +190,11 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
     {
         cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken, cancellationToken).Token;
         var processed = 0;
+        var bytesProcessed = 0;
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            if (processed >= opts.MaxMsgs)
+            if (processed >= opts.MaxMsgs || bytesProcessed >= opts.MaxBytes)
                 yield break;
 
             var mismatch = false;
@@ -204,7 +205,7 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
 
             try
             {
-                var fetchOpts = opts with { MaxMsgs = opts.MaxMsgs - processed };
+                var fetchOpts = opts with { MaxMsgs = opts.MaxMsgs - processed, MaxBytes = opts.MaxBytes - bytesProcessed };
 
                 await foreach (var msg in consumer.FetchAsync(fetchOpts, serializer, cancellationToken))
                 {
@@ -223,6 +224,7 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
                     cseq = metadata.Sequence.Consumer;
 
                     processed++;
+                    bytesProcessed += msg.Size;
 
                     yield return msg;
                 }
@@ -250,10 +252,11 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
     {
         cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken, cancellationToken).Token;
         var processed = 0;
+        var bytesProcessed = 0;
 
         while (!cancellationToken.IsCancellationRequested)
         {
-            if (processed >= opts.MaxMsgs)
+            if (processed >= opts.MaxMsgs || bytesProcessed >= opts.MaxBytes)
                 yield break;
 
             var mismatch = false;
@@ -263,7 +266,7 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
 
             try
             {
-                var fetchOpts = opts with { MaxMsgs = opts.MaxMsgs - processed };
+                var fetchOpts = opts with { MaxMsgs = opts.MaxMsgs - processed, MaxBytes = opts.MaxBytes - bytesProcessed };
 
                 await foreach (var msg in consumer.FetchNoWaitAsync(fetchOpts, serializer, cancellationToken))
                 {
@@ -282,6 +285,7 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
                     cseq = metadata.Sequence.Consumer;
 
                     processed++;
+                    bytesProcessed += msg.Size;
 
                     yield return msg;
                 }

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -195,7 +195,7 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
         var retry = 0;
         while (!cancellationToken.IsCancellationRequested)
         {
-            if (processed >= opts.MaxMsgs || bytesProcessed >= opts.MaxBytes)
+            if ((opts.MaxMsgs.HasValue && processed >= opts.MaxMsgs) || (opts.MaxBytes.HasValue && bytesProcessed >= opts.MaxBytes))
                 yield break;
 
             var mismatch = false;
@@ -263,7 +263,7 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
         var retry = 0;
         while (!cancellationToken.IsCancellationRequested)
         {
-            if (processed >= opts.MaxMsgs || bytesProcessed >= opts.MaxBytes)
+            if ((opts.MaxMsgs.HasValue && processed >= opts.MaxMsgs) || (opts.MaxBytes.HasValue && bytesProcessed >= opts.MaxBytes))
                 yield break;
 
             var mismatch = false;

--- a/tests/NATS.Client.JetStream.Tests/OrderedConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/OrderedConsumerTest.cs
@@ -229,4 +229,191 @@ public class OrderedConsumerTest
             }
         }
     }
+
+    [Fact]
+    public async Task Fetch_recovers_from_consumer_deletion()
+    {
+        await using var nats = _server.CreateNatsConnection();
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
+
+        // Publish 20 messages
+        for (var i = 0; i < 20; i++)
+        {
+            await js.PublishAsync($"{prefix}s1.foo", i, cancellationToken: cts.Token);
+        }
+
+        var consumer = (NatsJSOrderedConsumer)await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
+
+        var count = 0;
+        var fetchOpts = new NatsJSFetchOpts
+        {
+            MaxMsgs = 5,
+            Expires = TimeSpan.FromSeconds(3),
+        };
+
+        await foreach (var msg in consumer.FetchAsync<int>(opts: fetchOpts, cancellationToken: cts.Token))
+        {
+            Assert.Equal(count, msg.Data);
+            count++;
+
+            // After receiving 3 messages, delete the consumer to force sequence mismatch
+            if (count == 3)
+            {
+                var consumerName = consumer.Info.Name;
+                _output.WriteLine($"Deleting consumer {consumerName} after message {count}");
+                await js.DeleteConsumerAsync($"{prefix}s1", consumerName, cts.Token);
+            }
+        }
+
+        // Should have received all 5 messages despite consumer deletion
+        Assert.Equal(5, count);
+    }
+
+    [Fact]
+    public async Task Consume_recovers_from_consumer_deletion()
+    {
+        await using var nats = _server.CreateNatsConnection();
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
+
+        // Publish 20 messages
+        for (var i = 0; i < 20; i++)
+        {
+            await js.PublishAsync($"{prefix}s1.foo", i, cancellationToken: cts.Token);
+        }
+
+        var consumer = (NatsJSOrderedConsumer)await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
+
+        var count = 0;
+        var consumeOpts = new NatsJSConsumeOpts
+        {
+            MaxMsgs = 3,
+            Expires = TimeSpan.FromSeconds(3),
+        };
+
+        await foreach (var msg in consumer.ConsumeAsync<int>(opts: consumeOpts, cancellationToken: cts.Token))
+        {
+            Assert.Equal(count, msg.Data);
+            count++;
+
+            // After receiving 8 messages, delete the consumer to force sequence mismatch
+            if (count == 8)
+            {
+                var consumerName = consumer.Info.Name;
+                _output.WriteLine($"Deleting consumer {consumerName} after message {count}");
+                await js.DeleteConsumerAsync($"{prefix}s1", consumerName, cts.Token);
+            }
+
+            if (count == 20)
+                break;
+        }
+
+        // Should have received all 20 messages despite consumer deletion
+        Assert.Equal(20, count);
+    }
+
+    [Fact]
+    public async Task FetchNoWait_recovers_from_consumer_deletion()
+    {
+        await using var nats = _server.CreateNatsConnection();
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
+
+        // Publish 15 messages
+        for (var i = 0; i < 15; i++)
+        {
+            await js.PublishAsync($"{prefix}s1.foo", i, cancellationToken: cts.Token);
+        }
+
+        var consumer = (NatsJSOrderedConsumer)await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
+
+        var count = 0;
+        var fetchOpts = new NatsJSFetchOpts
+        {
+            MaxMsgs = 10,
+        };
+
+        await foreach (var msg in consumer.FetchNoWaitAsync<int>(opts: fetchOpts, cancellationToken: cts.Token))
+        {
+            Assert.Equal(count, msg.Data);
+            count++;
+
+            // After receiving 5 messages, delete the consumer to force sequence mismatch
+            if (count == 5)
+            {
+                var consumerName = consumer.Info.Name;
+                _output.WriteLine($"Deleting consumer {consumerName} after message {count}");
+                await js.DeleteConsumerAsync($"{prefix}s1", consumerName, cts.Token);
+            }
+        }
+
+        // Should have received all 10 messages despite consumer deletion
+        Assert.Equal(10, count);
+    }
+
+    [Fact]
+    public async Task Fetch_maxbytes_with_consumer_deletion()
+    {
+        await using var nats = _server.CreateNatsConnection();
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
+
+        // Publish 20 messages
+        for (var i = 0; i < 20; i++)
+        {
+            await js.PublishAsync($"{prefix}s1.foo", i, cancellationToken: cts.Token);
+        }
+
+        var consumer = (NatsJSOrderedConsumer)await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
+
+        var count = 0;
+        var fetchOpts = new NatsJSFetchOpts
+        {
+            MaxBytes = 1024, // Use MaxBytes instead of MaxMsgs
+            Expires = TimeSpan.FromSeconds(3),
+        };
+
+        await foreach (var msg in consumer.FetchAsync<int>(opts: fetchOpts, cancellationToken: cts.Token))
+        {
+            Assert.Equal(count, msg.Data);
+            count++;
+
+            // After receiving 5 messages, delete the consumer to force sequence mismatch
+            if (count == 5)
+            {
+                var consumerName = consumer.Info.Name;
+                _output.WriteLine($"Deleting consumer {consumerName} after message {count}");
+                await js.DeleteConsumerAsync($"{prefix}s1", consumerName, cts.Token);
+            }
+        }
+
+        // Should have received messages up to MaxBytes limit, with recovery after deletion
+        _output.WriteLine($"Received {count} messages with MaxBytes mode");
+        Assert.True(count > 5, "Should have received messages after consumer deletion");
+    }
 }


### PR DESCRIPTION
As per  https://github.com/nats-io/nats.net/issues/980 added explicit verification of the consumer sequence for an ordered consumer