### PR TITLE
Replace `OperationCanceledException` with `NatsTimeoutException`

### DIFF
--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -725,7 +725,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         {
             if (!await _semLock.WaitAsync(_defaultCommandTimeout, cancellationToken).ConfigureAwait(false))
             {
-                throw new OperationCanceledException();
+                NatsTimeoutException.Throw();
             }
         }
 
@@ -747,8 +747,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         catch (TimeoutException)
         {
             // WaitAsync throws a TimeoutException when the TimeSpan is exceeded
-            // standardize to an OperationCanceledException as if a cancellationToken was used
-            throw new OperationCanceledException();
+            NatsTimeoutException.Throw();
         }
         finally
         {
@@ -762,7 +761,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         {
             if (!await _semLock.WaitAsync(_defaultCommandTimeout, cancellationToken).ConfigureAwait(false))
             {
-                throw new OperationCanceledException();
+                NatsTimeoutException.Throw();
             }
         }
 
@@ -785,8 +784,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         catch (TimeoutException)
         {
             // WaitAsync throws a TimeoutException when the TimeSpan is exceeded
-            // standardize to an OperationCanceledException as if a cancellationToken was used
-            throw new OperationCanceledException();
+            NatsTimeoutException.Throw();
         }
         finally
         {
@@ -800,7 +798,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         {
             if (!await _semLock.WaitAsync(_defaultCommandTimeout, cancellationToken).ConfigureAwait(false))
             {
-                throw new OperationCanceledException();
+                NatsTimeoutException.Throw();
             }
         }
 
@@ -822,8 +820,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         catch (TimeoutException)
         {
             // WaitAsync throws a TimeoutException when the TimeSpan is exceeded
-            // standardize to an OperationCanceledException as if a cancellationToken was used
-            throw new OperationCanceledException();
+            NatsTimeoutException.Throw();
         }
         finally
         {
@@ -842,7 +839,7 @@ internal sealed class CommandWriter : IAsyncDisposable
             {
                 if (!await _semLock.WaitAsync(_defaultCommandTimeout, cancellationToken).ConfigureAwait(false))
                 {
-                    throw new OperationCanceledException();
+                    NatsTimeoutException.Throw();
                 }
             }
 
@@ -864,8 +861,7 @@ internal sealed class CommandWriter : IAsyncDisposable
             catch (TimeoutException)
             {
                 // WaitAsync throws a TimeoutException when the TimeSpan is exceeded
-                // standardize to an OperationCanceledException as if a cancellationToken was used
-                throw new OperationCanceledException();
+                NatsTimeoutException.Throw();
             }
             finally
             {
@@ -891,7 +887,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         {
             if (!await _semLock.WaitAsync(_defaultCommandTimeout, cancellationToken).ConfigureAwait(false))
             {
-                throw new OperationCanceledException();
+                NatsTimeoutException.Throw();
             }
         }
 
@@ -913,8 +909,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         catch (TimeoutException)
         {
             // WaitAsync throws a TimeoutException when the TimeSpan is exceeded
-            // standardize to an OperationCanceledException as if a cancellationToken was used
-            throw new OperationCanceledException();
+            NatsTimeoutException.Throw();
         }
         finally
         {
@@ -928,7 +923,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         {
             if (!await _semLock.WaitAsync(_defaultCommandTimeout, cancellationToken).ConfigureAwait(false))
             {
-                throw new OperationCanceledException();
+                NatsTimeoutException.Throw();
             }
         }
 
@@ -950,8 +945,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         catch (TimeoutException)
         {
             // WaitAsync throws a TimeoutException when the TimeSpan is exceeded
-            // standardize to an OperationCanceledException as if a cancellationToken was used
-            throw new OperationCanceledException();
+            NatsTimeoutException.Throw();
         }
         finally
         {

--- a/src/NATS.Client.Core/NatsException.cs
+++ b/src/NATS.Client.Core/NatsException.cs
@@ -65,3 +65,10 @@ public sealed class NatsPayloadTooLargeException : NatsException
 }
 
 public sealed class NatsConnectionFailedException(string message) : NatsException(message);
+
+public sealed class NatsTimeoutException() : NatsException("Operation timed out")
+{
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Throw() => throw new NatsTimeoutException();
+}

--- a/tests/NATS.Client.Core2.Tests/CancellationTest.cs
+++ b/tests/NATS.Client.Core2.Tests/CancellationTest.cs
@@ -30,10 +30,10 @@ public class CancellationTest
         var stopToken = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var stallTask = conn.CommandWriter.TestStallFlushAsync(TimeSpan.FromSeconds(10), stopToken.Token);
 
-        // commands that call ConnectAsync throw OperationCanceledException
-        await Assert.ThrowsAsync<OperationCanceledException>(() => conn.PingAsync(cancellationToken).AsTask());
-        await Assert.ThrowsAsync<OperationCanceledException>(() => conn.PublishAsync("test", cancellationToken: cancellationToken).AsTask());
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        // commands that call ConnectAsync throw NatsTimeoutException
+        await Assert.ThrowsAsync<NatsTimeoutException>(() => conn.PingAsync(cancellationToken).AsTask());
+        await Assert.ThrowsAsync<NatsTimeoutException>(() => conn.PublishAsync("test", cancellationToken: cancellationToken).AsTask());
+        await Assert.ThrowsAsync<NatsTimeoutException>(async () =>
         {
             await foreach (var unused in conn.SubscribeAsync<string>("test", cancellationToken: cancellationToken))
             {


### PR DESCRIPTION
This pull request standardizes timeout exception handling in the command writer logic of the NATS client library. Instead of throwing a generic `OperationCanceledException` on command timeouts, the code now throws a custom `NatsTimeoutException`, making timeout errors more explicit and easier to handle. The test suite is also updated to expect this new exception.

**Exception Handling Improvements:**

* Introduced a new `NatsTimeoutException` class in `NatsException.cs`, with a static `Throw()` method for consistent exception throwing.
* Replaced all occurrences of `OperationCanceledException` with `NatsTimeoutException.Throw()` in the state machine methods for connect, ping, pong, publish, subscribe, and unsubscribe operations in `CommandWriter.cs`. [[1]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L728-R728) [[2]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L750-R750) [[3]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L765-R764) [[4]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L788-R787) [[5]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L803-R801) [[6]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L825-R823) [[7]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L845-R842) [[8]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L867-R864) [[9]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L894-R890) [[10]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L916-R912) [[11]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L931-R926) [[12]](diffhunk://#diff-38654e36ec103f5b8aa4055cc66a71b983aebfbf3f1ebbba2866c94910669382L953-R948)

**Testing Updates:**

* Updated `CancellationTest.cs` to assert that `NatsTimeoutException` is thrown on command timeouts instead of `OperationCanceledException`.

fixes #795 