### PR TITLE
Add TermWithReason support to AckTerminateAsync

### DIFF
--- a/src/NATS.Client.JetStream/NatsJSMsg.cs
+++ b/src/NATS.Client.JetStream/NatsJSMsg.cs
@@ -8,7 +8,7 @@ namespace NATS.Client.JetStream;
 
 /// <summary>
 /// This interface provides an optional contract when passing
-/// messages to processing methods which is usually helpful in
+/// messages to processing methods, which is usually helpful in
 /// creating test doubles in unit testing.
 /// </summary>
 /// <remarks>
@@ -30,12 +30,12 @@ namespace NATS.Client.JetStream;
 public interface INatsJSMsg<out T> : INatsMsg
 {
     /// <summary>
-    /// Subject of the user message.
+    /// Get subject of the user message.
     /// </summary>
     string Subject { get; }
 
     /// <summary>
-    /// Message size in bytes.
+    /// Get message size in bytes.
     /// </summary>
     /// <remarks>
     /// Message size is calculated using the same method NATS server uses:
@@ -46,12 +46,12 @@ public interface INatsJSMsg<out T> : INatsMsg
     int Size { get; }
 
     /// <summary>
-    /// Deserialized user data.
+    /// Get deserialized user data.
     /// </summary>
     T? Data { get; }
 
     /// <summary>
-    /// The connection messages was delivered on.
+    /// Get the connection messages were delivered on.
     /// </summary>
     INatsConnection? Connection { get; }
 
@@ -80,7 +80,7 @@ public interface INatsJSMsg<out T> : INatsMsg
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the command.</param>
     /// <returns>A <see cref="ValueTask"/> that represents the asynchronous send operation.</returns>
     [Obsolete("ReplyAsync is not valid when using JetStream. The reply message will never reach the Requestor as NATS will reply to all JetStream publish by default.")]
-    ValueTask ReplyAsync(NatsHeaders? headers = default, string? replyTo = default, NatsPubOpts? opts = default, CancellationToken cancellationToken = default);
+    ValueTask ReplyAsync(NatsHeaders? headers = null, string? replyTo = null, NatsPubOpts? opts = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Acknowledges the message was completely handled.
@@ -88,7 +88,7 @@ public interface INatsJSMsg<out T> : INatsMsg
     /// <param name="opts">Ack options.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the call.</param>
     /// <returns>A <see cref="ValueTask"/> representing the async call.</returns>
-    ValueTask AckAsync(AckOpts? opts = default, CancellationToken cancellationToken = default);
+    ValueTask AckAsync(AckOpts? opts = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Signals that the message will not be processed now and processing can move onto the next message.
@@ -101,7 +101,7 @@ public interface INatsJSMsg<out T> : INatsMsg
     /// Messages rejected using <c>-NAK</c> will be resent by the NATS JetStream server after the configured timeout
     /// or the delay parameter if it's specified.
     /// </remarks>
-    ValueTask NakAsync(AckOpts? opts = default, TimeSpan delay = default, CancellationToken cancellationToken = default);
+    ValueTask NakAsync(AckOpts? opts = null, TimeSpan delay = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Indicates that work is ongoing and the wait period should be extended.
@@ -112,23 +112,31 @@ public interface INatsJSMsg<out T> : INatsMsg
     /// <remarks>
     /// <para>
     /// Time period is defined by the consumer's <c>ack_wait</c> configuration on the server which is
-    /// defined as how long to allow messages to remain un-acknowledged before attempting redelivery.
+    /// defined as how long to allow messages to remain unacknowledged before attempting redelivery.
     /// </para>
     /// <para>
     /// This message must be sent before the <c>ack_wait</c> period elapses. The period should be extended
     /// by another amount of time equal to <c>ack_wait</c> by the NATS JetStream server.
     /// </para>
     /// </remarks>
-    ValueTask AckProgressAsync(AckOpts? opts = default, CancellationToken cancellationToken = default);
+    ValueTask AckProgressAsync(AckOpts? opts = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Instructs the server to stop redelivery of the message without acknowledging it as successfully processed.
     /// </summary>
     /// <param name="opts">Ack options.</param>
-    /// <param name="reason">Optional reason for termination, included in JetStream advisory events. Requires NATS Server 2.10.4+.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the call.</param>
     /// <returns>A <see cref="ValueTask"/> representing the async call.</returns>
-    ValueTask AckTerminateAsync(AckOpts? opts = default, string? reason = null, CancellationToken cancellationToken = default);
+    ValueTask AckTerminateAsync(AckOpts? opts = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Instructs the server to stop redelivery of the message without acknowledging it as successfully processed.
+    /// </summary>
+    /// <param name="reason">Optional reason for termination, included in JetStream advisory events. Requires NATS Server 2.10.4+.</param>
+    /// <param name="opts">Ack options.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the call.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the async call.</returns>
+    ValueTask AckTerminateAsync(string reason, AckOpts? opts = null, CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -137,10 +145,6 @@ public interface INatsJSMsg<out T> : INatsMsg
 /// <typeparam name="T">User message type</typeparam>
 public readonly struct NatsJSMsg<T> : INatsJSMsg<T>
 {
-#if NETSTANDARD2_0
-    private static readonly byte[] TermPrefix = { (byte)'+', (byte)'T', (byte)'E', (byte)'R', (byte)'M', (byte)' ' };
-#endif
-
     private readonly INatsJSContext _context;
     private readonly NatsMsg<T> _msg;
     private readonly Lazy<NatsJSMsgMetadata?> _replyToDateTimeAndSeq;
@@ -152,45 +156,25 @@ public readonly struct NatsJSMsg<T> : INatsJSMsg<T>
         _replyToDateTimeAndSeq = new Lazy<NatsJSMsgMetadata?>(() => ReplyToDateTimeAndSeq.Parse(msg.ReplyTo));
     }
 
-    /// <summary>
-    /// Subject of the user message.
-    /// </summary>
+    /// <inheritdoc />
     public string Subject => _msg.Subject;
 
-    /// <summary>
-    /// Message size in bytes.
-    /// </summary>
-    /// <remarks>
-    /// Message size is calculated using the same method NATS server uses:
-    /// <code lang="C#">
-    /// int size = subject.Length + replyTo.Length + headers.Length + payload.Length;
-    /// </code>
-    /// </remarks>
+    /// <inheritdoc />
     public int Size => _msg.Size;
 
-    /// <summary>
-    /// Headers of the user message if set.
-    /// </summary>
+    /// <inheritdoc />
     public NatsHeaders? Headers => _msg.Headers;
 
-    /// <summary>
-    /// Deserialized user data.
-    /// </summary>
+    /// <inheritdoc />
     public T? Data => _msg.Data;
 
-    /// <summary>
-    /// The connection messages was delivered on.
-    /// </summary>
+    /// <inheritdoc />
     public INatsConnection? Connection => _msg.Connection;
 
-    /// <summary>
-    /// Additional metadata about the message.
-    /// </summary>
+    /// <inheritdoc />
     public NatsJSMsgMetadata? Metadata => _replyToDateTimeAndSeq.Value;
 
-    /// <summary>
-    /// The reply subject that subscribers can use to send a response back to the publisher/requester.
-    /// </summary>
+    /// <inheritdoc />
     public string? ReplyTo => _msg.ReplyTo;
 
     /// <inheritdoc />
@@ -201,40 +185,18 @@ public readonly struct NatsJSMsg<T> : INatsJSMsg<T>
     /// <inheritdoc />
     public void EnsureSuccess() => _msg.EnsureSuccess();
 
-    /// <summary>
-    /// Reply with an empty message.
-    /// </summary>
-    /// <param name="headers">Optional message headers.</param>
-    /// <param name="replyTo">Optional reply-to subject.</param>
-    /// <param name="opts">A <see cref="NatsPubOpts"/> for publishing options.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the command.</param>
-    /// <returns>A <see cref="ValueTask"/> that represents the asynchronous send operation.</returns>
+    /// <inheritdoc />
     [Obsolete("ReplyAsync is not valid when using JetStream. The reply message will never reach the Requestor as NATS will reply to all JetStream publish by default.")]
-    public ValueTask ReplyAsync(NatsHeaders? headers = default, string? replyTo = default, NatsPubOpts? opts = default, CancellationToken cancellationToken = default) =>
+    public ValueTask ReplyAsync(NatsHeaders? headers = null, string? replyTo = null, NatsPubOpts? opts = null, CancellationToken cancellationToken = default) =>
         _msg.ReplyAsync(headers, replyTo, opts, cancellationToken);
 
-    /// <summary>
-    /// Acknowledges the message was completely handled.
-    /// </summary>
-    /// <param name="opts">Ack options.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the call.</param>
-    /// <returns>A <see cref="ValueTask"/> representing the async call.</returns>
-    public ValueTask AckAsync(AckOpts? opts = default, CancellationToken cancellationToken = default) => SendAckAsync(NatsJSConstants.Ack, opts, cancellationToken);
+    /// <inheritdoc />
+    public ValueTask AckAsync(AckOpts? opts = null, CancellationToken cancellationToken = default) => SendAckAsync(NatsJSConstants.Ack, opts, cancellationToken);
 
-    /// <summary>
-    /// Signals that the message will not be processed now and processing can move onto the next message.
-    /// </summary>
-    /// <param name="delay">Delay redelivery of the message.</param>
-    /// <param name="opts">Ack options.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the call.</param>
-    /// <returns>A <see cref="ValueTask"/> representing the async call.</returns>
-    /// <remarks>
-    /// Messages rejected using <c>-NAK</c> will be resent by the NATS JetStream server after the configured timeout
-    /// or the delay parameter if it's specified.
-    /// </remarks>
-    public ValueTask NakAsync(AckOpts? opts = default, TimeSpan delay = default, CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public ValueTask NakAsync(AckOpts? opts = null, TimeSpan delay = default, CancellationToken cancellationToken = default)
     {
-        if (delay == default)
+        if (delay == TimeSpan.Zero)
         {
             return SendAckAsync(NatsJSConstants.Nak, opts, cancellationToken);
         }
@@ -245,32 +207,18 @@ public readonly struct NatsJSMsg<T> : INatsJSMsg<T>
         }
     }
 
-    /// <summary>
-    /// Indicates that work is ongoing and the wait period should be extended.
-    /// </summary>
-    /// <param name="opts">Ack options.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the call.</param>
-    /// <returns>A <see cref="ValueTask"/> representing the async call.</returns>
-    /// <remarks>
-    /// <para>
-    /// Time period is defined by the consumer's <c>ack_wait</c> configuration on the server which is
-    /// defined as how long to allow messages to remain un-acknowledged before attempting redelivery.
-    /// </para>
-    /// <para>
-    /// This message must be sent before the <c>ack_wait</c> period elapses. The period should be extended
-    /// by another amount of time equal to <c>ack_wait</c> by the NATS JetStream server.
-    /// </para>
-    /// </remarks>
-    public ValueTask AckProgressAsync(AckOpts? opts = default, CancellationToken cancellationToken = default) => SendAckAsync(NatsJSConstants.AckProgress, opts, cancellationToken);
+    /// <inheritdoc />
+    public ValueTask AckProgressAsync(AckOpts? opts = null, CancellationToken cancellationToken = default) => SendAckAsync(NatsJSConstants.AckProgress, opts, cancellationToken);
 
-    /// <summary>
-    /// Instructs the server to stop redelivery of the message without acknowledging it as successfully processed.
-    /// </summary>
-    /// <param name="opts">Ack options.</param>
-    /// <param name="reason">Optional reason for termination, included in JetStream advisory events. Requires NATS Server 2.10.4+.</param>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the call.</param>
-    /// <returns>A <see cref="ValueTask"/> representing the async call.</returns>
-    public ValueTask AckTerminateAsync(AckOpts? opts = default, string? reason = null, CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public ValueTask AckTerminateAsync(AckOpts? opts = null, CancellationToken cancellationToken = default)
+        => AckTerminateInternalAsync(opts, null, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask AckTerminateAsync(string reason, AckOpts? opts = null, CancellationToken cancellationToken = default)
+        => AckTerminateInternalAsync(opts, reason, cancellationToken);
+
+    private ValueTask AckTerminateInternalAsync(AckOpts? opts, string? reason, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(reason))
         {
@@ -283,13 +231,13 @@ public readonly struct NatsJSMsg<T> : INatsJSMsg<T>
     private async ValueTask AckTerminateWithReasonAsync(string reason, AckOpts? opts, CancellationToken cancellationToken)
     {
         var reasonByteCount = Encoding.ASCII.GetByteCount(reason);
-        var totalLength = 6 + reasonByteCount; // "+TERM " is 6 bytes
+        var totalLength = 6 + reasonByteCount; // `+TERM ` is 6 bytes
 
         var buffer = ArrayPool<byte>.Shared.Rent(totalLength);
         try
         {
 #if NETSTANDARD2_0
-            Buffer.BlockCopy(TermPrefix, 0, buffer, 0, 6);
+            Buffer.BlockCopy(NatsJSMsgConstants.TermPrefix, 0, buffer, 0, 6);
             Encoding.ASCII.GetBytes(reason, 0, reason.Length, buffer, 6);
 #else
             "+TERM "u8.CopyTo(buffer.AsSpan());
@@ -304,7 +252,7 @@ public readonly struct NatsJSMsg<T> : INatsJSMsg<T>
         }
     }
 
-    private async ValueTask SendAckAsync(ReadOnlySequence<byte> payload, AckOpts? opts = default, CancellationToken cancellationToken = default)
+    private async ValueTask SendAckAsync(ReadOnlySequence<byte> payload, AckOpts? opts = null, CancellationToken cancellationToken = default)
     {
         CheckPreconditions();
 
@@ -336,7 +284,7 @@ public readonly struct NatsJSMsg<T> : INatsJSMsg<T>
     [MemberNotNull(nameof(ReplyTo))]
     private void CheckPreconditions()
     {
-        if (Connection == default)
+        if (Connection == null)
         {
             throw new NatsException("unable to send acknowledgment; message did not originate from a consumer");
         }
@@ -361,3 +309,10 @@ public readonly record struct AckOpts
     /// </summary>
     public bool? DoubleAck { get; init; }
 }
+
+#if NETSTANDARD2_0
+internal static class NatsJSMsgConstants
+{
+    internal static readonly byte[] TermPrefix = "+TERM "u8.ToArray();
+}
+#endif


### PR DESCRIPTION
Add optional `reason` parameter to `AckTerminateAsync` that sends `+TERM <reason>` to the server, matching the Go client's `TermWithReason` functionality.

The reason appears in JetStream advisory events (requires NATS Server 2.10.4+).

Low-allocation implementation using `ArrayPool<byte>` with platform-specific optimizations for netstandard2.0 vs newer targets.

⚠️ This is a breaking change for applications implementing `INatsJSMsg<T>`

I only expect tests would break and can be detected and fairly easily fixed during build. However, if applications are using their own implementations of `INatsJSMsg<T>` they will break during build too but more severely if they are transitive dependencies using an earlier version of `NATS.Client.JetStream` they would fail at runtime.

### Interface `INatsJSMsg<T>` Changes

| Change | Binary Compatible | Source Compatible |
|--------|:-----------------:|:-----------------:|
| `default` → `null` on `ReplyAsync` params | ✅ Yes | ✅ Yes |
| `default` → `null` on `AckAsync` param | ✅ Yes | ✅ Yes |
| `default` → `null` on `NakAsync` param | ✅ Yes | ✅ Yes |
| `default` → `null` on `AckProgressAsync` param | ✅ Yes | ✅ Yes |
| `default` → `null` on `AckTerminateAsync` param | ✅ Yes | ✅ Yes |
| **New method `AckTerminateAsync(string reason, ...)`** | ❌ **No** | ❌ **No** |

---

### Struct `NatsJSMsg<T>` Changes

| Change | Binary Compatible | Source Compatible |
|--------|:-----------------:|:-----------------:|
| `default` → `null` on all method params | ✅ Yes | ✅ Yes |
| New overload `AckTerminateAsync(string reason, ...)` | ✅ Yes | ✅ Yes |
| `delay == default` → `delay == TimeSpan.Zero` | ✅ Yes | ✅ Yes |
| `Connection == default` → `Connection == null` | ✅ Yes | ✅ Yes |
| Doc comments → `<inheritdoc />` | ✅ Yes | ✅ Yes |
| Internal `NatsJSMsgConstants` class | ✅ Yes | ✅ Yes |

---

### Final Verdict

| Usage Pattern | Safe to Ship? |
|---------------|:-------------:|
| Applications using `NatsJSMsg<T>` directly | ✅ **Yes** |
| Applications calling methods via `INatsJSMsg<T>` | ✅ **Yes** |
| Applications/libraries implementing `INatsJSMsg<T>` | ❌ **No** |

---

### Breaking Change Details

**What breaks:**

```csharp
// Any type implementing INatsJSMsg<T> - e.g., user mocks for testing
public class MockJSMsg<T> : INatsJSMsg<T>
{
    // Must now implement:
    // ValueTask AckTerminateAsync(string reason, AckOpts? opts, CancellationToken ct)
}
```

**How it breaks:**

Scenario: Source break
Failure Mode: Compilation error when updating package and recompiling

Scenario: Binary break
Failure Mode: TypeLoadException at runtime if old compiled mock is loaded with new library version (transitive dependency scenario)

Who is affected:

- Users who created test doubles/mocks of INatsJSMsg<T>
- Libraries that expose their own implementations of INatsJSMsg<T>

Who is NOT affected:

- Users who only consume messages (vast majority)
- Users who only use the concrete NatsJSMsg<T> struct

---

**Risk Assessment**

Factor: Likelihood of user interface implementations
Assessment: Medium - Interface docs explicitly mention "creating test doubles in unit testing"

Factor: Severity of break
Assessment: High - TypeLoadException crashes app at startup

Factor: Detectability
Assessment: Low for transitive - User may not know they have a dependency with an implementation

Factor: SemVer classification
Assessment: Breaking change - requires major version bump per SemVer

---

**Conclusion**

The current implementation is a breaking change.

It will cause TypeLoadException at runtime for any code that implements INatsJSMsg<T>, including through transitive dependency updates where the user never modified their own code.