### PR TITLE
resolves: 1035 - Use ConnectTimeout when awaiting INFO signal

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -526,7 +526,7 @@ public partial class NatsConnection : INatsConnection
         {
             // Wait for an INFO message from server. If we land on a dead socket and server response
             // can't be received, this will throw a timeout exception and we will retry the connection.
-            await waitForInfoSignal.Task.WaitAsync(Opts.RequestTimeout).ConfigureAwait(false);
+            await waitForInfoSignal.Task.WaitAsync(Opts.ConnectTimeout).ConfigureAwait(false);
 
             // check to see if we should upgrade to TLS
             if (_socketConnection!.InnerSocket is INatsTlsUpgradeableSocketConnection tlsUpgradeableSocket)


### PR DESCRIPTION
## Context: Issue #1035 
After a successful NATS Connection, upon loss of that connection the configured retry policy/settings are executed. During this reconnect/retry loop, if the NATS Server is unreachable, we land on NatsConnection.cs:line:529, specifically the `WaitAsync` hanging on the `waitForInfoSignal` Task. This respects the timeout provided via `RequestTimeout` of the connection's `NatsOpts`.
In my use-case, the default `RequestTimeout` needs to be relatively long, on the order of ~1 minute. That led to observing Retries seemingly hanging well beyond expectations, I had expected the timeout to be the `ConnectTimeout`, not the `RequestTimeout`.

## This Change
This PR swaps the timeout from `NatsOpts.RequestTimeout` to the expected `NatsOpts.ConnectTimeout`.  