### PR TITLE
Add scheduled message source support

### DIFF
--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -187,10 +187,15 @@ public partial class NatsJSContext
 
             if (opts.ScheduleTTL != null)
             {
+                if (opts.ScheduleTTL.Value != TimeSpan.MaxValue && opts.ScheduleTTL.Value < TimeSpan.FromSeconds(1))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(opts.ScheduleTTL), "ScheduleTTL must be at least 1 second or TimeSpan.MaxValue.");
+                }
+
                 headers ??= new NatsHeaders();
                 headers["Nats-Schedule-TTL"] = opts.ScheduleTTL == TimeSpan.MaxValue
                     ? "never"
-                    : $"{(int)opts.ScheduleTTL.Value.TotalSeconds:D}s";
+                    : $"{(long)opts.ScheduleTTL.Value.TotalSeconds:D}s";
             }
         }
 
@@ -360,10 +365,15 @@ public partial class NatsJSContext
 
             if (opts.ScheduleTTL != null)
             {
+                if (opts.ScheduleTTL.Value != TimeSpan.MaxValue && opts.ScheduleTTL.Value < TimeSpan.FromSeconds(1))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(opts.ScheduleTTL), "ScheduleTTL must be at least 1 second or TimeSpan.MaxValue.");
+                }
+
                 headers ??= new NatsHeaders();
                 headers["Nats-Schedule-TTL"] = opts.ScheduleTTL == TimeSpan.MaxValue
                     ? "never"
-                    : $"{(int)opts.ScheduleTTL.Value.TotalSeconds:D}s";
+                    : $"{(long)opts.ScheduleTTL.Value.TotalSeconds:D}s";
             }
         }
 

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -166,6 +166,32 @@ public partial class NatsJSContext
                 headers ??= new NatsHeaders();
                 headers["Nats-Expected-Last-Subject-Sequence-Subject"] = opts.ExpectedLastSubjectSequenceSubject;
             }
+
+            if (opts.Schedule != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Schedule"] = opts.Schedule;
+            }
+
+            if (opts.ScheduleTarget != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Schedule-Target"] = opts.ScheduleTarget;
+            }
+
+            if (opts.ScheduleSource != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Schedule-Source"] = opts.ScheduleSource;
+            }
+
+            if (opts.ScheduleTTL != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Schedule-TTL"] = opts.ScheduleTTL == TimeSpan.MaxValue
+                    ? "never"
+                    : $"{(int)opts.ScheduleTTL.Value.TotalSeconds:D}s";
+            }
         }
 
         opts ??= NatsJSPubOpts.Default;
@@ -312,6 +338,32 @@ public partial class NatsJSContext
             {
                 headers ??= new NatsHeaders();
                 headers["Nats-Expected-Last-Subject-Sequence-Subject"] = opts.ExpectedLastSubjectSequenceSubject;
+            }
+
+            if (opts.Schedule != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Schedule"] = opts.Schedule;
+            }
+
+            if (opts.ScheduleTarget != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Schedule-Target"] = opts.ScheduleTarget;
+            }
+
+            if (opts.ScheduleSource != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Schedule-Source"] = opts.ScheduleSource;
+            }
+
+            if (opts.ScheduleTTL != null)
+            {
+                headers ??= new NatsHeaders();
+                headers["Nats-Schedule-TTL"] = opts.ScheduleTTL == TimeSpan.MaxValue
+                    ? "never"
+                    : $"{(int)opts.ScheduleTTL.Value.TotalSeconds:D}s";
             }
         }
 

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -271,6 +271,40 @@ public record NatsJSPubOpts : NatsPubOpts
     /// or use an extension that supports it.
     /// </remarks>
     public int RetryAttempts { get; init; } = 1;
+
+    /// <summary>
+    /// Sets the <c>Nats-Schedule</c> header for scheduling message delivery.
+    /// </summary>
+    /// <remarks>
+    /// Supports cron expressions (e.g. <c>"0 0 * * *"</c>), interval patterns (e.g. <c>"@every 5m"</c>),
+    /// or one-time schedules (e.g. <c>"@at 2024-01-01T00:00:00Z"</c>).
+    /// Requires the stream to have <c>AllowMsgSchedules</c> enabled.
+    /// </remarks>
+    public string? Schedule { get; init; }
+
+    /// <summary>
+    /// Sets the <c>Nats-Schedule-Target</c> header specifying the subject where the scheduled message will be published.
+    /// </summary>
+    public string? ScheduleTarget { get; init; }
+
+    /// <summary>
+    /// Sets the <c>Nats-Schedule-Source</c> header specifying a subject from which to source the last message's data and headers
+    /// when the schedule fires.
+    /// </summary>
+    /// <remarks>
+    /// The source subject must be a literal (no wildcards), and must not match the schedule or target subjects.
+    /// Requires the stream to have <c>AllowMsgSchedules</c> enabled.
+    /// </remarks>
+    public string? ScheduleSource { get; init; }
+
+    /// <summary>
+    /// Sets the <c>Nats-Schedule-TTL</c> header specifying the TTL for messages produced by the schedule.
+    /// </summary>
+    /// <remarks>
+    /// Minimum value is 1 second. Use <see cref="TimeSpan.MaxValue"/> to indicate the message should never expire.
+    /// Requires the stream to have <c>AllowMsgTTL</c> enabled.
+    /// </remarks>
+    public TimeSpan? ScheduleTTL { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
- Add Schedule, ScheduleTarget, ScheduleSource, and ScheduleTTL properties to NatsJSPubOpts for publishing scheduled messages via headers

- Wire schedule headers (Nats-Schedule, Nats-Schedule-Target, Nats-Schedule-Source, Nats-Schedule-TTL) in PublishAsync and PublishConcurrentAsync

- Add integration tests for subject sourcing and invalid source validation