### PR TITLE
Fix Ad-Hoc JSON Serializer to Use Default Options

### DIFF
--- a/src/NATS.Client.Serializers.Json/NatsJsonSerializer.cs
+++ b/src/NATS.Client.Serializers.Json/NatsJsonSerializer.cs
@@ -29,7 +29,11 @@ public sealed class NatsJsonSerializer<T> : INatsSerializer<T>
     /// This serializer is not suitable for native AOT deployments since it might rely on reflection
     /// </remarks>
     public NatsJsonSerializer()
-        : this(new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull })
+#if NET6_0
+        : this(new JsonSerializerOptions())
+#else
+        : this(JsonSerializerOptions.Default)
+#endif
     {
     }
 

--- a/tests/NATS.Client.CoreUnit.Tests/NatsJsonSerializerTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsJsonSerializerTests.cs
@@ -1,0 +1,88 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NATS.Client.Serializers.Json;
+
+namespace NATS.Client.CoreUnit.Tests;
+
+#if NET8_0_OR_GREATER
+public class NatsJsonSerializerTests
+{
+    [Fact]
+    public void RoundTrip_RequiredNullableProperty_ShouldSucceed()
+    {
+        // This test demonstrates the issue reported in https://github.com/nats-io/nats.net/issues/974
+        // It FAILS with the current implementation because DefaultIgnoreCondition = WhenWritingNull
+        // breaks round-tripping for required nullable properties.
+        //
+        // This test will PASS once the default options are changed to JsonSerializerOptions.Default
+
+        // Arrange
+        var serializer = NatsJsonSerializer<TestObjectWithRequiredNullable>.Default;
+        var obj = new TestObjectWithRequiredNullable { Name = null };
+        var bufferWriter = new ArrayBufferWriter<byte>();
+
+        // Act - Serialize
+        serializer.Serialize(bufferWriter, obj);
+
+        // Deserialize back
+        var buffer = new ReadOnlySequence<byte>(bufferWriter.WrittenMemory);
+        var result = serializer.Deserialize(buffer);
+
+        // Assert - Round trip should succeed
+        Assert.NotNull(result);
+        Assert.Null(result.Name);
+    }
+
+    [Fact]
+    public void Deserialize_RequiredNullableProperty_WithJsonSerializerOptionsDefault_Succeeds()
+    {
+        // Arrange - Using JsonSerializerOptions.Default (without WhenWritingNull)
+        var serializer = new NatsJsonSerializer<TestObjectWithRequiredNullable>(JsonSerializerOptions.Default);
+        var json = "{\"Name\":null}"u8.ToArray();
+        var buffer = new ReadOnlySequence<byte>(json);
+
+        // Act
+        var result = serializer.Deserialize(buffer);
+
+        // Assert - This should work fine
+        Assert.NotNull(result);
+        Assert.Null(result.Name);
+    }
+
+    [Fact]
+    public void RoundTrip_RequiredNullableProperty_WithJsonSerializerOptionsDefault_Succeeds()
+    {
+        // Arrange - Using JsonSerializerOptions.Default (without WhenWritingNull)
+        var serializer = new NatsJsonSerializer<TestObjectWithRequiredNullable>(JsonSerializerOptions.Default);
+        var obj = new TestObjectWithRequiredNullable { Name = null };
+        var bufferWriter = new ArrayBufferWriter<byte>();
+
+        // Act - Serialize
+        serializer.Serialize(bufferWriter, obj);
+        var json = Encoding.UTF8.GetString(bufferWriter.WrittenSpan);
+
+        // With default options, null is included in JSON
+        Assert.Contains("null", json);
+
+        // Deserialize back
+        var buffer = new ReadOnlySequence<byte>(bufferWriter.WrittenMemory);
+        var result = serializer.Deserialize(buffer);
+
+        // Assert - Round trip succeeds
+        Assert.NotNull(result);
+        Assert.Null(result.Name);
+    }
+
+    private class TestObjectWithOptionalNullable
+    {
+        public string? Name { get; init; }
+    }
+
+    private class TestObjectWithRequiredNullable
+    {
+        public required string? Name { get; init; }
+    }
+}
+#endif


### PR DESCRIPTION
This pull request addresses an issue with the default JSON serialization options in `NatsJsonSerializer<T>`, specifically regarding round-tripping of required nullable properties. The main change is to use the default `JsonSerializerOptions` instead of ignoring null values by default, which fixes serialization/deserialization issues for required nullable properties. Additionally, new unit tests are added to verify the correct behavior, especially for .NET 8 and above.

**Serializer options update:**

* Changed the default constructor of `NatsJsonSerializer<T>` to use `JsonSerializerOptions.Default` (or an empty options instance on .NET 6), instead of setting `DefaultIgnoreCondition = WhenWritingNull`. This ensures that required nullable properties are correctly round-tripped during serialization and deserialization.

**Testing improvements:**

* Added new unit tests in `NatsJsonSerializerTests` (for .NET 8 or greater) to verify that required nullable properties are correctly serialized and deserialized, and that round-tripping works as expected with the updated serializer options.

* Fixes #974