### PR TITLE
fix: ensure NatsConnectionPool cannot overflow

### DIFF
--- a/src/NATS.Client.Core/NatsConnectionPool.cs
+++ b/src/NATS.Client.Core/NatsConnectionPool.cs
@@ -41,7 +41,7 @@ public sealed class NatsConnectionPool : INatsConnectionPool
     public INatsConnection GetConnection()
     {
         var i = Interlocked.Increment(ref _index);
-        return _connections[i % _connections.Length];
+        return _connections[(uint)i % _connections.Length];
     }
 
     public IEnumerable<INatsConnection> GetConnections()


### PR DESCRIPTION
Call me paranoid but assuming someone can try to send 5000 messages per second (which is not insane) by taking connection from pool every time (which is not insane either) it gives service 5 days before crash (2**31/5000/60/60/24 = 4.97).

This is just about ensuring division returns positive number.
