### PR TITLE
tls: document Prefer mode plaintext behavior

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
-        with: { cache: true }
+        with:
+          go-version: 'stable'
+          cache: true
 
       - name: Install nats-server
         run: go install github.com/nats-io/nats-server/v2@${{ matrix.config.branch }}

--- a/.github/workflows/test_linux_core.yml
+++ b/.github/workflows/test_linux_core.yml
@@ -25,7 +25,9 @@ jobs:
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
-        with: { cache: true }
+        with:
+          go-version: 'stable'
+          cache: true
 
       - name: Install nats-server
         run: go install github.com/nats-io/nats-server/v2@${{ matrix.config.branch }}

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -40,7 +40,9 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v5
-        with: { cache: true }
+        with:
+          go-version: 'stable'
+          cache: true
 
       - name: Install nats-server
         run: go install github.com/nats-io/nats-server/v2@${{ matrix.config.branch }}

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -72,6 +72,16 @@ public sealed record NatsOpts
 
     public NatsAuthOpts AuthOpts { get; init; } = new();
 
+    /// <summary>
+    /// TLS options for the connection.
+    /// </summary>
+    /// <remarks>
+    /// By default the client attempts a TLS upgrade when the server advertises TLS support.
+    /// If you don't want TLS (e.g. behind a TLS-terminating proxy), set
+    /// <see cref="NatsTlsOpts.Mode"/> to <see cref="TlsMode.Disable"/>.
+    /// </remarks>
+    /// <seealso cref="NatsTlsOpts.Mode"/>
+    /// <seealso cref="TlsMode"/>
     public NatsTlsOpts TlsOpts { get; init; } = new();
 
     public NatsWebSocketOpts WebSocketOpts { get; init; } = new();

--- a/src/NATS.Client.Core/NatsTlsOpts.cs
+++ b/src/NATS.Client.Core/NatsTlsOpts.cs
@@ -18,9 +18,9 @@ public enum TlsMode
     /// For connections that use the "tls://" scheme or supply Client or CA Certificates - same as <see cref="Require"/>.
     /// </summary>
     /// <remarks>
-    /// When this resolves to <see cref="Prefer"/>, TLS is opportunistic and subject to the same
-    /// limitations described in the <see cref="Prefer"/> remarks.
-    /// Use the <c>tls://</c> scheme or set <see cref="Require"/> explicitly when TLS is required for security.
+    /// When this resolves to <see cref="Prefer"/>, TLS is opportunistic: the connection
+    /// may remain plaintext depending on the server's INFO response.
+    /// Use the <c>tls://</c> scheme or set <see cref="Require"/> explicitly when TLS is required.
     /// </remarks>
     Auto,
 
@@ -29,15 +29,12 @@ public enum TlsMode
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This is an opportunistic TLS mode. Whether the server "supports TLS" is determined
-    /// from the server's INFO message, which is received over plaintext TCP before any TLS
-    /// upgrade occurs. A man-in-the-middle attacker on the network could forge the INFO
-    /// message to strip the TLS flags, causing the client to skip TLS and send credentials
-    /// in plaintext. This is inherent to the NATS protocol's connection flow and applies to
-    /// all NATS client implementations.
+    /// This is an opportunistic TLS mode. The TLS decision is based on the server's
+    /// INFO message, which arrives over plaintext before any encryption is established.
+    /// On an untrusted network the connection may remain plaintext.
     /// </para>
     /// <para>
-    /// If TLS is required for security, use the <c>tls://</c> scheme or set <see cref="TlsMode.Require"/> explicitly.
+    /// If TLS is required, use the <c>tls://</c> scheme or set <see cref="TlsMode.Require"/> explicitly.
     /// </para>
     /// </remarks>
     Prefer,
@@ -122,8 +119,8 @@ public sealed record NatsTlsOpts
     /// </summary>
     /// <remarks>
     /// Defaults to <see cref="TlsMode.Auto"/>. When the effective mode is <see cref="TlsMode.Prefer"/>,
