### PR TITLE
Add protocol size checks

### DIFF
--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -1,7 +1,6 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -80,22 +79,10 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
     {
         if (!Utf8Parser.TryParse(span, out int value, out var consumed))
         {
-            throw new Exception(); // throw...
+            throw new NatsException("Protocol error: invalid integer in message header");
         }
 
         return value;
-    }
-
-    private static int GetInt32(in ReadOnlySequence<byte> sequence)
-    {
-        if (sequence.IsSingleSegment || sequence.GetFirstSpan().Length <= 10)
-        {
-            return GetInt32(sequence.GetFirstSpan());
-        }
-
-        Span<byte> buf = stackalloc byte[Math.Min((int)sequence.Length, 10)];
-        sequence.Slice(buf.Length).CopyTo(buf);
-        return GetInt32(buf);
     }
 
     // https://docs.nats.io/reference/reference-protocols/nats-protocol#info
@@ -182,6 +169,17 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
                         var msgHeader = buffer.Slice(0, positionBeforePayload.Value);
                         var (subject, sid, payloadLength, replyTo) = ParseMessageHeader(msgHeader);
 
+                        if (payloadLength < 0)
+                        {
+                            throw new NatsException($"Protocol error: negative MSG payload length {payloadLength}");
+                        }
+
+                        var serverInfo = _connection.WritableServerInfo;
+                        if (serverInfo != null && payloadLength > serverInfo.MaxPayload)
+                        {
+                            throw new NatsException($"Protocol error: MSG payload length {payloadLength} exceeds server's max payload {serverInfo.MaxPayload}");
+                        }
+
                         if (payloadLength == 0)
                         {
                             // payload is empty.
@@ -254,8 +252,23 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
                             _logger.LogTrace(NatsLogEvents.Protocol, "HMSG trace parsed: {Subject} {Sid} {ReplyTo} {HeadersLength} {TotalLength}", subject, sid, replyTo, headersLength, totalLength);
                         }
 
+                        if (headersLength < 0 || totalLength < 0)
+                        {
+                            throw new NatsException($"Protocol error: negative HMSG lengths (headers={headersLength}, total={totalLength})");
+                        }
+
+                        if (totalLength < headersLength)
+                        {
+                            throw new NatsException($"Protocol error: HMSG total length {totalLength} is less than headers length {headersLength}");
+                        }
+
+                        var serverInfo2 = _connection.WritableServerInfo;
+                        if (serverInfo2 != null && totalLength > serverInfo2.MaxPayload)
+                        {
+                            throw new NatsException($"Protocol error: HMSG total length {totalLength} exceeds server's max payload {serverInfo2.MaxPayload}");
+                        }
+
                         var payloadLength = totalLength - headersLength;
-                        Debug.Assert(payloadLength >= 0, "Protocol error: illogical header and total lengths");
 
                         var headerBegin = buffer.GetPosition(1, positionBeforeNatsHeader.Value);
                         var totalSlice = buffer.Slice(headerBegin);

