### PR TITLE
Enable subject validation by default

### DIFF
--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -238,19 +238,21 @@ public sealed record NatsOpts
 
     /// <summary>
     /// Gets or sets a value indicating whether to skip subject validation.
-    /// The default is <c>true</c>, meaning subject validation is disabled.
+    /// The default is <c>false</c>, meaning subject validation is enabled.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// When set to <c>true</c> (default), all subject validation is bypassed.
+    /// When set to <c>false</c> (default), subjects are validated to ensure they are not empty
+    /// and don't contain whitespace characters (space, tab, CR, LF). This prevents CRLF
+    /// protocol injection where a subject containing \r\n could inject arbitrary NATS commands.
     /// </para>
     /// <para>
-    /// When set to <c>false</c>, subjects are validated to ensure they are not empty
-    /// and don't contain whitespace characters (space, tab, CR, LF). This can help
-    /// catch invalid subjects early but adds minor overhead.
+    /// When set to <c>true</c>, all subject validation is bypassed for maximum throughput.
+    /// Only use this if you fully control all subject strings and can guarantee they never
+    /// contain whitespace or CRLF sequences.
     /// </para>
     /// </remarks>
-    public bool SkipSubjectValidation { get; init; } = true;
+    public bool SkipSubjectValidation { get; init; } = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether to suppress warning logs when a slow consumer is detected.

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionSubjectValidationTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionSubjectValidationTests.cs
@@ -8,6 +8,13 @@ public class NatsConnectionSubjectValidationTests
 {
     private static readonly NatsOpts OptsWithValidation = new() { SkipSubjectValidation = false };
 
+    // Guard against regression: default opts must have validation enabled
+    [Fact]
+    public void DefaultOpts_HasValidationEnabled()
+    {
+        NatsOpts.Default.SkipSubjectValidation.Should().BeFalse();
+    }
+
     // PublishAsync tests
     [Theory]
     [InlineData("foo bar")]
@@ -150,7 +157,7 @@ public class NatsConnectionSubjectValidationTests
     {
         // SkipSubjectValidation=true bypasses validation at the API level.
         // The call will fail later (e.g., connection timeout) but not due to validation.
-        await using var nats = new NatsConnection(new NatsOpts { SkipSubjectValidation = true });
+        await using var nats = new NatsConnection(NatsOpts.Default with { SkipSubjectValidation = true });
 
         // This should not throw NatsException for invalid subject
         // It will throw something else (timeout, connection error) since we're not connected
@@ -171,7 +178,7 @@ public class NatsConnectionSubjectValidationTests
     public async Task SubscribeAsync_WithSkipValidation_DoesNotThrowOnInvalidSubject(string subject)
     {
         // SkipSubjectValidation=true bypasses validation at the API level.
-        await using var nats = new NatsConnection(new NatsOpts { SkipSubjectValidation = true });
+        await using var nats = new NatsConnection(NatsOpts.Default with { SkipSubjectValidation = true });
 
         // This should not throw NatsException for invalid subject
         Func<Task> action = async () =>

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionSubjectValidationTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionSubjectValidationTests.cs
@@ -142,15 +142,15 @@ public class NatsConnectionSubjectValidationTests
         await action.Should().ThrowAsync<NatsException>().WithMessage("Queue group is invalid.");
     }
 
-    // SkipSubjectValidation option tests (default is true, so validation is skipped by default)
+    // SkipSubjectValidation option tests (default is false, so validation is enabled by default)
     [Theory]
     [InlineData("foo bar")]
     [InlineData("foo\tbar")]
     public async Task PublishAsync_WithSkipValidation_DoesNotThrowOnInvalidSubject(string subject)
     {
-        // Default SkipSubjectValidation=true, validation is bypassed at the API level.
+        // SkipSubjectValidation=true bypasses validation at the API level.
         // The call will fail later (e.g., connection timeout) but not due to validation.
-        await using var nats = new NatsConnection();
+        await using var nats = new NatsConnection(new NatsOpts { SkipSubjectValidation = true });
 
         // This should not throw NatsException for invalid subject
         // It will throw something else (timeout, connection error) since we're not connected
@@ -170,8 +170,8 @@ public class NatsConnectionSubjectValidationTests
     [InlineData("foo\tbar")]
     public async Task SubscribeAsync_WithSkipValidation_DoesNotThrowOnInvalidSubject(string subject)
     {
-        // Default SkipSubjectValidation=true
-        await using var nats = new NatsConnection();
+        // SkipSubjectValidation=true bypasses validation at the API level.
+        await using var nats = new NatsConnection(new NatsOpts { SkipSubjectValidation = true });
 
         // This should not throw NatsException for invalid subject
         Func<Task> action = async () =>


### PR DESCRIPTION
Changes SkipSubjectValidation default from true to false so that subjects are validated out of the box, preventing CRLF protocol injection from malformed subjects. Updates xmldoc to reflect the new default and adds a regression test for the default value.

Breaking change: code that publishes or subscribes with subjects containing whitespace (space, tab, CR, LF) will now throw NatsException. To restore the old behavior, set SkipSubjectValidation = true in NatsOpts.

Test: dotnet test tests/NATS.Client.CoreUnit.Tests -c Release --filter SubjectValidation