### PR TITLE
Add Nats-Expected-Last-Subject-Sequence-Subject

### DIFF
--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -160,6 +160,12 @@ public partial class NatsJSContext
                 headers ??= new NatsHeaders();
                 headers["Nats-Expected-Last-Subject-Sequence"] = opts.ExpectedLastSubjectSequence.ToString();
             }
+
+            if (opts.ExpectedLastSubjectSequenceSubject != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Expected-Last-Subject-Sequence-Subject"] = opts.ExpectedLastSubjectSequenceSubject;
+            }
         }
 
         opts ??= NatsJSPubOpts.Default;
@@ -300,6 +306,12 @@ public partial class NatsJSContext
             {
                 headers ??= new NatsHeaders();
                 headers["Nats-Expected-Last-Subject-Sequence"] = opts.ExpectedLastSubjectSequence.ToString();
+            }
+
+            if (opts.ExpectedLastSubjectSequenceSubject != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Expected-Last-Subject-Sequence-Subject"] = opts.ExpectedLastSubjectSequenceSubject;
             }
         }
 

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -238,6 +238,9 @@ public record NatsJSPubOpts : NatsPubOpts
     // lss *uint64 // Expected last sequence per subject
     public ulong? ExpectedLastSubjectSequence { get; init; }
 
+    // Expected last sequence subject filter (allows wildcard subjects)
+    public string? ExpectedLastSubjectSequenceSubject { get; init; }
+
     // Publish retries for NoResponders err.
     // rwait time.Duration // Retry wait between attempts
     public TimeSpan RetryWaitBetweenAttempts { get; init; } = TimeSpan.FromMilliseconds(250);


### PR DESCRIPTION
This pull request adds support for the `ExpectedLastSubjectSequenceSubject` option to JetStream publish operations, allowing users to specify a subject filter (including wildcards) for expected last subject sequence checks. This enables more flexible conditional publishing based on the last sequence of a specific subject. The changes also include a new test to verify the correct behavior of this feature.

### JetStream publish options enhancements

* Added a new property `ExpectedLastSubjectSequenceSubject` to the `NatsJSPubOpts` record, allowing users to specify a subject filter for expected last subject sequence checks.
* Updated both `TryPublishAsync<T>` and `PublishConcurrentAsync<T>` methods in `NatsJSContext.cs` to include the `Nats-Expected-Last-Subject-Sequence-Subject` header when `ExpectedLastSubjectSequenceSubject` is set. [[1]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86R163-R168) [[2]](diffhunk://#diff-5942aa8cec42899503745e8123d9999ff9c0f44c9e1e3190aea5b6085c5dbf86R310-R315)

### Testing improvements

* Added a new test `Publish_expected_last_subject_sequence_subject_test` to verify that publishing with the `ExpectedLastSubjectSequenceSubject` option works as expected, including handling of correct and stale sequence numbers.