--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -83,7 +83,7 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
     {
         if (!Utf8Parser.TryParse(span, out int value, out var consumed))
         {
-            throw new NatsException("Protocol error: invalid integer in message header");
+            NatsProtocolViolationException.Throw("Invalid integer in message header");
         }
 
         return value;
@@ -321,7 +321,7 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
             }
             catch (NatsProtocolViolationException e)
             {
-                _logger.LogError(NatsLogEvents.Protocol, e, "Protocol violation, dropping connection");
+                _logger.LogError(NatsLogEvents.Protocol, e, "Protocol violation");
                 _socketConnection.SignalDisconnected(e);
                 _waitForInfoSignal.TrySetObservedException(e);
                 _waitForPongOrErrorSignal.TrySetObservedException(e);

--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -13,6 +13,7 @@ namespace NATS.Client.Core.Internal;
 internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
 {
     private readonly NatsConnection _connection;
+    private readonly SocketConnectionWrapper _socketConnection;
     private readonly SocketReader _socketReader;
     private readonly Task _readLoop;
     private readonly TaskCompletionSource _waitForInfoSignal;
@@ -22,11 +23,14 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
     private readonly ILogger<NatsReadProtocolProcessor> _logger;
     private readonly Encoding _subjectEncoding;
     private readonly bool _trace;
+    private readonly int _maxPayloadHardCap;
     private int _disposed;
 
     public NatsReadProtocolProcessor(SocketConnectionWrapper socketConnection, NatsConnection connection, TaskCompletionSource waitForInfoSignal, TaskCompletionSource waitForPongOrErrorSignal, Task infoParsed)
     {
         _connection = connection;
+        _socketConnection = socketConnection;
+        _maxPayloadHardCap = connection.Opts.MaxPayloadHardCap;
         _subjectEncoding = connection.Opts.SubjectEncoding;
         _logger = connection.Opts.LoggerFactory.CreateLogger<NatsReadProtocolProcessor>();
         _trace = _logger.IsEnabled(LogLevel.Trace);
@@ -171,13 +175,13 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
 
                         if (payloadLength < 0)
                         {
-                            throw new NatsException($"Protocol error: negative MSG payload length {payloadLength}");
+                            NatsProtocolViolationException.Throw($"Negative MSG payload length {payloadLength}");
                         }
 
-                        var serverInfo = _connection.WritableServerInfo;
-                        if (serverInfo != null && payloadLength > serverInfo.MaxPayload)
+                        var maxPayload = Math.Min(_connection.WritableServerInfo?.MaxPayload ?? _maxPayloadHardCap, _maxPayloadHardCap);
+                        if (payloadLength > maxPayload)
                         {
-                            throw new NatsException($"Protocol error: MSG payload length {payloadLength} exceeds server's max payload {serverInfo.MaxPayload}");
+                            NatsProtocolViolationException.Throw($"MSG payload length {payloadLength} exceeds max payload {maxPayload}");
                         }
 
                         if (payloadLength == 0)
@@ -254,18 +258,18 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
 
                         if (headersLength < 0 || totalLength < 0)
                         {
-                            throw new NatsException($"Protocol error: negative HMSG lengths (headers={headersLength}, total={totalLength})");
+                            NatsProtocolViolationException.Throw($"Negative HMSG lengths (headers={headersLength}, total={totalLength})");
                         }
 
                         if (totalLength < headersLength)
                         {
-                            throw new NatsException($"Protocol error: HMSG total length {totalLength} is less than headers length {headersLength}");
+                            NatsProtocolViolationException.Throw($"HMSG total length {totalLength} is less than headers length {headersLength}");
                         }
 
-                        var serverInfo2 = _connection.WritableServerInfo;
-                        if (serverInfo2 != null && totalLength > serverInfo2.MaxPayload)
+                        var maxPayload = Math.Min(_connection.WritableServerInfo?.MaxPayload ?? _maxPayloadHardCap, _maxPayloadHardCap);
+                        if (totalLength > maxPayload)
                         {
-                            throw new NatsException($"Protocol error: HMSG total length {totalLength} exceeds server's max payload {serverInfo2.MaxPayload}");
+                            NatsProtocolViolationException.Throw($"HMSG total length {totalLength} exceeds max payload {maxPayload}");
                         }
 
                         var payloadLength = totalLength - headersLength;
@@ -313,6 +317,14 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
             catch (SocketClosedException e)
             {
                 _logger.LogDebug(NatsLogEvents.Protocol, e, "Socket closed during read loop");
+                _waitForInfoSignal.TrySetObservedException(e);
+                _waitForPongOrErrorSignal.TrySetObservedException(e);
+                return;
+            }
+            catch (NatsProtocolViolationException e)
+            {
+                _logger.LogError(NatsLogEvents.Protocol, e, "Protocol violation, dropping connection");
+                _socketConnection.SignalDisconnected(e);
                 _waitForInfoSignal.TrySetObservedException(e);
                 _waitForPongOrErrorSignal.TrySetObservedException(e);
                 return;

--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -178,10 +178,9 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
                             NatsProtocolViolationException.Throw($"Negative MSG payload length {payloadLength}");
                         }
 
-                        var maxPayload = Math.Min(_connection.WritableServerInfo?.MaxPayload ?? _maxPayloadHardCap, _maxPayloadHardCap);
-                        if (payloadLength > maxPayload)
+                        if (payloadLength > _maxPayloadHardCap)
                         {
-                            NatsProtocolViolationException.Throw($"MSG payload length {payloadLength} exceeds max payload {maxPayload}");
+                            NatsProtocolViolationException.Throw($"Payload length {payloadLength} exceeds max allowed size {_maxPayloadHardCap}");
                         }
 
                         if (payloadLength == 0)
@@ -266,10 +265,9 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
                             NatsProtocolViolationException.Throw($"HMSG total length {totalLength} is less than headers length {headersLength}");
                         }
 
-                        var maxPayload = Math.Min(_connection.WritableServerInfo?.MaxPayload ?? _maxPayloadHardCap, _maxPayloadHardCap);
-                        if (totalLength > maxPayload)
+                        if (totalLength > _maxPayloadHardCap)
                         {
-                            NatsProtocolViolationException.Throw($"HMSG total length {totalLength} exceeds max payload {maxPayload}");
+                            NatsProtocolViolationException.Throw($"HMSG total length {totalLength} exceeds max allowed size {_maxPayloadHardCap}");
                         }
 
                         var payloadLength = totalLength - headersLength;

--- a/src/NATS.Client.Core/Internal/SocketReader.cs
+++ b/src/NATS.Client.Core/Internal/SocketReader.cs
@@ -128,7 +128,9 @@ internal sealed class SocketReader
 
             if (totalRead > _maxControlLineSize)
             {
-                throw new NatsException($"Protocol error: control line exceeded maximum size of {_maxControlLineSize} bytes without newline");
+                var msg = $"Control line exceeded maximum size of {_maxControlLineSize} bytes without newline";
+                _socketConnection.SignalDisconnected(new NatsProtocolViolationException(msg));
+                NatsProtocolViolationException.Throw(msg);
             }
         }
 

--- a/src/NATS.Client.Core/Internal/SocketReader.cs
+++ b/src/NATS.Client.Core/Internal/SocketReader.cs
@@ -9,7 +9,6 @@ namespace NATS.Client.Core.Internal;
 internal sealed class SocketReader
 {
     private readonly int _minimumBufferSize;
-    private readonly int _maxControlLineSize;
     private readonly ConnectionStatsCounter _counter;
     private readonly SeqeunceBuilder _seqeunceBuilder = new SeqeunceBuilder();
     private readonly Stopwatch _stopwatch = new Stopwatch();
@@ -19,11 +18,10 @@ internal sealed class SocketReader
 
     private Memory<byte> _availableMemory;
 
-    public SocketReader(SocketConnectionWrapper socketConnection, int minimumBufferSize, ConnectionStatsCounter counter, ILoggerFactory loggerFactory, int maxControlLineSize = 4 * 1024 * 1024)
+    public SocketReader(SocketConnectionWrapper socketConnection, int minimumBufferSize, ConnectionStatsCounter counter, ILoggerFactory loggerFactory)
     {
         _socketConnection = socketConnection;
         _minimumBufferSize = minimumBufferSize;
-        _maxControlLineSize = maxControlLineSize;
         _counter = counter;
         _logger = loggerFactory.CreateLogger<SocketReader>();
         _isTraceLogging = _logger.IsEnabled(LogLevel.Trace);
@@ -80,9 +78,11 @@ internal sealed class SocketReader
 #if !NETSTANDARD
     [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
 #endif
+
+    // No incoming control line size check — we trust the server after TLS handshake.
+    // Outgoing control line size is the server's responsibility to enforce.
     public async ValueTask<ReadOnlySequence<byte>> ReadUntilReceiveNewLineAsync()
     {
-        var totalRead = 0;
         while (true)
         {
             if (_availableMemory.Length == 0)
@@ -115,7 +115,6 @@ internal sealed class SocketReader
                 throw ex;
             }
 
-            totalRead += read;
             Interlocked.Add(ref _counter.ReceivedBytes, read);
             var appendMemory = _availableMemory.Slice(0, read);
             _seqeunceBuilder.Append(appendMemory);
@@ -124,13 +123,6 @@ internal sealed class SocketReader
             if (appendMemory.Span.Contains((byte)'\n'))
             {
                 break;
-            }
-
-            if (totalRead > _maxControlLineSize)
-            {
-                var msg = $"Control line exceeded maximum size of {_maxControlLineSize} bytes without newline";
-                _socketConnection.SignalDisconnected(new NatsProtocolViolationException(msg));
-                NatsProtocolViolationException.Throw(msg);
             }
         }
 

--- a/src/NATS.Client.Core/Internal/SocketReader.cs
+++ b/src/NATS.Client.Core/Internal/SocketReader.cs
@@ -9,6 +9,7 @@ namespace NATS.Client.Core.Internal;
 internal sealed class SocketReader
 {
     private readonly int _minimumBufferSize;
+    private readonly int _maxControlLineSize;
     private readonly ConnectionStatsCounter _counter;
     private readonly SeqeunceBuilder _seqeunceBuilder = new SeqeunceBuilder();
     private readonly Stopwatch _stopwatch = new Stopwatch();
@@ -18,10 +19,11 @@ internal sealed class SocketReader
 
     private Memory<byte> _availableMemory;
 
-    public SocketReader(SocketConnectionWrapper socketConnection, int minimumBufferSize, ConnectionStatsCounter counter, ILoggerFactory loggerFactory)
+    public SocketReader(SocketConnectionWrapper socketConnection, int minimumBufferSize, ConnectionStatsCounter counter, ILoggerFactory loggerFactory, int maxControlLineSize = 4 * 1024 * 1024)
     {
         _socketConnection = socketConnection;
         _minimumBufferSize = minimumBufferSize;
+        _maxControlLineSize = maxControlLineSize;
         _counter = counter;
         _logger = loggerFactory.CreateLogger<SocketReader>();
         _isTraceLogging = _logger.IsEnabled(LogLevel.Trace);
@@ -80,6 +82,7 @@ internal sealed class SocketReader
 #endif
     public async ValueTask<ReadOnlySequence<byte>> ReadUntilReceiveNewLineAsync()
     {
+        var totalRead = 0;
         while (true)
         {
             if (_availableMemory.Length == 0)
@@ -112,6 +115,7 @@ internal sealed class SocketReader
                 throw ex;
             }
 
+            totalRead += read;
             Interlocked.Add(ref _counter.ReceivedBytes, read);
             var appendMemory = _availableMemory.Slice(0, read);
             _seqeunceBuilder.Append(appendMemory);
@@ -120,6 +124,11 @@ internal sealed class SocketReader
             if (appendMemory.Span.Contains((byte)'\n'))
             {
                 break;
+            }
+
+            if (totalRead > _maxControlLineSize)
+            {
+                throw new NatsException($"Protocol error: control line exceeded maximum size of {_maxControlLineSize} bytes without newline");
             }
         }
 

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -669,6 +669,12 @@ public partial class NatsConnection : INatsConnection
                 // wait for the current socket to complete or throw
                 await _socketConnection!.WaitForClosed.ConfigureAwait(false);
             }
+            catch (NatsProtocolViolationException e)
+            {
+                // Protocol violations indicate a malicious or broken server — do not reconnect
+                _logger.LogError(NatsLogEvents.Connection, e, "Protocol violation, will not reconnect");
+                return;
+            }
             catch (Exception)
             {
                 // If the NatsConnection is disposed, WaitForClosed throws so stop reconnect-loop correctly

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -669,12 +669,6 @@ public partial class NatsConnection : INatsConnection
                 // wait for the current socket to complete or throw
                 await _socketConnection!.WaitForClosed.ConfigureAwait(false);
             }
-            catch (NatsProtocolViolationException e)
-            {
-                // Protocol violations indicate a malicious or broken server — do not reconnect
-                _logger.LogError(NatsLogEvents.Connection, e, "Protocol violation, will not reconnect");
-                return;
-            }
             catch (Exception)
             {
                 // If the NatsConnection is disposed, WaitForClosed throws so stop reconnect-loop correctly

--- a/src/NATS.Client.Core/NatsException.cs
+++ b/src/NATS.Client.Core/NatsException.cs
@@ -66,6 +66,13 @@ public sealed class NatsPayloadTooLargeException : NatsException
 
 public sealed class NatsConnectionFailedException(string message) : NatsException(message);
 
+public sealed class NatsProtocolViolationException(string message) : NatsException(message)
+{
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static new void Throw(string message) => throw new NatsProtocolViolationException(message);
+}
+
 public sealed class NatsTimeoutException() : NatsException("Operation timed out")
 {
     [DoesNotReturn]

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -85,8 +85,8 @@ public sealed record NatsOpts
     public int ReaderBufferSize { get; init; } = 65536;
 
     /// <summary>
-    /// Absolute maximum allowed payload size, applied as a ceiling regardless of the server's advertised max_payload.
-    /// Provides a client-side safeguard against unexpectedly large messages causing out-of-memory conditions.
+    /// Maximum allowed incoming message size. Provides a client-side safeguard against
+    /// unexpectedly large messages causing out-of-memory conditions.
     /// Default is 64 MB.
     /// </summary>
     public int MaxPayloadHardCap { get; init; } = 64 * 1024 * 1024;

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -84,6 +84,13 @@ public sealed record NatsOpts
 
     public int ReaderBufferSize { get; init; } = 65536;
 
+    /// <summary>
+    /// Absolute maximum allowed payload size, applied as a ceiling regardless of the server's advertised max_payload.
+    /// Provides a client-side safeguard against unexpectedly large messages causing out-of-memory conditions.
+    /// Default is 64 MB.
+    /// </summary>
+    public int MaxPayloadHardCap { get; init; } = 64 * 1024 * 1024;
+
     public bool UseThreadPoolCallback { get; init; } = false;
 
     public string InboxPrefix { get; init; } = "_INBOX";

--- a/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
+++ b/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
@@ -1,0 +1,350 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using NATS.Client.TestUtilities;
+
+namespace NATS.Client.Core.Tests;
+
+/// <summary>
+/// These tests use a raw TcpListener to send crafted protocol data
+/// that a malicious server could send to crash the client via OOM.
+/// </summary>
+public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
+{
+    /// <summary>
+    /// MSG with payload size exceeding server's max_payload must not
+    /// cause an unbounded allocation (previously would call ReadAtLeastAsync(2147483647)).
+    /// </summary>
+    [Fact]
+    public async Task Msg_with_payload_exceeding_max_payload_does_not_oom()
+    {
+        var logFactory = new InMemoryTestLoggerFactory(LogLevel.Error, m => output.WriteLine($"[LOG] {m.Message}"));
+        await using var server = new FakeServer(output);
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory });
+        await nats.ConnectAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
+        await server.WaitForSubAsync("foo");
+
+        // Send a MSG claiming payload of 2GB — far exceeds max_payload
+        await server.SendRawAsync("MSG foo 1 2147483647\r\n");
+
+        await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
+            .ShouldWithRetryAsync(
+                m => m.LogLevel == LogLevel.Error
+                     && m.Exception is NatsException
+                     && m.Exception.Message.Contains("max payload"),
+                "MSG with oversized payload should be rejected");
+    }
+
+    /// <summary>
+    /// MSG with negative payload length must be rejected.
+    /// </summary>
+    [Fact]
+    public async Task Msg_with_negative_payload_length_does_not_oom()
+    {
+        var logFactory = new InMemoryTestLoggerFactory(LogLevel.Error, m => output.WriteLine($"[LOG] {m.Message}"));
+        await using var server = new FakeServer(output);
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory });
+        await nats.ConnectAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
+        await server.WaitForSubAsync("foo");
+
+        await server.SendRawAsync("MSG foo 1 -1\r\n");
+
+        await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
+            .ShouldWithRetryAsync(
+                m => m.LogLevel == LogLevel.Error
+                     && m.Exception is NatsException
+                     && m.Exception.Message.Contains("negative"),
+                "MSG with negative payload length should be rejected");
+    }
+
+    /// <summary>
+    /// HMSG with totalLength less than headersLength must be rejected.
+    /// Previously only protected by Debug.Assert (stripped in Release).
+    /// </summary>
+    [Fact]
+    public async Task Hmsg_with_total_less_than_headers_does_not_oom()
+    {
+        var logFactory = new InMemoryTestLoggerFactory(LogLevel.Error, m => output.WriteLine($"[LOG] {m.Message}"));
+        await using var server = new FakeServer(output);
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory });
+        await nats.ConnectAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
+        await server.WaitForSubAsync("foo");
+
+        // headersLength=100, totalLength=10 — impossible
+        await server.SendRawAsync("HMSG foo 1 100 10\r\n");
+
+        await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
+            .ShouldWithRetryAsync(
+                m => m.LogLevel == LogLevel.Error
+                     && m.Exception is NatsException
+                     && m.Exception.Message.Contains("less than headers"),
+                "HMSG with total < headers should be rejected");
+    }
+
+    /// <summary>
+    /// HMSG with totalLength exceeding max_payload must be rejected.
+    /// </summary>
+    [Fact]
+    public async Task Hmsg_with_total_exceeding_max_payload_does_not_oom()
+    {
+        var logFactory = new InMemoryTestLoggerFactory(LogLevel.Error, m => output.WriteLine($"[LOG] {m.Message}"));
+        await using var server = new FakeServer(output);
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory });
+        await nats.ConnectAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
+        await server.WaitForSubAsync("foo");
+
+        // headersLength=10, totalLength=2147483647 — exceeds 1MB max_payload
+        await server.SendRawAsync("HMSG foo 1 10 2147483647\r\n");
+
+        await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
+            .ShouldWithRetryAsync(
+                m => m.LogLevel == LogLevel.Error
+                     && m.Exception is NatsException
+                     && m.Exception.Message.Contains("max payload"),
+                "HMSG exceeding max_payload should be rejected");
+    }
+
+    /// <summary>
+    /// A control line without \n must not cause unbounded memory allocation.
+    /// ReadUntilReceiveNewLineAsync loops renting 64KB buffers forever — the fix
+    /// adds a max control line size (default 4MB).
+    /// </summary>
+    [Fact]
+    public async Task Control_line_without_newline_does_not_cause_oom()
+    {
+        var logFactory = new InMemoryTestLoggerFactory(LogLevel.Error, m => output.WriteLine($"[LOG] {m.Message}"));
+        await using var server = new FakeServer(output);
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory });
+        await nats.ConnectAsync();
+
+        // Send -ERR prefix so the parser enters a path that calls ReadUntilReceiveNewLineAsync,
+        // then flood with data that has no newline.
+        var junk = new string('X', 64 * 1024);
+        await server.SendRawAsync("-ERR ");
+
+        var totalSent = 5;
+        try
+        {
+            while (totalSent < 5 * 1024 * 1024)
+            {
+                await server.SendRawAsync(junk);
+                totalSent += junk.Length;
+            }
+
+            output.WriteLine($"Sent {totalSent} bytes without newline");
+        }
+        catch (IOException)
+        {
+            output.WriteLine("Client disconnected before all data sent (expected)");
+        }
+
+        await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
+            .ShouldWithRetryAsync(
+                m => m.LogLevel == LogLevel.Error
+                     && m.Exception is NatsException
+                     && m.Exception.Message.Contains("control line"),
+                "control line exceeding max size should be rejected");
+    }
+
+    /// <summary>
+    /// Sanity check: a valid MSG with normal payload still works after the fixes.
+    /// </summary>
+    [Fact]
+    public async Task Valid_msg_still_works()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await using var server = new MockServer(
+            handler: (client, cmd) =>
+            {
+                if (cmd.Name == "SUB")
+                {
+                    client.SendMsg(cmd.Subject, payload: "hello");
+                }
+
+                return Task.CompletedTask;
+            },
+            logger: m => output.WriteLine(m),
+            cancellationToken: cts.Token);
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectAsync();
+
+        await foreach (var msg in nats.SubscribeAsync<string>("foo", cancellationToken: cts.Token))
+        {
+            msg.Data.Should().Be("hello");
+            break;
+        }
+    }
+
+    /// <summary>
+    /// Sanity check: a valid HMSG with headers and payload still works after the fixes.
+    /// Uses raw wire protocol to ensure correct byte counts.
+    /// </summary>
+    [Fact]
+    public async Task Valid_hmsg_still_works()
+    {
+        await using var server = new FakeServer(output);
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var sub = await nats.SubscribeCoreAsync<byte[]>("foo", cancellationToken: cts.Token);
+        await server.WaitForSubAsync("foo");
+
+        // Build a well-formed HMSG:
+        // Headers: "NATS/1.0\r\nX-Test: value\r\n\r\n" (28 bytes, including the \r\n\r\n terminator)
+        // Payload: "world" (5 bytes)
+        // Total: 33 bytes
+        var headers = "NATS/1.0\r\nX-Test: value\r\n\r\n";
+        var payload = "world";
+        var headersLen = headers.Length;
+        var totalLen = headersLen + payload.Length;
+        await server.SendRawAsync($"HMSG foo 1 {headersLen} {totalLen}\r\n{headers}{payload}\r\n");
+
+        await foreach (var msg in sub.Msgs.ReadAllAsync(cts.Token))
+        {
+            msg.Headers.Should().NotBeNull();
+            msg.Headers!["X-Test"].ToString().Should().Be("value");
+            break;
+        }
+    }
+
+    /// <summary>
+    /// A minimal fake NATS server that does the handshake then exposes raw send.
+    /// </summary>
+    private sealed class FakeServer : IAsyncDisposable
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new(TimeSpan.FromSeconds(30));
+        private readonly TaskCompletionSource _accepted = new();
+        private readonly Dictionary<string, TaskCompletionSource> _subWaiters = new();
+        private TcpClient? _tcpClient;
+        private StreamWriter? _writer;
+        private Task? _readLoop;
+
+        public FakeServer(ITestOutputHelper output, string info = "{\"max_payload\":1048576}")
+        {
+            _output = output;
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start(1);
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+
+            // Accept one client and perform handshake
+            _readLoop = Task.Run(async () => await AcceptAndServeAsync(info), _cts.Token);
+        }
+
+        public int Port { get; }
+
+        public string Url => $"127.0.0.1:{Port}";
+
+        public async Task SendRawAsync(string data)
+        {
+            await _accepted.Task.ConfigureAwait(false);
+            await _writer!.WriteAsync(data);
+            await _writer.FlushAsync();
+        }
+
+        public Task WaitForSubAsync(string subject)
+        {
+            lock (_subWaiters)
+            {
+                if (_subWaiters.TryGetValue(subject, out var existing) && existing.Task.IsCompleted)
+                    return Task.CompletedTask;
+
+                var tcs = new TaskCompletionSource();
+                _subWaiters[subject] = tcs;
+                return tcs.Task;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            _tcpClient?.Dispose();
+
+            if (_readLoop != null)
+            {
+                try
+                {
+                    await _readLoop.WaitAsync(TimeSpan.FromSeconds(3));
+                }
+                catch
+                {
+                    // ignore cleanup errors
+                }
+            }
+        }
+
+        private async Task AcceptAndServeAsync(string info)
+        {
+            _tcpClient = await _listener.AcceptTcpClientAsync();
+            var stream = _tcpClient.GetStream();
+            var encoding = Encoding.GetEncoding(28591);
+            _writer = new StreamWriter(stream, encoding) { AutoFlush = false };
+            var reader = new StreamReader(stream, encoding);
+
+            // Send INFO
+            await _writer.WriteAsync($"INFO {info}\r\n");
+            await _writer.FlushAsync();
+
+            // Read lines: respond to PING, track SUB
+            while (!_cts.Token.IsCancellationRequested)
+            {
+                var line = await reader.ReadLineAsync();
+                if (line == null)
+                    break;
+
+                _output.WriteLine($"[S] RCV: {line}");
+
+                if (line.StartsWith("PING"))
+                {
+                    await _writer.WriteAsync("PONG\r\n");
+                    await _writer.FlushAsync();
+
+                    if (!_accepted.Task.IsCompleted)
+                        _accepted.TrySetResult();
+                }
+                else if (line.StartsWith("SUB"))
+                {
+                    // SUB <subject> [queue] <sid>
+                    var parts = line.Split(' ');
+                    var subject = parts[1];
+
+                    lock (_subWaiters)
+                    {
+                        if (_subWaiters.TryGetValue(subject, out var tcs))
+                            tcs.TrySetResult();
+                        else
+                            _subWaiters[subject] = new TaskCompletionSource();
+
+                        // Mark as completed for late callers
+                        if (!_subWaiters[subject].Task.IsCompleted)
+                            _subWaiters[subject].TrySetResult();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
+++ b/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
@@ -36,7 +36,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
             .ShouldWithRetryAsync(
                 m => m.LogLevel == LogLevel.Error
                      && m.Exception is NatsProtocolViolationException
-                     && m.Exception.Message.Contains("max payload"),
+                     && m.Exception.Message.Contains("max allowed size"),
                 "MSG with oversized payload should be rejected");
     }
 
@@ -117,76 +117,22 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
             .ShouldWithRetryAsync(
                 m => m.LogLevel == LogLevel.Error
                      && m.Exception is NatsProtocolViolationException
-                     && m.Exception.Message.Contains("max payload"),
+                     && m.Exception.Message.Contains("max allowed size"),
                 "HMSG exceeding max_payload should be rejected");
     }
 
     /// <summary>
-    /// A control line without \n must not cause unbounded memory allocation.
-    /// ReadUntilReceiveNewLineAsync loops renting 64KB buffers forever — the fix
-    /// adds a max control line size (default 4MB).
+    /// A protocol violation exits the read loop cleanly (not in a spin loop).
+    /// The connection will attempt to reconnect to other servers.
     /// </summary>
     [Fact]
-    public async Task Control_line_without_newline_does_not_cause_oom()
+    public async Task Protocol_violation_exits_read_loop_cleanly()
     {
         var logFactory = new InMemoryTestLoggerFactory(LogLevel.Error, m => output.WriteLine($"[LOG] {m.Message}"));
         await using var server = new FakeServer(output);
 
-        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory });
-        await nats.ConnectAsync();
-
-        // Send -ERR prefix so the parser enters a path that calls ReadUntilReceiveNewLineAsync,
-        // then flood with data that has no newline.
-        // Default _maxControlLineSize is 4MB, so we need to exceed that.
-        var junk = new string('X', 64 * 1024);
-        using var sendCts = new CancellationTokenSource();
-        var sendTask = Task.Run(async () =>
-        {
-            try
-            {
-                await server.SendRawAsync("-ERR ");
-                var totalSent = 5;
-                while (totalSent < 5 * 1024 * 1024 && !sendCts.Token.IsCancellationRequested)
-                {
-                    await server.SendRawAsync(junk);
-                    totalSent += junk.Length;
-                }
-            }
-            catch
-            {
-                // Client may close socket mid-write — expected
-            }
-        });
-
-        await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
-            .ShouldWithRetryAsync(
-                m => m.LogLevel == LogLevel.Error
-                     && m.Exception is NatsProtocolViolationException
-                     && m.Exception.Message.Contains("Control line"),
-                "control line exceeding max size should be rejected");
-
-        sendCts.Cancel();
-        try
-        {
-            await sendTask.WaitAsync(TimeSpan.FromSeconds(3));
-        }
-        catch
-        {
-            // Send task may not complete cleanly
-        }
-    }
-
-    /// <summary>
-    /// A protocol violation drops the connection (read loop exits) rather than
-    /// spinning in an infinite error loop on the same bad buffer.
-    /// </summary>
-    [Fact]
-    public async Task Protocol_violation_drops_connection()
-    {
-        var logFactory = new InMemoryTestLoggerFactory(LogLevel.Error, m => output.WriteLine($"[LOG] {m.Message}"));
-        await using var server = new FakeServer(output);
-
-        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory });
+        // MaxReconnectRetry=0 because FakeServer only accepts one connection
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory, MaxReconnectRetry = 0 });
         await nats.ConnectAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