-    /// TLS is opportunistic and a network attacker can downgrade the connection to plaintext.
-    /// Use the <c>tls://</c> scheme or <see cref="TlsMode.Require"/> when TLS must be guaranteed.
+    /// TLS is opportunistic and the connection may remain plaintext.
+    /// Use the <c>tls://</c> scheme or <see cref="TlsMode.Require"/> when TLS is required.
     /// </remarks>
     public TlsMode Mode { get; init; }
 

--- a/src/NATS.Client.Core/NatsTlsOpts.cs
+++ b/src/NATS.Client.Core/NatsTlsOpts.cs
@@ -34,6 +34,11 @@ public enum TlsMode
     /// On an untrusted network the connection may remain plaintext.
     /// </para>
     /// <para>
+    /// When connecting directly, this mode upgrades to TLS if the server supports it.
+    /// Behind a TLS-terminating proxy, use <see cref="TlsMode.Disable"/> instead,
+    /// as the client may attempt a TLS upgrade that the nats-server cannot complete.
+    /// </para>
+    /// <para>
     /// If TLS is required, use the <c>tls://</c> scheme or set <see cref="TlsMode.Require"/> explicitly.
     /// </para>
     /// </remarks>
@@ -118,9 +123,17 @@ public sealed record NatsTlsOpts
     /// TLS mode to use during connection.
     /// </summary>
     /// <remarks>
-    /// Defaults to <see cref="TlsMode.Auto"/>. When the effective mode is <see cref="TlsMode.Prefer"/>,
-    /// TLS is opportunistic and the connection may remain plaintext.
+    /// <para>
+    /// Defaults to <see cref="TlsMode.Auto"/>, which resolves to <see cref="TlsMode.Prefer"/>
+    /// for <c>nats://</c> connections without certificates. In this mode the client will
+    /// attempt a TLS upgrade when the server advertises TLS support. This differs from most
+    /// other NATS clients, which do not upgrade unless explicitly configured.
+    /// </para>
+    /// <para>
+    /// Behind a TLS-terminating proxy, use <see cref="TlsMode.Disable"/> to prevent the
+    /// client from attempting a TLS upgrade that the nats-server cannot complete.
     /// Use the <c>tls://</c> scheme or <see cref="TlsMode.Require"/> when TLS is required.
+    /// </para>
     /// </remarks>
     public TlsMode Mode { get; init; }
 

--- a/src/NATS.Client.Core/NatsTlsOpts.cs
+++ b/src/NATS.Client.Core/NatsTlsOpts.cs
@@ -11,6 +11,10 @@ namespace NATS.Client.Core;
 /// <summary>
 /// TLS mode to use during connection.
 /// </summary>
