### PR TITLE
Replace deprecated IndexRange package with Microsoft.Bcl.Memory to solve possible dependency conflicts (for netFramework/netStandard2.0)

### DIFF
--- a/src/NATS.Client.Core/NATS.Client.Core.csproj
+++ b/src/NATS.Client.Core/NATS.Client.Core.csproj
@@ -32,8 +32,8 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Memory" Version="4.5.5"/>
         <PackageReference Include="System.Buffers" Version="4.5.1"/>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.11"/>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.0"/>
         <!--  Nerdbank.Streams for SequenceReader support https://github.com/dotnet/standard/issues/1493  -->
         <PackageReference Include="Nerdbank.Streams" Version="2.10.72"/>
     </ItemGroup>

--- a/src/NATS.Client.Core/NATS.Client.Core.csproj
+++ b/src/NATS.Client.Core/NATS.Client.Core.csproj
@@ -32,7 +32,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Memory" Version="4.5.5"/>
         <PackageReference Include="System.Buffers" Version="4.5.1"/>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.0"/>
         <!--  Nerdbank.Streams for SequenceReader support https://github.com/dotnet/standard/issues/1493  -->
         <PackageReference Include="Nerdbank.Streams" Version="2.10.72"/>

--- a/src/NATS.Client.Core/NATS.Client.Core.csproj
+++ b/src/NATS.Client.Core/NATS.Client.Core.csproj
@@ -33,9 +33,9 @@
         <PackageReference Include="System.Memory" Version="4.5.5"/>
         <PackageReference Include="System.Buffers" Version="4.5.1"/>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.11"/>
         <!--  Nerdbank.Streams for SequenceReader support https://github.com/dotnet/standard/issues/1493  -->
         <PackageReference Include="Nerdbank.Streams" Version="2.10.72"/>
-        <PackageReference Include="IndexRange" Version="1.0.3"/>
     </ItemGroup>
 
     <!--  Dependencies for net6.0 and net8.0 only -->

--- a/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
+++ b/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
@@ -20,7 +20,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.5"/>
     <PackageReference Include="System.Buffers" Version="4.5.1"/>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
     <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.0"/>
     <PackageReference Include="System.Text.Json" Version="8.0.5"/>
     <PackageReference Include="System.Threading.Channels" Version="8.0.0"/>

--- a/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
+++ b/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
@@ -20,8 +20,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.5"/>
     <PackageReference Include="System.Buffers" Version="4.5.1"/>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.11"/>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0"/>
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.0"/>
     <PackageReference Include="System.Text.Json" Version="8.0.5"/>
     <PackageReference Include="System.Threading.Channels" Version="8.0.0"/>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1"/>

--- a/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
+++ b/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="System.Memory" Version="4.5.5"/>
     <PackageReference Include="System.Buffers" Version="4.5.1"/>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
-    <PackageReference Include="IndexRange" Version="1.0.3"/>
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.11"/>
     <PackageReference Include="System.Text.Json" Version="8.0.5"/>
     <PackageReference Include="System.Threading.Channels" Version="8.0.0"/>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1"/>


### PR DESCRIPTION
This solves a dependency conflict between `IndexRange` and `Microsoft.Bcl.Memory` that can cause duplicate `System.Index` definitions when using NATS from netframework/netstandard2.0.