+++ b/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
@@ -35,7 +35,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
         await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
             .ShouldWithRetryAsync(
                 m => m.LogLevel == LogLevel.Error
-                     && m.Exception is NatsException
+                     && m.Exception is NatsProtocolViolationException
                      && m.Exception.Message.Contains("max payload"),
                 "MSG with oversized payload should be rejected");
     }
@@ -61,8 +61,8 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
         await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
             .ShouldWithRetryAsync(
                 m => m.LogLevel == LogLevel.Error
-                     && m.Exception is NatsException
-                     && m.Exception.Message.Contains("negative"),
+                     && m.Exception is NatsProtocolViolationException
+                     && m.Exception.Message.Contains("Negative"),
                 "MSG with negative payload length should be rejected");
     }
 
@@ -89,7 +89,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
         await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
             .ShouldWithRetryAsync(
                 m => m.LogLevel == LogLevel.Error
-                     && m.Exception is NatsException
+                     && m.Exception is NatsProtocolViolationException
                      && m.Exception.Message.Contains("less than headers"),
                 "HMSG with total < headers should be rejected");
     }
@@ -116,7 +116,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
         await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
             .ShouldWithRetryAsync(
                 m => m.LogLevel == LogLevel.Error
-                     && m.Exception is NatsException
+                     && m.Exception is NatsProtocolViolationException
                      && m.Exception.Message.Contains("max payload"),
                 "HMSG exceeding max_payload should be rejected");
     }