+/// <remarks>
+/// Only <see cref="Require"/> and <see cref="Implicit"/> provide the full protection that TLS can offer.
+/// Other modes may fall back to plaintext depending on server configuration.
+/// </remarks>
 public enum TlsMode
 {
     /// <summary>
@@ -133,6 +137,10 @@ public sealed record NatsTlsOpts
     /// Behind a TLS-terminating proxy, use <see cref="TlsMode.Disable"/> to prevent the
     /// client from attempting a TLS upgrade that the nats-server cannot complete.
     /// Use the <c>tls://</c> scheme or <see cref="TlsMode.Require"/> when TLS is required.
+    /// </para>
+    /// <para>
+    /// Only <see cref="TlsMode.Require"/> and <see cref="TlsMode.Implicit"/> provide the full
+    /// protection that TLS can offer. Other modes may fall back to plaintext depending on server configuration.
     /// </para>
     /// </remarks>
     public TlsMode Mode { get; init; }

--- a/src/NATS.Client.Core/NatsTlsOpts.cs
+++ b/src/NATS.Client.Core/NatsTlsOpts.cs
@@ -14,14 +14,32 @@ namespace NATS.Client.Core;
 public enum TlsMode
 {
     /// <summary>
-    /// For connections that use the "nats://" scheme and don't supply Client or CA Certificates - same as <c>Prefer</c>
-    /// For connections that use the "tls://" scheme or supply Client or CA Certificates - same as <c>Require</c>
+    /// For connections that use the "nats://" scheme and don't supply Client or CA Certificates - same as <see cref="Prefer"/>.
+    /// For connections that use the "tls://" scheme or supply Client or CA Certificates - same as <see cref="Require"/>.
     /// </summary>
+    /// <remarks>
+    /// When this resolves to <see cref="Prefer"/>, TLS is opportunistic and subject to the same
+    /// limitations described in the <see cref="Prefer"/> remarks.
+    /// Use the <c>tls://</c> scheme or set <see cref="Require"/> explicitly when TLS is required for security.
+    /// </remarks>
     Auto,
 
     /// <summary>
-    /// if the Server supports TLS, then use it, otherwise use plain-text.
+    /// If the server supports TLS, then use it; otherwise, use plain-text.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is an opportunistic TLS mode. Whether the server "supports TLS" is determined
+    /// from the server's INFO message, which is received over plaintext TCP before any TLS
+    /// upgrade occurs. A man-in-the-middle attacker on the network could forge the INFO
+    /// message to strip the TLS flags, causing the client to skip TLS and send credentials
+    /// in plaintext. This is inherent to the NATS protocol's connection flow and applies to
+    /// all NATS client implementations.
+    /// </para>
+    /// <para>
+    /// If TLS is required for security, use the <c>tls://</c> scheme or set <see cref="TlsMode.Require"/> explicitly.
+    /// </para>
+    /// </remarks>
     Prefer,
 
     /// <summary>
@@ -99,7 +117,14 @@ public sealed record NatsTlsOpts
     /// <summary>When true, skip remote certificate verification and accept any server certificate</summary>
     public bool InsecureSkipVerify { get; init; }
 
-    /// <summary>TLS mode to use during connection</summary>
+    /// <summary>
+    /// TLS mode to use during connection.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="TlsMode.Auto"/>. When the effective mode is <see cref="TlsMode.Prefer"/>,
+    /// TLS is opportunistic and a network attacker can downgrade the connection to plaintext.
+    /// Use the <c>tls://</c> scheme or <see cref="TlsMode.Require"/> when TLS must be guaranteed.
+    /// </remarks>
     public TlsMode Mode { get; init; }
 
     internal bool HasTlsCerts

--- a/tests/NATS.Client.Core2.Tests/NATS.Client.Core2.Tests.csproj
+++ b/tests/NATS.Client.Core2.Tests/NATS.Client.Core2.Tests.csproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="[7,8)" />
+        <PackageReference Include="Synadia.Orbit.Testing.GoHarness" Version="1.0.0-preview.1" />
         <PackageReference Include="ProcessX" Version="1.5.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="xunit.v3" Version="1.0.1" />

--- a/tests/NATS.Client.Core2.Tests/TlsPreferMitmTest.cs
+++ b/tests/NATS.Client.Core2.Tests/TlsPreferMitmTest.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace NATS.Client.Core.Tests;
+
+/// <summary>
+/// Demonstrates that TlsMode.Prefer (and TlsMode.Auto over nats://) is
+/// susceptible to a MITM downgrade: if an attacker forges the server's
+/// INFO message to strip TLS flags, the client will skip TLS and send
+/// CONNECT (including credentials) in plaintext.
+///
+/// This is by design -- the NATS protocol sends INFO before TLS upgrade,
+/// so every NATS client behaves this way. The mitigation is to use
+/// tls:// or TlsMode.Require when TLS must be guaranteed.
+/// </summary>
+public class TlsPreferMitmTest(ITestOutputHelper output)
+{
+    /// <summary>
+    /// Simulates a MITM that strips tls_available/tls_required from INFO.
+    /// Verifies the client sends CONNECT with credentials over plaintext.
+    /// </summary>
+    [Fact]
+    public async Task Prefer_mode_sends_credentials_in_plaintext_when_info_has_no_tls_flags()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        // Start a fake server that sends INFO with no TLS flags (MITM scenario)
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var connectLine = string.Empty;
+
+        var serverTask = Task.Run(
+            async () =>
+            {
+#if NET6_0_OR_GREATER
+                using var tcp = await listener.AcceptTcpClientAsync(cts.Token);
+#else
+                using var tcp = await listener.AcceptTcpClientAsync();
+#endif
+                var stream = tcp.GetStream();
+
+                // ISO 8859-1 (Latin-1): 1-byte encoding where (int)char == byte, for lossless byte round-tripping
+                var encoding = Encoding.GetEncoding(28591);
+                var sw = new StreamWriter(stream, encoding);
+                var sr = new StreamReader(stream, encoding);
+
+                // MITM-forged INFO: no tls_required, no tls_available
+                await sw.WriteAsync("INFO {\"server_id\":\"mitm\",\"max_payload\":1048576,\"tls_required\":false,\"tls_available\":false}\r\n");
+                await sw.FlushAsync();
+
+                // Read lines until we see CONNECT
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    var line = await sr.ReadLineAsync();
+                    if (line == null)
+                        break;
+
+                    output.WriteLine($"[MITM] RCV: {line}");
+
+                    if (line.StartsWith("CONNECT"))
+                    {
+                        connectLine = line;
+                    }
+                    else if (line.StartsWith("PING"))
+                    {
+                        await sw.WriteAsync("PONG\r\n");
+                        await sw.FlushAsync();
+                        break; // handshake complete
+                    }
+                }
+            },
+            cts.Token);
+
+        // Client with credentials using Prefer mode (same as Auto with nats://)
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = $"nats://127.0.0.1:{port}",
+            AuthOpts = new NatsAuthOpts
+            {
+                Username = "secret_user",
+                Password = "secret_pass",
+            },
+            TlsOpts = new NatsTlsOpts { Mode = TlsMode.Prefer },
+        });
+
+        await nats.ConnectAsync();
+        await serverTask;
+        listener.Stop();
+
+        // The CONNECT line was sent over plaintext and contains credentials
+        connectLine.Should().NotBeEmpty("client should have sent CONNECT");
+        connectLine.Should().Contain("secret_user", "credentials were sent over plaintext");
+        connectLine.Should().Contain("secret_pass", "credentials were sent over plaintext");
+
+        output.WriteLine($"CONNECT sent in plaintext: {connectLine}");
+    }
+
+    /// <summary>
+    /// Verifies that TlsMode.Auto resolves to Prefer for nats:// without certs,
+    /// making it equally susceptible to the same MITM downgrade.
+    /// </summary>
+    [Fact]
+    public void Auto_mode_resolves_to_prefer_for_nats_scheme_without_certs()
+    {
+        var opts = new NatsTlsOpts { Mode = TlsMode.Auto };
+        var uri = new Uri("nats://127.0.0.1:4222");
+
+        var effective = opts.EffectiveMode(uri);
+
+        effective.Should().Be(TlsMode.Prefer, "Auto with nats:// and no certs should resolve to Prefer");
+    }
+
+    /// <summary>
+    /// Verifies that TlsMode.Require refuses to connect when the server
+    /// does not advertise TLS -- the secure alternative to Prefer.
+    /// </summary>
+    [Fact]
+    public async Task Require_mode_throws_when_server_does_not_support_tls()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var serverTask = Task.Run(
+            async () =>
+            {
+#if NET6_0_OR_GREATER
+                using var tcp = await listener.AcceptTcpClientAsync(cts.Token);
+#else
+                using var tcp = await listener.AcceptTcpClientAsync();
+#endif
+                var stream = tcp.GetStream();
+
+                // ISO 8859-1 (Latin-1): 1-byte encoding where (int)char == byte, for lossless byte round-tripping
+                var encoding = Encoding.GetEncoding(28591);
+                var sw = new StreamWriter(stream, encoding);
+
+                // Server with no TLS support
+                await sw.WriteAsync("INFO {\"server_id\":\"notls\",\"max_payload\":1048576,\"tls_required\":false,\"tls_available\":false}\r\n");
+                await sw.FlushAsync();
+
+                // Keep connection open until cancelled
+                try
+                {
+                    await Task.Delay(Timeout.Infinite, cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            },
+            cts.Token);
+
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = $"nats://127.0.0.1:{port}",
+            AuthOpts = new NatsAuthOpts
+            {
+                Username = "secret_user",
+                Password = "secret_pass",
+            },
+            TlsOpts = new NatsTlsOpts { Mode = TlsMode.Require },
+        });
+
+        var act = () => nats.ConnectAsync().AsTask();
+
+        await act.Should().ThrowAsync<NatsException>();
+
+        cts.Cancel();
+        listener.Stop();
+    }
+
+    /// <summary>
+    /// Verifies that tls:// scheme resolves to Require, not Prefer.
+    /// </summary>
+    [Fact]
+    public void Tls_scheme_resolves_to_require()
+    {
+        var opts = new NatsTlsOpts { Mode = TlsMode.Auto };
+        var uri = new Uri("tls://127.0.0.1:4222");
+
+        var effective = opts.EffectiveMode(uri);
+
+        effective.Should().Be(TlsMode.Require, "tls:// scheme should always resolve to Require");
+    }
+}

