### PR TITLE
Fix OTel network telemetry tags

### DIFF
--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -52,7 +52,7 @@ internal static class Telemetry
             tags[4] = new KeyValuePair<string, object?>(Constants.ServerAddress, conn.ServerInfo.Host);
             tags[5] = new KeyValuePair<string, object?>(Constants.ServerPort, serverPort);
             tags[6] = new KeyValuePair<string, object?>(Constants.NetworkProtoName, "nats");
-            tags[7] = new KeyValuePair<string, object?>(Constants.NetworkProtoVersion, conn.ServerInfo.ProtocolVersion.ToString());
+            tags[7] = new KeyValuePair<string, object?>(Constants.NetworkTransport, "tcp");
             tags[8] = new KeyValuePair<string, object?>(Constants.NetworkPeerAddress, conn.ServerInfo.Host);
             tags[9] = new KeyValuePair<string, object?>(Constants.NetworkPeerPort, serverPort);
             tags[10] = new KeyValuePair<string, object?>(Constants.NetworkLocalAddress, conn.ServerInfo.ClientIp);
@@ -167,7 +167,7 @@ internal static class Telemetry
             tags[10] = new KeyValuePair<string, object?>(Constants.ServerAddress, conn.ServerInfo.Host);
             tags[11] = new KeyValuePair<string, object?>(Constants.ServerPort, serverPort);
             tags[12] = new KeyValuePair<string, object?>(Constants.NetworkProtoName, "nats");
-            tags[13] = new KeyValuePair<string, object?>(Constants.NetworkProtoVersion, conn.ServerInfo.ProtocolVersion.ToString());
+            tags[13] = new KeyValuePair<string, object?>(Constants.NetworkTransport, "tcp");
             tags[14] = new KeyValuePair<string, object?>(Constants.NetworkPeerAddress, conn.ServerInfo.Host);
             tags[15] = new KeyValuePair<string, object?>(Constants.NetworkPeerPort, serverPort);
             tags[16] = new KeyValuePair<string, object?>(Constants.NetworkLocalAddress, conn.ServerInfo.ClientIp);
@@ -323,7 +323,7 @@ internal static class Telemetry
         public const string ServerAddress = "server.address";
         public const string ServerPort = "server.port";
         public const string NetworkProtoName = "network.protocol.name";
-        public const string NetworkProtoVersion = "network.protocol.version";
+        public const string NetworkTransport = "network.transport";
         public const string NetworkPeerAddress = "network.peer.address";
         public const string NetworkPeerPort = "network.peer.port";
         public const string NetworkLocalAddress = "network.local.address";

