### PR TITLE
Reduce closure allocations

### DIFF
--- a/sandbox/MicroBenchmark/SubscribeCtor.cs
+++ b/sandbox/MicroBenchmark/SubscribeCtor.cs
@@ -1,0 +1,22 @@
+using BenchmarkDotNet.Attributes;
+using NATS.Client.Core;
+
+namespace MicroBenchmark;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+[PlainExporter]
+public class SubscribeCtor
+{
+    private readonly NatsConnection _natsConnection = new();
+    private readonly NatsSubOpts _opts = new()
+    {
+        Timeout = TimeSpan.FromSeconds(1),
+        StartUpTimeout = TimeSpan.FromSeconds(1),
+        IdleTimeout = TimeSpan.FromSeconds(1),
+    };
+
+    [Benchmark]
+    public NatsSub<int> NewNatsSub()
+        => new(_natsConnection, null, null, null, _opts, null);
+}

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -90,7 +90,7 @@ public abstract class NatsSubBase
 
 #if NETSTANDARD
         _tokenRegistration = cancellationToken.Register(
-            state =>
+            static state =>
             {
                 var self = (NatsSubBase)state!;
                 self.EndSubscription(NatsSubEndReason.Cancelled);
@@ -98,7 +98,7 @@ public abstract class NatsSubBase
             this);
 #else
         _tokenRegistration = cancellationToken.UnsafeRegister(
-            state =>
+            static state =>
             {
                 var self = (NatsSubBase)state!;
                 self.EndSubscription(NatsSubEndReason.Cancelled);
@@ -107,7 +107,7 @@ public abstract class NatsSubBase
 #endif
 
         // Only allocate timers if necessary to reduce GC pressure
-        if (_idleTimeout != default)
+        if (_idleTimeout != TimeSpan.Zero)
         {
             // Instead of Timers what we could've used here is a cancellation token source based loop
             // i.e. CancellationTokenSource.CancelAfter(TimeSpan) within a Task.Run(async delegate)
@@ -118,17 +118,41 @@ public abstract class NatsSubBase
             // chance to await the unsubscribe call but leaves us to deal with the created task.
             // Since awaiting unsubscribe isn't crucial Timer approach is currently acceptable.
             // If we need an async loop in the future cancellation token source approach can be used.
-            _idleTimeoutTimer = new Timer(_ => EndSubscription(NatsSubEndReason.IdleTimeout));
+            _idleTimeoutTimer = new Timer(
+                static state =>
+                {
+                    var self = (NatsSubBase)state!;
+                    self.EndSubscription(NatsSubEndReason.IdleTimeout);
+                },
+                this,
+                Timeout.Infinite,
+                Timeout.Infinite);
         }
 
         if (_startUpTimeout != default)
         {
-            _startUpTimeoutTimer = new Timer(_ => EndSubscription(NatsSubEndReason.StartUpTimeout));
+            _startUpTimeoutTimer = new Timer(
+                static state =>
+                {
+                    var self = (NatsSubBase)state!;
+                    self.EndSubscription(NatsSubEndReason.StartUpTimeout);
+                },
+                this,
+                Timeout.Infinite,
+                Timeout.Infinite);
         }
 
         if (_timeout != default)
         {
-            _timeoutTimer = new Timer(_ => EndSubscription(NatsSubEndReason.Timeout));
+            _timeoutTimer = new Timer(
+                static state =>
+                {
+                    var self = (NatsSubBase)state!;
+                    self.EndSubscription(NatsSubEndReason.Timeout);
+                },
+                this,
+                Timeout.Infinite,
+                Timeout.Infinite);
         }
     }
 

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -72,9 +72,9 @@ public abstract class NatsSubBase
         _manager = manager;
         _pendingMsgs = opts is { MaxMsgs: > 0 } ? opts.MaxMsgs ?? -1 : -1;
         _countPendingMsgs = _pendingMsgs > 0;
-        _idleTimeout = opts?.IdleTimeout ?? default;
-        _startUpTimeout = opts?.StartUpTimeout ?? default;
-        _timeout = opts?.Timeout ?? default;
+        _idleTimeout = opts?.IdleTimeout ?? TimeSpan.Zero;
+        _startUpTimeout = opts?.StartUpTimeout ?? TimeSpan.Zero;
+        _timeout = opts?.Timeout ?? TimeSpan.Zero;
 
         Connection = connection;
         Subject = subject;
@@ -129,7 +129,7 @@ public abstract class NatsSubBase
                 Timeout.Infinite);
         }
 
-        if (_startUpTimeout != default)
+        if (_startUpTimeout != TimeSpan.Zero)
         {
             _startUpTimeoutTimer = new Timer(
                 static state =>
@@ -142,7 +142,7 @@ public abstract class NatsSubBase
                 Timeout.Infinite);
         }
 
-        if (_timeout != default)
+        if (_timeout != TimeSpan.Zero)
         {
             _timeoutTimer = new Timer(
                 static state =>


### PR DESCRIPTION
This pull request focuses on improving timer initialization and timeout handling in the `NatsSubBase` class, and introduces a new microbenchmark for subscription construction. The main changes ensure that timers are only created when necessary and initialized with explicit parameters, and that timeouts default to `TimeSpan.Zero` instead of the default struct value. Additionally, the code now uses static delegates for timer callbacks to reduce allocations.

**Timeout and Timer Initialization Improvements:**

* Changed the default values for `_idleTimeout`, `_startUpTimeout`, and `_timeout` to use `TimeSpan.Zero` instead of the default struct value, ensuring more explicit and predictable timeout behavior.
* Updated timer creation logic to check for `TimeSpan.Zero` instead of `default` and to initialize timers with explicit state and callback parameters. This reduces GC pressure and ensures timers are only allocated when needed. [[1]](diffhunk://#diff-33c1ddca5a4a01cad41d22e3e5adb3a649d2f0c3292cdd68192955617f512415L110-R110) [[2]](diffhunk://#diff-33c1ddca5a4a01cad41d22e3e5adb3a649d2f0c3292cdd68192955617f512415L121-R155)

**Delegate and Callback Optimization:**

* Replaced inline delegates for cancellation token and timer callbacks with static delegates, reducing allocations and improving performance. [[1]](diffhunk://#diff-33c1ddca5a4a01cad41d22e3e5adb3a649d2f0c3292cdd68192955617f512415L93-R101) [[2]](diffhunk://#diff-33c1ddca5a4a01cad41d22e3e5adb3a649d2f0c3292cdd68192955617f512415L121-R155)

**Benchmarking:**

* Added a new microbenchmark class `SubscribeCtor` to measure the performance of constructing new `NatsSub<int>` instances, aiding in performance testing and analysis.

### Benchmark SubscribeCtor.NewNatsSub
#### this PR:
| Method     | Mean     | Error    | StdDev    | Gen0   | Gen1   | Allocated |
|----------- |---------:|---------:|----------:|-------:|-------:|----------:|
| NewNatsSub | 2.270 us | 1.555 us | 0.0852 us | 0.1183 | 0.1144 |   1.61 KB |
#### main:
| Method     | Mean     | Error     | StdDev    | Gen0   | Gen1   | Allocated |
|----------- |---------:|----------:|----------:|-------:|-------:|----------:|
| NewNatsSub | 2.790 us | 0.7886 us | 0.0432 us | 0.1335 | 0.1297 |    1.8 KB |