@@ -137,31 +137,78 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
 
         // Send -ERR prefix so the parser enters a path that calls ReadUntilReceiveNewLineAsync,
         // then flood with data that has no newline.
+        // Default _maxControlLineSize is 4MB, so we need to exceed that.
         var junk = new string('X', 64 * 1024);
-        await server.SendRawAsync("-ERR ");
-
-        var totalSent = 5;
-        try
+        using var sendCts = new CancellationTokenSource();
+        var sendTask = Task.Run(async () =>
         {
-            while (totalSent < 5 * 1024 * 1024)
+            try
             {
-                await server.SendRawAsync(junk);
-                totalSent += junk.Length;
+                await server.SendRawAsync("-ERR ");
+                var totalSent = 5;
+                while (totalSent < 5 * 1024 * 1024 && !sendCts.Token.IsCancellationRequested)
+                {
+                    await server.SendRawAsync(junk);
+                    totalSent += junk.Length;
+                }
             }
-
-            output.WriteLine($"Sent {totalSent} bytes without newline");
-        }
-        catch (IOException)
-        {
-            output.WriteLine("Client disconnected before all data sent (expected)");
-        }
+            catch
+            {
+                // Client may close socket mid-write — expected
+            }
+        });
 
         await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
             .ShouldWithRetryAsync(
                 m => m.LogLevel == LogLevel.Error
-                     && m.Exception is NatsException
-                     && m.Exception.Message.Contains("control line"),
+                     && m.Exception is NatsProtocolViolationException
+                     && m.Exception.Message.Contains("Control line"),
                 "control line exceeding max size should be rejected");
