### PR TITLE
Fix code analyzer warning

### DIFF
--- a/src/NATS.Client.Core/NaCl/Internal/Ed25519Ref10/open.cs
+++ b/src/NATS.Client.Core/NaCl/Internal/Ed25519Ref10/open.cs
@@ -78,7 +78,7 @@ namespace NATS.Client.Core.NaCl.Internal.Ed25519Ref10
             hasher.Update(sig, sigoffset, 32);
             hasher.Update(pk, pkoffset, 32);
             hasher.Update(m, moffset, mlen);
-            h = hasher.Finalize();
+            h = hasher.FinalizeHash();
 
             ScalarOperations.sc_reduce(h);
 

--- a/src/NATS.Client.Core/NaCl/Internal/Ed25519Ref10/sign.cs
+++ b/src/NATS.Client.Core/NaCl/Internal/Ed25519Ref10/sign.cs
@@ -29,13 +29,13 @@ namespace NATS.Client.Core.NaCl.Internal.Ed25519Ref10
 		    using var hasher = new Sha512();
 			{
                 hasher.Update(sk, skoffset, 32);
-			    az = hasher.Finalize();
+			    az = hasher.FinalizeHash();
 			    ScalarOperations.sc_clamp(az, 0);
 
 			    hasher.Init();
 				hasher.Update(az, 32, 32);
 				hasher.Update(m, moffset, mlen);
-				r = hasher.Finalize();
+				r = hasher.FinalizeHash();
 
 				ScalarOperations.sc_reduce(r);
 				GroupOperations.ge_scalarmult_base(out R, r, 0);
@@ -45,7 +45,7 @@ namespace NATS.Client.Core.NaCl.Internal.Ed25519Ref10
 				hasher.Update(sig, sigoffset, 32);
 				hasher.Update(sk, skoffset + 32, 32);
 				hasher.Update(m, moffset, mlen);
-				hram = hasher.Finalize();
+				hram = hasher.FinalizeHash();
 
 				ScalarOperations.sc_reduce(hram);
 				var s = new byte[32];//todo: remove allocation

--- a/src/NATS.Client.Core/NaCl/Sha512.cs
+++ b/src/NATS.Client.Core/NaCl/Sha512.cs
@@ -51,7 +51,7 @@ namespace NATS.Client.Core.NaCl
         /// Finalizes SHA-512 hashing.
         /// </summary>
         /// <returns>Hash bytes</returns>
-        public byte[] Finalize()
+        public byte[] FinalizeHash()
         {
             _ = _sha512Inner.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
             return _sha512Inner.Hash!;


### PR DESCRIPTION
Code analyzers flagging the use of '`Finalize`' as method name. Renamed to '`FinalizeHash`' to avoid confusion.

This is an internal method.