--- a/tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs
+++ b/tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs
@@ -1,0 +1,115 @@
+// ReSharper disable SuggestVarOrType_SimpleTypes
+// ReSharper disable SuggestVarOrType_Elsewhere
+#pragma warning disable SA1123
+#pragma warning disable SA1124
+#pragma warning disable SA1509
+#pragma warning disable IDE0007
+#pragma warning disable IDE0008
+
+using System.Diagnostics;
+using NATS.Client.Core;
+
+namespace NATS.Net.DocsExamples.Advanced;
+
+public class OpenTelemetryPage
+{
+    public async Task Run()
+    {
+        Console.WriteLine("____________________________________________________________");
+        Console.WriteLine("NATS.Net.DocsExamples.Advanced.OpenTelemetryPage");
+
+        {
+            #region setup
+            // The NATS.Net client uses System.Diagnostics.Activity for tracing.
+            // No additional packages are needed to enable tracing — just add an
+            // ActivityListener or configure an OpenTelemetry TracerProvider that
+            // listens to the "NATS.Net" source.
+
+            // Using OpenTelemetry SDK (install OpenTelemetry and an exporter):
+            //
+            //   using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            //       .AddSource("NATS.Net")         // listen for NATS activities
+            //       .AddSource("MyApp")             // listen for your own activities
+            //       .AddOtlpExporter()              // export to Jaeger, Zipkin, etc.
+            //       .Build();
+
+            // Or using a plain ActivityListener (no extra packages):
+            using ActivityListener listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == "NATS.Net",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = activity =>
+                    Console.WriteLine($"Started: {activity.OperationName}"),
+                ActivityStopped = activity =>
+                    Console.WriteLine($"Stopped: {activity.OperationName}"),
+            };
+            ActivitySource.AddActivityListener(listener);
+            #endregion
+        }
+
+        {
+            #region publish-subscribe
+            await using NatsConnection nats = new NatsConnection();
+
+            // Publish and subscribe — activities are created automatically
+            await using var sub = await nats.SubscribeCoreAsync<string>("orders.new");
+            await nats.PublishAsync("orders.new", "order-123");
+
+            // The message carries trace context in its headers, so the
+            // receive activity is automatically linked to the send activity.
+            await foreach (NatsMsg<string> msg in sub.Msgs.ReadAllAsync())
+            {
+                Console.WriteLine($"Received: {msg.Data}");
+                break;
+            }
+            #endregion
+        }
+
+        {
+            #region custom-activity
+            await using NatsConnection nats = new NatsConnection();
+
+            await using var sub = await nats.SubscribeCoreAsync<string>("work.items");
+            await nats.PublishAsync("work.items", "item-456");
+
+            await foreach (NatsMsg<string> msg in sub.Msgs.ReadAllAsync())
+            {
+                // Start a child activity under the message's trace context
+                using Activity? activity = msg.StartActivity("ProcessWorkItem");
+
+                // The activity is linked to the original publish span
+                Console.WriteLine($"Processing: {msg.Data}");
+                break;
+            }
+            #endregion
+        }
+
+        {
+            #region filter
+            // Filter lets you skip telemetry for specific subjects
+            NatsInstrumentationOptions.Default.Filter = context =>
+            {
+                // Skip internal/health-check subjects
+                if (context.Subject.StartsWith("_INBOX."))
+                    return false;
+
+                return true;
+            };
+            #endregion
+        }
+
+        {
+            #region enrich
+            // Enrich lets you add custom tags to every activity
+            NatsInstrumentationOptions.Default.Enrich = (activity, context) =>
+            {
+                activity.SetTag("app.environment", "production");
+
+                if (context.QueueGroup is not null)
+                    activity.SetTag("app.queue_group", context.QueueGroup);
+            };
+            #endregion
+        }
+    }
+}

--- a/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
@@ -128,6 +128,14 @@ public class OpenTelemetryTest
         AssertStringTagNotNullOrEmpty(sendActivity, "network.peer.address");
         AssertStringTagNotNullOrEmpty(sendActivity, "network.local.address");
         AssertStringTagNotNullOrEmpty(sendActivity, "server.address");
+
+        // Verify network.transport is set on both activities
+        Assert.Equal("tcp", sendActivity.GetTagItem("network.transport") as string);
+        Assert.Equal("tcp", receiveActivity.GetTagItem("network.transport") as string);
+
+        // Verify network.protocol.version is no longer present
+        Assert.Null(sendActivity.GetTagItem("network.protocol.version"));
+        Assert.Null(receiveActivity.GetTagItem("network.protocol.version"));
     }
 
     private void AssertStringTagNotNullOrEmpty(Activity activity, string name)

--- a/tools/site_src/documentation/advanced/intro.md
+++ b/tools/site_src/documentation/advanced/intro.md
@@ -95,5 +95,6 @@ essentially sent back to back after they're picked up from internal queues and b
 - [Slow Consumers](slow-consumers.md) explains how to detect and handle subscribers that can't keep up with the message rate, including the `MessageDropped` and `SlowConsumerDetected` events.
 - [Serialization](serialization.md) is the process of converting an object into a format that can be stored or transmitted.
 - [Security](security.md) is an important aspect of any distributed system. NATS provides a number of security features to help you secure your applications.
+- [OpenTelemetry](opentelemetry.md) covers built-in distributed tracing with automatic trace context propagation, activity filtering, and enrichment.
 - [AOT Deployment](aot.md) is a way to deploy your applications as native platform executables, which produces faster startup times and better performance in most cases.
 - [Platform Compatibility](platform-compatibility.md) documents API differences across target frameworks (.NET Standard, .NET 6, .NET 8).