+
+        sendCts.Cancel();
+        try
+        {
+            await sendTask.WaitAsync(TimeSpan.FromSeconds(3));
+        }
+        catch
+        {
+            // Send task may not complete cleanly
+        }
+    }
+
+    /// <summary>
+    /// A protocol violation drops the connection (read loop exits) rather than
+    /// spinning in an infinite error loop on the same bad buffer.
+    /// </summary>
+    [Fact]
+    public async Task Protocol_violation_drops_connection()
+    {
+        var logFactory = new InMemoryTestLoggerFactory(LogLevel.Error, m => output.WriteLine($"[LOG] {m.Message}"));
+        await using var server = new FakeServer(output);
+
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory });
+        await nats.ConnectAsync();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
+        await server.WaitForSubAsync("foo");
+
+        // Send a malicious MSG with negative payload
+        await server.SendRawAsync("MSG foo 1 -1\r\n");
+
+        // The violation should be logged exactly once (not in a loop), then connection drops
+        await new Func<IReadOnlyList<InMemoryTestLoggerFactory.LogMessage>>(() => logFactory.Logs)
+            .ShouldWithRetryAsync(
+                m => m.LogLevel == LogLevel.Error
+                     && m.Exception is NatsProtocolViolationException
+                     && m.Exception.Message.Contains("Negative"),
+                "protocol violation should be logged");
+
+        // Give a moment for any spin to manifest, then verify no error flood.
+        // Expect a small number (read loop + reconnect loop each log once) but not hundreds.
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+        var violationCount = logFactory.Logs.Count(m => m.Exception is NatsProtocolViolationException);
+        violationCount.Should().BeLessThanOrEqualTo(3, "the error should be logged a few times, not in a spin loop");
     }
 
     /// <summary>