--- a/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
+++ b/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using Synadia.Orbit.Testing.GoHarness;
+using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.Core.Tests;
 
@@ -182,4 +184,249 @@ public class TlsPreferTest(ITestOutputHelper output)
 
         effective.Should().Be(TlsMode.Require, "tls:// scheme should always resolve to Require");
     }
+
+    /// <summary>
+    /// Replicates nats-io/nats-server#7927: server behind a TLS-terminating proxy
+    /// has tls: {} + allow_non_tls, so INFO advertises tls_available=true.
+    /// Client in Prefer/Auto mode sees tls_available and attempts a TLS upgrade,
+    /// which fails because the server (plain TCP behind the proxy) cannot do TLS.
+    /// </summary>
+    [Fact]
+    public async Task Prefer_mode_attempts_tls_upgrade_when_server_advertises_tls_available()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var clientAttemptedTls = false;
+
+        var serverTask = Task.Run(
+            async () =>
+            {
+#if NET6_0_OR_GREATER
+                using var tcp = await listener.AcceptTcpClientAsync(cts.Token);
+#else
+                using var tcp = await listener.AcceptTcpClientAsync();
+#endif
+                var stream = tcp.GetStream();
+                var encoding = Encoding.GetEncoding(28591);
+                var sw = new StreamWriter(stream, encoding);
+                var sr = new StreamReader(stream, encoding);
+
+                // Server behind TLS proxy: tls_required=false, tls_available=true
+                await sw.WriteAsync("INFO {\"server_id\":\"proxy-backend\",\"max_payload\":1048576,\"tls_required\":false,\"tls_available\":true}\r\n");
+                await sw.FlushAsync();
+
+                // Read whatever the client sends next
+                var line = await sr.ReadLineAsync();
+                output.WriteLine($"[SERVER] RCV: {line}");
+
+                // If the client sent CONNECT, it stayed plaintext (didn't try TLS).
+                // If we get something else or the connection drops, client tried TLS upgrade.
+                if (line == null || !line.StartsWith("CONNECT"))
+                {
+                    clientAttemptedTls = true;
+                }
+            },
+            cts.Token);
+
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = $"nats://127.0.0.1:{port}",
+            TlsOpts = new NatsTlsOpts { Mode = TlsMode.Prefer },
+            MaxReconnectRetry = 0,
+        });
+
+        try
+        {
+            await nats.ConnectAsync();
+        }
+        catch
+        {
+            // Expected: TLS handshake fails because server can't do TLS
+        }
+
+        await serverTask;
+        listener.Stop();
+
+        clientAttemptedTls.Should().BeTrue(
+            "Prefer mode should attempt TLS upgrade when server advertises tls_available=true");
+    }
+
+    /// <summary>
+    /// TlsMode.Disable skips TLS upgrade even when server advertises tls_available=true.
+    /// This is the workaround for the TLS-terminating proxy scenario (nats-io/nats-server#7927).
+    /// </summary>
+    [Fact]
+    public async Task Disable_mode_skips_tls_when_server_advertises_tls_available()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var connectLine = string.Empty;
+
+        var serverTask = Task.Run(
+            async () =>
+            {
+#if NET6_0_OR_GREATER
+                using var tcp = await listener.AcceptTcpClientAsync(cts.Token);
+#else
+                using var tcp = await listener.AcceptTcpClientAsync();
+#endif
+                var stream = tcp.GetStream();
+                var encoding = Encoding.GetEncoding(28591);
+                var sw = new StreamWriter(stream, encoding);
+                var sr = new StreamReader(stream, encoding);
+
+                // Server behind TLS proxy: tls_required=false, tls_available=true
+                await sw.WriteAsync("INFO {\"server_id\":\"proxy-backend\",\"max_payload\":1048576,\"tls_required\":false,\"tls_available\":true}\r\n");
+                await sw.FlushAsync();
+
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    var line = await sr.ReadLineAsync();
+                    if (line == null)
+                        break;
+
+                    output.WriteLine($"[SERVER] RCV: {line}");
+
+                    if (line.StartsWith("CONNECT"))
+                    {
+                        connectLine = line;
+                    }
+                    else if (line.StartsWith("PING"))
+                    {
+                        await sw.WriteAsync("PONG\r\n");
+                        await sw.FlushAsync();
+                        break;
+                    }
+                }
+            },
+            cts.Token);
+
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = $"nats://127.0.0.1:{port}",
+            TlsOpts = new NatsTlsOpts { Mode = TlsMode.Disable },
+        });
+
+        await nats.ConnectAsync();
+        await serverTask;
+        listener.Stop();
+
+        connectLine.Should().NotBeEmpty("client should have sent CONNECT in plaintext");
+        output.WriteLine($"Disable mode connected in plaintext: {connectLine}");
+    }
+
+    /// <summary>
+    /// Real nats-server with tls: {} + allow_non_tls (nats-io/nats-server#7927 scenario).
+    /// .NET client in Prefer mode attempts TLS upgrade and succeeds because the server
+    /// can actually do TLS. Disable mode stays plaintext.
+    /// </summary>
+    [Fact]
+    public async Task Real_server_tls_available_prefer_upgrades_disable_stays_plaintext()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var conf = Path.GetFullPath("tls_available_test.conf");
+        var confContents = """
+            tls {}
+            allow_non_tls: true
+            """;
+        File.WriteAllText(conf, confContents);
+
+        await using var server = await NatsServerProcess.StartAsync(config: conf);
+        output.WriteLine($"Server started at {server.Url}");
+
+        // Prefer mode: attempts TLS upgrade, fails because the auto-generated
+        // server cert can't complete the handshake. This is the issue scenario.
+        await using var natsPrefer = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            TlsOpts = new NatsTlsOpts { Mode = TlsMode.Prefer },
+            MaxReconnectRetry = 0,
+        });
+
+        var act = () => natsPrefer.ConnectAsync().AsTask();
+        await act.Should().ThrowAsync<Exception>("Prefer mode tries TLS upgrade which fails");
+        output.WriteLine("Prefer mode: failed as expected (tried TLS upgrade)");
+
+        // Disable mode: skips TLS, stays plaintext, connects fine
+        await using var natsDisable = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            TlsOpts = new NatsTlsOpts { Mode = TlsMode.Disable },
+        });
+
+        await natsDisable.ConnectAsync();
+        await natsDisable.PingAsync(cts.Token);
+        output.WriteLine("Disable mode: connected in plaintext");
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Go client against real nats-server with tls_available=true.
+    /// Go ignores tls_available and connects plaintext without Secure() option.
+    /// </summary>
+    [Fact]
+    public async Task Real_server_tls_available_go_client_stays_plaintext()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        var conf = Path.GetFullPath("tls_available_go_test.conf");
+        var confContents = """
+            tls {}
+            allow_non_tls: true
+            """;
+        File.WriteAllText(conf, confContents);
+
+        await using var server = await NatsServerProcess.StartAsync(config: conf);
+        output.WriteLine($"Server started at {server.Url}");
+
+        // lang=go
+        var goCode = $$"""
+            package main
+
+            import (
+                "fmt"
+                "os"
+
+                "github.com/nats-io/nats.go"
+            )
+
+            func main() {
+                // Plain nats:// without Secure() -- should connect in plaintext
+                nc, err := nats.Connect("{{server.Url}}",
+                    nats.MaxReconnects(0),
+                )
+                if err != nil {
+                    fmt.Fprintf(os.Stderr, "connect error: %v\n", err)
+                    fmt.Println("CONNECT_FAILED")
+                    os.Exit(1)
+                }
+
+                fmt.Println("CONNECTED_PLAINTEXT")
+                nc.Close()
+            }
+            """;
+
+        await using var go = await GoProcess.RunCodeAsync(
+            goCode,
+            logger: m => output.WriteLine($"[GO] {m}"),
+            goModules: ["github.com/nats-io/nats.go@latest"],
+            cancellationToken: cts.Token);
+
+        var line = await go.ReadLineAsync(cts.Token);
+        output.WriteLine($"Go output: {line}");
+
+        await go.WaitForExitAsync(cts.Token);
+        go.ExitCode.Should().Be(0, "Go client should connect successfully");
+        line.Should().Be("CONNECTED_PLAINTEXT", "Go client should connect in plaintext despite tls_available=true");
+    }
+#endif
 }

