### PR TITLE
POC: Add .NET 10 Target

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,14 +2,14 @@
     <Import Project="..\Directory.Build.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
         <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
-        
+
         <!-- NuGet Packaging -->
         <Version>$([System.IO.File]::ReadAllText("$(MSBuildThisFileDirectory)..\version.txt"))</Version>
         <PackageVersion>$(Version)</PackageVersion>

--- a/src/NATS.Client.Core/NKeyPair.cs
+++ b/src/NATS.Client.Core/NKeyPair.cs
@@ -384,9 +384,9 @@ internal class Base32
 
     public static byte[] Decode(ReadOnlySpan<char> input)
     {
-        if (input == null || input.Length == 0)
+        if (input.Length == 0)
         {
-            throw new ArgumentNullException(nameof(input));
+            throw new ArgumentException("Input must not be empty.", nameof(input));
         }
 
         // input = input.TrimEnd('='); //remove padding characters

--- a/src/NATS.Client.Core/NaCl/Internal/Ed25519Ref10/open.cs
+++ b/src/NATS.Client.Core/NaCl/Internal/Ed25519Ref10/open.cs
@@ -78,7 +78,7 @@ namespace NATS.Client.Core.NaCl.Internal.Ed25519Ref10
             hasher.Update(sig, sigoffset, 32);
             hasher.Update(pk, pkoffset, 32);
             hasher.Update(m, moffset, mlen);
-            h = hasher.Finalize();
+            h = hasher.FinalizeHash();
 
             ScalarOperations.sc_reduce(h);
 

--- a/src/NATS.Client.Core/NaCl/Internal/Ed25519Ref10/sign.cs
+++ b/src/NATS.Client.Core/NaCl/Internal/Ed25519Ref10/sign.cs
@@ -29,13 +29,13 @@ namespace NATS.Client.Core.NaCl.Internal.Ed25519Ref10
 		    using var hasher = new Sha512();
 			{
                 hasher.Update(sk, skoffset, 32);
-			    az = hasher.Finalize();
+			    az = hasher.FinalizeHash();
 			    ScalarOperations.sc_clamp(az, 0);
 
 			    hasher.Init();
 				hasher.Update(az, 32, 32);
 				hasher.Update(m, moffset, mlen);
-				r = hasher.Finalize();
+				r = hasher.FinalizeHash();
 
 				ScalarOperations.sc_reduce(r);
 				GroupOperations.ge_scalarmult_base(out R, r, 0);
@@ -45,7 +45,7 @@ namespace NATS.Client.Core.NaCl.Internal.Ed25519Ref10
 				hasher.Update(sig, sigoffset, 32);
 				hasher.Update(sk, skoffset + 32, 32);
 				hasher.Update(m, moffset, mlen);
-				hram = hasher.Finalize();
+				hram = hasher.FinalizeHash();
 
 				ScalarOperations.sc_reduce(hram);
 				var s = new byte[32];//todo: remove allocation

--- a/src/NATS.Client.Core/NaCl/Sha512.cs
+++ b/src/NATS.Client.Core/NaCl/Sha512.cs
@@ -51,7 +51,7 @@ namespace NATS.Client.Core.NaCl
         /// Finalizes SHA-512 hashing.
         /// </summary>
         /// <returns>Hash bytes</returns>
-        public byte[] Finalize()
+        public byte[] FinalizeHash()
         {
             _ = _sha512Inner.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
             return _sha512Inner.Hash!;

--- a/src/NATS.Client.Hosting/NATS.Client.Hosting.csproj
+++ b/src/NATS.Client.Hosting/NATS.Client.Hosting.csproj
@@ -6,11 +6,11 @@
     <Description>ASP.NET Core and Generic Host support for NATS.Client.</Description>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0"/>
   </ItemGroup>
 

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NATS.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NATS.Extensions.Microsoft.DependencyInjection.csproj
@@ -6,12 +6,12 @@
         <Description>ASP.NET Core and Generic Host support for NATS.Net.</Description>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+    <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.1" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     </ItemGroup>


### PR DESCRIPTION
**Minimum required changes to add .NET 10 target:**

- [X509Certificate2 constructors obsoleted (SYSLIB0057)](https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0057) — .NET 10 deprecates loading certificates via new
  X509Certificate2(...) and X509Certificate2Collection.Import(...). The replacement is X509CertificateLoader with methods
  like LoadPkcs12(), LoadPkcs12FromFile(), and LoadPkcs12CollectionFromFile().

- [Span null comparison (CA2265)](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2265) — .NET 10 flags comparing Span<T> / ReadOnlySpan<T> to null as an error, since null is
  implicitly converted to Span.Empty, making the check redundant.

- TFM-conditional package references — csproj conditions that matched specific TFMs (e.g. == 'net8.0') didn't account for
  net10.0, causing it to fall through to older package versions missing required APIs (keyed DI services).

TODO:
- [ ] Remove all .NET 6 conditionals
- [ ] Look into using new .NET 10 APIs e.g.
   - [ ] [System.Threading.Lock](https://learn.microsoft.com/en-us/dotnet/api/system.threading.lock?view=net-10.0)
   - [ ] [JsonSerializer.DeserializeAsync(PipeReader)](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonserializer.deserializeasync?view=net-10.0#system-text-json-jsonserializer-deserializeasync(system-io-pipelines-pipereader-system-type-system-text-json-serialization-jsonserializercontext-system-threading-cancellationtoken))