@@ -242,6 +289,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
         private TcpClient? _tcpClient;
         private StreamWriter? _writer;
         private Task? _readLoop;
+        private bool _protocolDump;
 
         public FakeServer(ITestOutputHelper output, string info = "{\"max_payload\":1048576}")
         {
@@ -258,9 +306,25 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
 
         public string Url => $"127.0.0.1:{Port}";
 
+        /// <summary>
+        /// Enable protocol dump — all sent and received data is logged to test output.
+        /// Call before ConnectAsync.
+        /// </summary>
+        public FakeServer EnableProtocolDump()
+        {
+            _protocolDump = true;
+            return this;
+        }
+
         public async Task SendRawAsync(string data)
         {
             await _accepted.Task.ConfigureAwait(false);
+            if (_protocolDump)
+            {
+                var preview = data.Length > 200 ? data.Substring(0, 200) + $"...({data.Length} chars)" : data;
+                _output.WriteLine($"[S] SND: {preview.Replace("\r", "\\r").Replace("\n", "\\n")}");
+            }
+
             await _writer!.WriteAsync(data);
             await _writer.FlushAsync();
         }
@@ -306,7 +370,10 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
             var reader = new StreamReader(stream, encoding);
 
             // Send INFO
-            await _writer.WriteAsync($"INFO {info}\r\n");
+            var infoLine = $"INFO {info}\r\n";
+            if (_protocolDump)
+                _output.WriteLine($"[S] SND: {infoLine.Replace("\r", "\\r").Replace("\n", "\\n")}");
+            await _writer.WriteAsync(infoLine);
             await _writer.FlushAsync();
 
             // Read lines: respond to PING, track SUB
@@ -317,6 +384,8 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
                     break;
 
                 _output.WriteLine($"[S] RCV: {line}");
+                if (_protocolDump)
+                    _output.WriteLine($"[S] RCV (dump): {line}");
 
                 if (line.StartsWith("PING"))
                 {

--- a/tests/NATS.Client.TestUtilities/FluentAssertionsExtension.cs
+++ b/tests/NATS.Client.TestUtilities/FluentAssertionsExtension.cs
@@ -1,11 +1,51 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using FluentAssertions.Collections;
 
 namespace NATS.Client.Core.Tests;
 
 public static class FluentAssertionsExtension
 {
+    /// <summary>
+    /// Polls <paramref name="getCollection"/> until the assertion passes or the timeout expires.
+    /// Useful when an async background operation (e.g. a read-loop) populates the collection.
+    /// </summary>
+    public static async Task ShouldWithRetryAsync<T>(
+        this Func<IReadOnlyList<T>> getCollection,
+        Func<T, bool> predicate,
+        string because = "",
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null)
+    {
+        var timeoutValue = timeout ?? TimeSpan.FromSeconds(10);
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(100);
+
+        using var cts = new CancellationTokenSource(timeoutValue);
+        while (!cts.Token.IsCancellationRequested)
+        {
+            var items = getCollection();
+            foreach (var item in items)
+            {
+                if (predicate(item))
+                    return;
+            }
+
+            try
+            {
+                await Task.Delay(interval, cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        // Final assertion — will fail with a useful message
+        getCollection().Should().Contain(item => predicate(item), because);
+    }
+
     public static void ShouldBe(this object actual, object expected)
     {
         actual.Should().Be(expected);


### PR DESCRIPTION
Add protocol parser size validation and defensive checks:

- Validate incoming MSG/HMSG payload sizes against a configurable hard cap (MaxPayloadHardCap, default 64MB, consistent with nats.js)
- Reject negative or impossible length values in message headers
- Replace Debug.Assert with runtime checks for HMSG header/total length invariant
- Introduce NatsProtocolViolationException for clean error handling on protocol violations