--- a/tools/site_src/documentation/advanced/opentelemetry.md
+++ b/tools/site_src/documentation/advanced/opentelemetry.md
@@ -1,0 +1,74 @@
+# OpenTelemetry
+
+NATS.Net has built-in distributed tracing support using [`System.Diagnostics.Activity`](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity),
+the standard .NET API for OpenTelemetry. Activities are created automatically for publish and subscribe operations,
+and trace context is propagated through message headers so that send and receive spans are linked across services.
+
+The activity source name is `NATS.Net`.
+
+## Setting Up Tracing
+
+To collect traces, register a listener for the `NATS.Net` activity source. You can use the OpenTelemetry SDK
+with an exporter (Jaeger, Zipkin, OTLP, etc.) or a plain `ActivityListener` for lightweight scenarios:
+
+[!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs#setup)]
+
+## Automatic Trace Context Propagation
+
+When you publish a message, the client injects the current trace context into the message headers.
+When a subscriber reads the message, the receive activity is automatically parented to the send activity,
+giving you end-to-end traces across services with no extra code:
+
+[!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs#publish-subscribe)]
+
+## Starting Custom Activities
+
+You can start child activities under a message's trace context using the `StartActivity` extension method.
+This is useful for tracking processing work that happens after a message is received:
+
+[!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs#custom-activity)]
+
+The `StartActivity` method is available on both [`NatsMsg<T>`](xref:NATS.Client.Core.NatsMsgTelemetryExtensions)
+and [`INatsJSMsg<T>`](xref:NATS.Client.JetStream.NatsJSTelemetryExtensions) for JetStream messages.
+
+## Filtering
+
+Use [`NatsInstrumentationOptions.Default.Filter`](xref:NATS.Client.Core.NatsInstrumentationOptions) to skip
+telemetry for specific requests. When the filter returns `false`, no activity is created:
+
+[!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs#filter)]
+
+## Enriching Activities
+
+Use [`NatsInstrumentationOptions.Default.Enrich`](xref:NATS.Client.Core.NatsInstrumentationOptions) to add
+custom tags to every activity:
+
+[!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs#enrich)]
+
+## Semantic Conventions
+
+NATS.Net follows the [OpenTelemetry Semantic Conventions for Messaging](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/).
+The following attributes are set on activities:
+
+| Attribute | Example | Description |
+|---|---|---|
+| `messaging.system` | `nats` | Always `nats` |
+| `messaging.operation` | `publish` / `receive` | Operation type |
+| `messaging.destination.name` | `orders.new` | Subject name |
+| `messaging.client_id` | `42` | NATS client ID |
+| `server.address` | `localhost` | Server host |
+| `server.port` | `4222` | Server port |
+| `network.protocol.name` | `nats` | Protocol name |
+| `network.transport` | `tcp` | Transport protocol |
+| `network.peer.address` | `localhost` | Remote host |
+| `network.peer.port` | `4222` | Remote port |
+| `network.local.address` | `127.0.0.1` | Local IP |
+
+Receive activities include additional attributes:
+
+| Attribute | Example | Description |
+|---|---|---|
+| `messaging.destination.template` | `orders.*` | Subscription subject pattern |
+| `messaging.message.body.size` | `1024` | Message body size in bytes |
+| `messaging.message.envelope.size` | `1280` | Total message size in bytes |
+| `messaging.consumer.group.name` | `workers` | Queue group (if used) |

--- a/tools/site_src/documentation/toc.yml
+++ b/tools/site_src/documentation/toc.yml
@@ -44,6 +44,8 @@
       href: advanced/security.md
     - name: AOT Deployments
       href: advanced/aot.md
+    - name: OpenTelemetry
+      href: advanced/opentelemetry.md
     - name: Platform Compatibility
       href: advanced/platform-compatibility.md
 


### PR DESCRIPTION
* Fixes #865

### What changed
- Replaced `network.protocol.version` with `network.transport = "tcp"` in both send and receive activity methods
- Kept `network.protocol.name = "nats"` (already correct)

### Why
The `network.protocol.version` attribute was set to [PROTO](https://github.com/nats-io/nats-server/blob/main/server/const.go#L71-L75), which is the NATS protocol capability level (0 = original, 1 = echo support + extended INFO). While technically a protocol level, the value "1" provides little practical insight in traces since it's the same for all modern NATS servers.

Meanwhile, `network.transport` was not being set at all. Per the [OTel docs](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-transport), `network.transport` is recommended whenever a port number is present — and we already emit `network.peer.port`.

**Attribute**: [`network-protocol-name`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-protocol-name)
Before: `"nats"`
After: `"nats"`
Rationale: Correct — application-layer protocol name

**Attribute**: [`network-protocol-version`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-protocol-version)
Before: `"1"` (proto level)
After: Removed
Rationale: Low-value; [OTel messaging-spans](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/) don't reference this attribute

**Attribute**: [`network-transport`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-transport)
Before: Not set
After: `"tcp"`
Rationale: Spec advises setting transport when a port number is present
[footnote [4] for network-transport](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-transport):
> Consider always setting the transport when setting a port number, since a port number is ambiguous without knowing the transport.