### PR TITLE
FIXED unobserved exceptions surfacing due to unobserved tcs.

### DIFF
--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -298,8 +298,8 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
             catch (SocketClosedException e)
             {
                 _logger.LogDebug(NatsLogEvents.Protocol, e, "Socket closed during read loop");
-                _waitForInfoSignal.TrySetException(e);
-                _waitForPongOrErrorSignal.TrySetException(e);
+                _waitForInfoSignal.TrySetObservedException(e);
+                _waitForPongOrErrorSignal.TrySetObservedException(e);
                 return;
             }
             catch (Exception ex)
@@ -379,14 +379,14 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
                 var newPosition = newBuffer.PositionOf((byte)'\n');
                 var error = ParseError(newBuffer.Slice(0, newBuffer.GetOffset(newPosition!.Value) - 1));
                 _logger.LogError(NatsLogEvents.Protocol, "Server error {Error}", error);
-                _waitForPongOrErrorSignal.TrySetException(new NatsServerException(error));
+                _waitForPongOrErrorSignal.TrySetObservedException(new NatsServerException(error));
                 return newBuffer.Slice(newBuffer.GetPosition(1, newPosition!.Value));
             }
             else
             {
                 var error = ParseError(buffer.Slice(0, buffer.GetOffset(position.Value) - 1));
                 _logger.LogError(NatsLogEvents.Protocol, "Server error {Error}", error);
-                _waitForPongOrErrorSignal.TrySetException(new NatsServerException(error));
+                _waitForPongOrErrorSignal.TrySetObservedException(new NatsServerException(error));
                 return buffer.Slice(buffer.GetPosition(1, position.Value));
             }
         }

--- a/src/NATS.Client.Core/Internal/SocketConnectionWrapper.cs
+++ b/src/NATS.Client.Core/Internal/SocketConnectionWrapper.cs
@@ -20,7 +20,7 @@ internal record SocketConnectionWrapper(INatsSocketConnection InnerSocket) : INa
         _sem.Wait();
         try
         {
-            _waitForClosedSource.TrySetException(exception);
+            _waitForClosedSource.TrySetObservedException(exception);
         }
         finally
         {

--- a/src/NATS.Client.Core/Internal/TaskCompletionSourceExtensions.cs
+++ b/src/NATS.Client.Core/Internal/TaskCompletionSourceExtensions.cs
@@ -1,0 +1,22 @@
+namespace NATS.Client.Core.Internal;
+
+internal static class TaskCompletionSourceExtensions
+{
+    /// <summary>
+    /// Sets an exception on the task completion source and immediately observes it to avoid unobserved task exceptions surfacing.
+    /// </summary>
+    /// <param name="source">The task completion source.</param>
+    /// <param name="ex">The exception to set and observe.</param>
+    /// <returns>True if the exception was successfully set, otherwise false</returns>
+    internal static bool TrySetObservedException(this TaskCompletionSource source, Exception ex)
+    {
+        var result = source.TrySetException(ex);
+
+        if (result)
+        {
+            _ = source.Task.Exception;
+        }
+
+        return result;
+    }
+}

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -407,13 +407,7 @@ public partial class NatsConnection : INatsConnection
                 ConnectionState = NatsConnectionState.Closed; // allow retry connect
 
                 // throw for the waiter
-                if (_waitForOpenConnection.TrySetException(exception))
-                {
-                    // Suppress unobserved exceptions as the exceptions will surface elsewhere,
-                    // the exception is thrown below as well.
-                    _ = _waitForOpenConnection.Task.Exception;
-                }
-
+                _waitForOpenConnection.TrySetObservedException(exception);
                 _waitForOpenConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
@@ -435,13 +429,7 @@ public partial class NatsConnection : INatsConnection
                 ConnectionState = NatsConnectionState.Closed; // allow retry connect
 
                 // throw for the waiter
-                if (_waitForOpenConnection.TrySetException(exception))
-                {
-                    // Suppress unobserved exceptions as the exceptions will surface elsewhere,
-                    // the exception is thrown below as well.
-                    _ = _waitForOpenConnection.Task.Exception;
-                }
-
+                _waitForOpenConnection.TrySetObservedException(exception);
                 _waitForOpenConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             }
 
@@ -788,7 +776,7 @@ public partial class NatsConnection : INatsConnection
         }
         catch (Exception ex)
         {
-            _waitForOpenConnection.TrySetException(ex);
+            _waitForOpenConnection.TrySetObservedException(ex);
             try
             {
                 if (!IsDisposed)

--- a/tests/NATS.Client.Core.Tests/ProtocolTest.cs
+++ b/tests/NATS.Client.Core.Tests/ProtocolTest.cs
@@ -21,7 +21,7 @@ public class ProtocolTest
 
         var signal = new WaitSignal();
         var counts = 0;
-        _ = Task.Run(
+        var subscribeTask = Task.Run(
             async () =>
             {
                 var count = 0;
@@ -52,7 +52,7 @@ public class ProtocolTest
 
         var r = 0;
         var payload = new byte[size];
-        _ = Task.Run(
+        var publishTask = Task.Run(
             async () =>
             {
                 while (!cts.Token.IsCancellationRequested)
@@ -94,6 +94,10 @@ public class ProtocolTest
 
             await Retry.Until("subject count goes up", () => Volatile.Read(ref counts) > subjectCount, timeout: TimeSpan.FromSeconds(60));
         }
+
+        cts.Cancel();
+        await subscribeTask;
+        await publishTask;
 
         foreach (var log in logger.Logs.Where(x => x.EventId == NatsLogEvents.Protocol && x.LogLevel == LogLevel.Error))
         {

--- a/tests/NATS.Client.CoreUnit.Tests/SocketConnectionWrapperTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/SocketConnectionWrapperTests.cs
@@ -1,0 +1,40 @@
+namespace NATS.Client.CoreUnit.Tests;
+
+public class SocketConnectionWrapperTests
+{
+    [Fact]
+    public async Task SignalDisconnected_DoesNotCause_UnobservedException()
+    {
+        // Arrange
+        var exceptionThrown = false;
+        var socketConnection = new FakeSocketConnection();
+        var socket = new SocketConnectionWrapper(socketConnection);
+
+        // Act
+        TaskScheduler.UnobservedTaskException += (_, _) =>
+        {
+            exceptionThrown = true;
+        };
+
+        socket.SignalDisconnected(new Exception("test"));
+        await socket.DisposeAsync();
+        socket = null;
+
+        await Task.Delay(100);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        // Assert
+        Assert.False(exceptionThrown);
+    }
+
+    internal class FakeSocketConnection : INatsSocketConnection
+    {
+        public ValueTask DisposeAsync() => default;
+
+        public ValueTask<int> ReceiveAsync(Memory<byte> buffer) => throw new NotImplementedException();
+
+        public ValueTask<int> SendAsync(ReadOnlyMemory<byte> buffer) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Resolves #1050 

Fixed unobserved exceptions surfacing from `TaskCompletionSource` objects setting exceptions but not observing them.

The fix includes an extension method `TrySetObservedException` for `TaskCompletionSource` that sets the exception and immediately observes it to avoid any unobserved exceptions. All usages of `TrySetException` has been replaced with `TrySetObservedException`.

Two new tests have been added and one unrelated test has been modified due to it causing unobserved exceptions that are then caught in one of the new tests, causing it to fail. 

My recommendation for the future would be to create a global garbage collection test or similar to ensure no future unobserved exceptions appear throughout the library.