### PR TITLE
Add more tests for JetStream consumer behavior

### DIFF
--- a/tests/NATS.Client.JetStream.Tests/ConsumerConsumeTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerConsumeTest.cs
@@ -794,4 +794,229 @@ public class ConsumerConsumeTest
 
         Assert.Equal(2, messagesReceived);
     }
+
+    [Fact]
+    public async Task Consume_ephemeral_consumer_deleted_on_server_terminates_with_409()
+    {
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var js = nats.CreateJetStreamContext();
+        await js.CreateStreamAsync(new StreamConfig("s1", ["s1.*"]), cts.Token);
+        var consumer = await js.CreateOrUpdateConsumerAsync("s1", new ConsumerConfig("c1") { MemStorage = true }, cts.Token);
+
+        // Publish messages
+        for (var i = 0; i < 5; i++)
+        {
+            var ack = await js.PublishAsync("s1.foo", i, cancellationToken: cts.Token);
+            ack.EnsureSuccess();
+        }
+
+        var firstMessageConsumed = new WaitSignal(TimeSpan.FromSeconds(30));
+        var messagesReceived = 0;
+
+        var consumeTask = Task.Run(async () =>
+        {
+            var opts = new NatsJSConsumeOpts
+            {
+                MaxMsgs = 10,
+                MaxConsecutive503Errors = 3,
+            };
+
+            await foreach (var msg in consumer.ConsumeAsync<int>(opts: opts, cancellationToken: cts.Token))
+            {
+                await msg.AckAsync(cancellationToken: cts.Token);
+                Interlocked.Increment(ref messagesReceived);
+                firstMessageConsumed.Pulse();
+            }
+        });
+
+        // Wait until at least one message is consumed, then delete the consumer
+        await firstMessageConsumed;
+        Assert.True(messagesReceived > 0, "Should have received at least one message before deletion");
+
+        await js.DeleteConsumerAsync("s1", "c1", cts.Token);
+
+        // Server sends 409 Consumer Deleted to the active pull, which is a terminal error
+        var exception = await Assert.ThrowsAnyAsync<NatsJSException>(async () => await consumeTask);
+        Assert.IsType<NatsJSProtocolException>(exception);
+        var protocolException = (NatsJSProtocolException)exception;
+        Assert.Equal(409, protocolException.HeaderCode);
+        Assert.Contains("Consumer Deleted", protocolException.Message);
+    }
+
+    [Fact]
+    public async Task Consume_ephemeral_memstorage_consumer_server_restart_terminates_with_503()
+    {
+        var logger = new InMemoryTestLoggerFactory(LogLevel.Debug);
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logger });
+        await nats.ConnectRetryAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var js = nats.CreateJetStreamContext();
+        await js.CreateStreamAsync(new StreamConfig("s1", ["s1.*"]), cts.Token);
+        var consumer = await js.CreateOrUpdateConsumerAsync("s1", new ConsumerConfig("c1") { MemStorage = true }, cts.Token);
+
+        // Publish messages
+        for (var i = 0; i < 5; i++)
+        {
+            var ack = await js.PublishAsync("s1.foo", i, cancellationToken: cts.Token);
+            ack.EnsureSuccess();
+        }
+
+        var firstMessageConsumed = new WaitSignal(TimeSpan.FromSeconds(30));
+
+        var consumeTask = Task.Run(async () =>
+        {
+            var opts = new NatsJSConsumeOpts
+            {
+                MaxMsgs = 10,
+                MaxConsecutive503Errors = 3,
+                IdleHeartbeat = TimeSpan.FromSeconds(1),
+                Expires = TimeSpan.FromSeconds(2),
+            };
+
+            await foreach (var msg in consumer.ConsumeAsync<int>(opts: opts, cancellationToken: cts.Token))
+            {
+                await msg.AckAsync(cancellationToken: cts.Token);
+                firstMessageConsumed.Pulse();
+            }
+        });
+
+        // Wait until at least one message is consumed, then restart server
+        await firstMessageConsumed;
+
+        await server.RestartAsync();
+
+        // MemStorage consumer vanishes on restart. The server doesn't send 409 because
+        // it doesn't know about the old consumer, so pulls return 503 no responders.
+        var exception = await Assert.ThrowsAnyAsync<NatsJSException>(async () => await consumeTask);
+        Assert.Contains("503", exception.Message);
+
+        // Verify NoResponders log events were accumulated
+        var noResponderLogs = logger.Logs.Count(m => m.EventId == NatsJSLogEvents.NoResponders);
+        Assert.True(noResponderLogs > 0, "Should have logged NoResponders events");
+    }
+
+    [Fact]
+    public async Task Consume_slow_message_processing_does_not_prevent_consumer_deleted_detection()
+    {
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var js = nats.CreateJetStreamContext();
+        await js.CreateStreamAsync(new StreamConfig("s1", ["s1.*"]), cts.Token);
+        var consumer = await js.CreateOrUpdateConsumerAsync("s1", new ConsumerConfig("c1") { MemStorage = true }, cts.Token);
+
+        // Publish messages
+        for (var i = 0; i < 5; i++)
+        {
+            var ack = await js.PublishAsync("s1.foo", i, cancellationToken: cts.Token);
+            ack.EnsureSuccess();
+        }
+
+        var firstMessageReceived = new WaitSignal(TimeSpan.FromSeconds(30));
+        var messagesProcessed = 0;
+
+        var consumeTask = Task.Run(async () =>
+        {
+            var opts = new NatsJSConsumeOpts
+            {
+                MaxMsgs = 10,
+                MaxConsecutive503Errors = 3,
+            };
+
+            await foreach (var msg in consumer.ConsumeAsync<int>(opts: opts, cancellationToken: cts.Token))
+            {
+                firstMessageReceived.Pulse();
+
+                // Simulate slow processing - consumer will be deleted during this delay
+                await Task.Delay(TimeSpan.FromSeconds(5), cts.Token);
+
+                await msg.AckAsync(cancellationToken: cts.Token);
+                Interlocked.Increment(ref messagesProcessed);
+            }
+        });
+
+        // Wait for first message to arrive, then delete consumer during slow processing
+        await firstMessageReceived;
+
+        await js.DeleteConsumerAsync("s1", "c1", cts.Token);
+
+        // ConsumeAsync should still terminate despite slow message processing.
+        // The server sends 409 Consumer Deleted which terminates the channel writer.
+        var exception = await Assert.ThrowsAnyAsync<NatsJSException>(async () => await consumeTask);
+        Assert.IsType<NatsJSProtocolException>(exception);
+        var protocolException = (NatsJSProtocolException)exception;
+        Assert.Equal(409, protocolException.HeaderCode);
+        Assert.Contains("Consumer Deleted", protocolException.Message);
+    }
+
+    [Fact]
+    public async Task Consume_503_counter_accumulates_across_heartbeat_timer_pulls()
+    {
+        var logger = new InMemoryTestLoggerFactory(LogLevel.Debug);
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logger });
+        await nats.ConnectRetryAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var js = nats.CreateJetStreamContext();
+        await js.CreateStreamAsync(new StreamConfig("s1", ["s1.*"]), cts.Token);
+        var consumer = await js.CreateOrUpdateConsumerAsync("s1", new ConsumerConfig("c1") { MemStorage = true }, cts.Token);
+
+        // Publish a message so consume loop starts
+        var ack = await js.PublishAsync("s1.foo", 1, cancellationToken: cts.Token);
+        ack.EnsureSuccess();
+
+        var firstMessageConsumed = new WaitSignal(TimeSpan.FromSeconds(30));
+
+        var consumeTask = Task.Run(async () =>
+        {
+            var opts = new NatsJSConsumeOpts
+            {
+                MaxMsgs = 10,
+                MaxConsecutive503Errors = 5,
+                IdleHeartbeat = TimeSpan.FromSeconds(1),
+                Expires = TimeSpan.FromSeconds(2),
+            };
+
+            await foreach (var msg in consumer.ConsumeAsync<int>(opts: opts, cancellationToken: cts.Token))
+            {
+                await msg.AckAsync(cancellationToken: cts.Token);
+                firstMessageConsumed.Pulse();
+            }
+        });
+
+        // Wait for message to be consumed, then restart server so consumer vanishes
+        // without the server sending a 409 notification
+        await firstMessageConsumed;
+
+        await server.RestartAsync();
+
+        // Heartbeat timer fires repeatedly, generating pull requests that return 503
+        // because the MemStorage consumer no longer exists after restart
+        var exception = await Assert.ThrowsAnyAsync<NatsJSException>(async () => await consumeTask);
+        Assert.Contains("503", exception.Message);
+
+        // Verify that idle timeout events were logged (heartbeat timer callbacks)
+        await Retry.Until(
+            "idle timeout logs present",
+            () => logger.Logs.Count(m => m.EventId == NatsJSLogEvents.IdleTimeout) > 0,
+            retryDelay: TimeSpan.FromMilliseconds(500),
+            timeout: TimeSpan.FromSeconds(10));
+
+        // Verify 503 counter accumulated from timer-originated pulls
+        var noResponderLogs = logger.Logs.Count(m => m.EventId == NatsJSLogEvents.NoResponders);
+        Assert.True(noResponderLogs >= 5, $"Should have accumulated at least 5 NoResponders events, got {noResponderLogs}");
+    }
 }


### PR DESCRIPTION
- Added tests to validate consumer behavior when deleted or restarted:
  * Consume with ephemeral consumer deletion (409 response validation).
  * Handle server restart with memory storage consumer (503 response validation).
  * Managing slow message processing with consumer deletion.
  * Accumulation of 503 errors across heartbeat pulls.
Resolves #933