--- a/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
+++ b/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
@@ -376,7 +376,7 @@ public class TlsPreferTest(ITestOutputHelper output)
     [Fact]
     public async Task Real_server_tls_available_go_client_stays_plaintext()
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(180));
 
         var conf = Path.GetFullPath("tls_available_go_test.conf");
         var confContents = """

--- a/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
+++ b/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
@@ -5,20 +5,16 @@ using System.Text;
 namespace NATS.Client.Core.Tests;
 
 /// <summary>
-/// Demonstrates that TlsMode.Prefer (and TlsMode.Auto over nats://) is
-/// susceptible to a MITM downgrade: if an attacker forges the server's
-/// INFO message to strip TLS flags, the client will skip TLS and send
-/// CONNECT (including credentials) in plaintext.
-///
-/// This is by design -- the NATS protocol sends INFO before TLS upgrade,
-/// so every NATS client behaves this way. The mitigation is to use
-/// tls:// or TlsMode.Require when TLS must be guaranteed.
+/// Verifies TlsMode.Prefer (and TlsMode.Auto over nats://) behavior:
+/// TLS is opportunistic, so when the server's INFO does not advertise TLS
+/// the connection stays plaintext. This is expected -- use tls:// or
+/// TlsMode.Require when TLS is required.
 /// </summary>
-public class TlsPreferMitmTest(ITestOutputHelper output)
+public class TlsPreferTest(ITestOutputHelper output)
 {
     /// <summary>
-    /// Simulates a MITM that strips tls_available/tls_required from INFO.
-    /// Verifies the client sends CONNECT with credentials over plaintext.
+    /// When INFO has no TLS flags the client proceeds in plaintext,
+    /// including any configured credentials in the CONNECT message.
     /// </summary>
     [Fact]
     public async Task Prefer_mode_sends_credentials_in_plaintext_when_info_has_no_tls_flags()
@@ -47,8 +43,8 @@ public class TlsPreferMitmTest(ITestOutputHelper output)
                 var sw = new StreamWriter(stream, encoding);
                 var sr = new StreamReader(stream, encoding);
 
-                // MITM-forged INFO: no tls_required, no tls_available
-                await sw.WriteAsync("INFO {\"server_id\":\"mitm\",\"max_payload\":1048576,\"tls_required\":false,\"tls_available\":false}\r\n");
+                // INFO with no TLS flags (server does not offer TLS)
+                await sw.WriteAsync("INFO {\"server_id\":\"fake\",\"max_payload\":1048576,\"tls_required\":false,\"tls_available\":false}\r\n");
                 await sw.FlushAsync();
 
                 // Read lines until we see CONNECT
@@ -58,7 +54,7 @@ public class TlsPreferMitmTest(ITestOutputHelper output)
                     if (line == null)
                         break;
 
-                    output.WriteLine($"[MITM] RCV: {line}");
+                    output.WriteLine($"[SERVER] RCV: {line}");
 
                     if (line.StartsWith("CONNECT"))
                     {
@@ -74,7 +70,7 @@ public class TlsPreferMitmTest(ITestOutputHelper output)
             },
             cts.Token);
 
-        // Client with credentials using Prefer mode (same as Auto with nats://)
+        // Client with credentials using Prefer mode
         await using var nats = new NatsConnection(new NatsOpts
         {
             Url = $"nats://127.0.0.1:{port}",
@@ -90,7 +86,7 @@ public class TlsPreferMitmTest(ITestOutputHelper output)
         await serverTask;
         listener.Stop();
 
-        // The CONNECT line was sent over plaintext and contains credentials
+        // CONNECT was sent over plaintext and includes credentials
         connectLine.Should().NotBeEmpty("client should have sent CONNECT");
         connectLine.Should().Contain("secret_user", "credentials were sent over plaintext");
         connectLine.Should().Contain("secret_pass", "credentials were sent over plaintext");
@@ -99,8 +95,7 @@ public class TlsPreferMitmTest(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// Verifies that TlsMode.Auto resolves to Prefer for nats:// without certs,
-    /// making it equally susceptible to the same MITM downgrade.
+    /// Verifies that TlsMode.Auto resolves to Prefer for nats:// without certs.
     /// </summary>
     [Fact]
     public void Auto_mode_resolves_to_prefer_for_nats_scheme_without_certs()

--- a/tools/site_src/documentation/advanced/security.md
+++ b/tools/site_src/documentation/advanced/security.md
@@ -34,3 +34,37 @@ You can set the TLS options to use your client certificates when connecting to a
 > only solution is to add the certificates to the certificate store manually.
 >
 > See also .NET documentation on [Troubleshooting SslStream authentication issues](https://learn.microsoft.com/en-us/dotnet/core/extensions/sslstream-troubleshooting#intermediate-certificates-are-not-sent)
+
+## TLS Modes
+
+The .NET client supports several TLS modes via `NatsTlsOpts.Mode`:
+
+| Mode | Behavior |
+|------|----------|
+| `Auto` (default) | Resolves to `Prefer` for `nats://` without certificates, `Require` for `tls://` or when certificates are provided |
+| `Prefer` | Upgrades to TLS if the server advertises TLS support, otherwise connects in plaintext |
+| `Require` | Always requires TLS, fails if the server does not support it |
+| `Implicit` | Connects with TLS immediately, before any protocol exchange |
+| `Disable` | Never attempts TLS, always connects in plaintext |
+
+### TLS Behind a Proxy
+
+When the nats-server is behind a TLS-terminating proxy, the server may advertise TLS support
+(`tls_available`) even though TLS is handled by the proxy. In this configuration the default
+`Auto`/`Prefer` mode will attempt a TLS upgrade that the nats-server cannot complete, causing
+the connection to fail.
+
+Set `TlsMode.Disable` to skip the TLS upgrade:
+
+```csharp
+var opts = new NatsOpts
+{
+    Url = "nats://my-nats-behind-proxy:4222",
+    TlsOpts = new NatsTlsOpts { Mode = TlsMode.Disable },
+};
+await using var nats = new NatsConnection(opts);
+```
+
+> [!NOTE]
+> This behavior differs from most other NATS clients, which do not attempt a TLS upgrade
+> when the server only advertises `tls_available` without `tls_required`.

--- a/tools/site_src/documentation/advanced/security.md
+++ b/tools/site_src/documentation/advanced/security.md
@@ -47,6 +47,10 @@ The .NET client supports several TLS modes via `NatsTlsOpts.Mode`:
 | `Implicit` | Connects with TLS immediately, before any protocol exchange |
 | `Disable` | Never attempts TLS, always connects in plaintext |
 
+> [!NOTE]
+> Only `Require` and `Implicit` provide the full protection that TLS can offer.
+> Other modes may fall back to plaintext depending on server configuration.
+
 ### TLS Behind a Proxy
 
 When the nats-server is behind a TLS-terminating proxy, the server may advertise TLS support


### PR DESCRIPTION
Documents TLS Prefer/Auto mode behavior and adds guidance for TLS-terminating proxy setups (nats-io/nats-server#7927).

Unlike most other NATS clients (Go, Rust, Java, Python), the .NET client attempts a TLS upgrade when the server advertises `tls_available` without `tls_required`. This can cause connection failures behind a TLS-terminating proxy. The workaround is `TlsMode.Disable`.

We are not changing the default behavior to match other clients because existing configurations may rely on the automatic TLS upgrade. Switching to plaintext silently would be a security regression for those users.

- XML doc remarks on NatsOpts.TlsOpts, NatsTlsOpts.Mode, TlsMode.Prefer, TlsMode.Auto
- TLS proxy section in docfx security page
- Real nats-server tests with `tls {}` + `allow_non_tls`
- Go client cross-check via GoHarness
- Fake-server tests for Prefer, Disable, Require, Auto modes