### PR TITLE
Fix OTel activity leak in Direct request mode

### DIFF
--- a/examples/Example.OpenTelemetry/ClientApp.cs
+++ b/examples/Example.OpenTelemetry/ClientApp.cs
@@ -24,7 +24,10 @@ public static class ClientApp
 
         Console.WriteLine("Client App is starting...");
 
-        await using var nats = new NatsConnection();
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            RequestReplyMode = NatsRequestReplyMode.Direct,
+        });
 
         using (var activity = activitySource.StartActivity("SayHi"))
         {

--- a/examples/Example.OpenTelemetry/ServiceApp.cs
+++ b/examples/Example.OpenTelemetry/ServiceApp.cs
@@ -24,7 +24,10 @@ public static class ServiceApp
 
         Console.WriteLine("Service App is starting...");
 
-        await using var nats = new NatsConnection();
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            RequestReplyMode = NatsRequestReplyMode.Direct,
+        });
 
         await foreach (var msg in nats.SubscribeAsync<string>("greet.>"))
         {

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -50,7 +50,9 @@ public partial class NatsConnection
                     using var rt = _replyTaskFactory.CreateReplyTask(replySerializer, replyOpts.Timeout);
                     requestSerializer ??= Opts.SerializerRegistry.GetSerializer<TRequest>();
                     await PublishAsync(subject, data, headers, rt.Subject, requestSerializer, requestOpts, cancellationToken).ConfigureAwait(false);
-                    return await rt.GetResultAsync(cancellationToken).ConfigureAwait(false);
+                    var msg = await rt.GetResultAsync(cancellationToken).ConfigureAwait(false);
+                    msg.Headers?.Activity?.Dispose();
+                    return msg;
                 }
 
                 await using var sub1 = await CreateRequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)
@@ -77,7 +79,9 @@ public partial class NatsConnection
             using var rt = _replyTaskFactory.CreateReplyTask(replySerializer, replyOpts.Timeout);
             requestSerializer ??= Opts.SerializerRegistry.GetSerializer<TRequest>();
             await PublishAsync(subject, data, headers, rt.Subject, requestSerializer, requestOpts, cancellationToken).ConfigureAwait(false);
-            return await rt.GetResultAsync(cancellationToken).ConfigureAwait(false);
+            var msg = await rt.GetResultAsync(cancellationToken).ConfigureAwait(false);
+            msg.Headers?.Activity?.Dispose();
+            return msg;
         }
 
         await using var sub = await CreateRequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)


### PR DESCRIPTION
Fix OpenTelemetry activity not being disposed when using `NatsRequestReplyMode.Direct`.

The activity stored in message headers is now explicitly disposed after receiving the response, matching the behavior of `SharedInbox` mode which disposes via `ActivityEndingMsgReader`.

Fixes #862