### PR TITLE
Clear ArrayPool buffers before returning to pool

### DIFF
--- a/src/NATS.Client.Core/Commands/CommandWriter.cs
+++ b/src/NATS.Client.Core/Commands/CommandWriter.cs
@@ -78,6 +78,7 @@ internal sealed class CommandWriter : IAsyncDisposable
         _cts = new CancellationTokenSource();
 
         var pipe = new Pipe(new PipeOptions(
+            pool: new ClearingMemoryPool(),
             pauseWriterThreshold: opts.WriterBufferSize, // flush will block after hitting
             resumeWriterThreshold: opts.WriterBufferSize / 2,
             minimumSegmentSize: MinSegmentSize,

--- a/src/NATS.Client.Core/Commands/NatsPooledBufferWriter.cs
+++ b/src/NATS.Client.Core/Commands/NatsPooledBufferWriter.cs
@@ -123,7 +123,7 @@ internal sealed class NatsPooledBufferWriter<T> : IBufferWriter<T>, IObjectPoolN
     public void Reset()
     {
         if (_array != null)
-            _pool.Return(_array);
+            _pool.Return(_array, clearArray: true);
         _array = _pool.Rent(_size);
         _index = 0;
     }

--- a/src/NATS.Client.Core/Internal/ClearingMemoryPool.cs
+++ b/src/NATS.Client.Core/Internal/ClearingMemoryPool.cs
@@ -1,0 +1,43 @@
+using System.Buffers;
+
+namespace NATS.Client.Core.Internal;
+
+/// <summary>
+/// A <see cref="MemoryPool{T}"/> wrapper that clears rented buffers when they
+/// are returned, preventing credential data from leaking through pooled memory.
+/// </summary>
+internal sealed class ClearingMemoryPool : MemoryPool<byte>
+{
+    private readonly MemoryPool<byte> _inner = MemoryPool<byte>.Shared;
+
+    public override int MaxBufferSize => _inner.MaxBufferSize;
+
+    public override IMemoryOwner<byte> Rent(int minBufferSize = -1)
+    {
+        return new ClearingMemoryOwner(_inner.Rent(minBufferSize));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+    }
+
+    private sealed class ClearingMemoryOwner : IMemoryOwner<byte>
+    {
+        private IMemoryOwner<byte>? _inner;
+
+        public ClearingMemoryOwner(IMemoryOwner<byte> inner) => _inner = inner;
+
+        public Memory<byte> Memory => _inner?.Memory ?? Memory<byte>.Empty;
+
+        public void Dispose()
+        {
+            var inner = _inner;
+            if (inner == null)
+                return;
+
+            _inner = null;
+            inner.Memory.Span.Clear();
+            inner.Dispose();
+        }
+    }
+}

--- a/src/NATS.Client.Core/Internal/ClearingMemoryPool.cs
+++ b/src/NATS.Client.Core/Internal/ClearingMemoryPool.cs
@@ -31,11 +31,10 @@ internal sealed class ClearingMemoryPool : MemoryPool<byte>
 
         public void Dispose()
         {
-            var inner = _inner;
+            var inner = Interlocked.Exchange(ref _inner, null);
             if (inner == null)
                 return;
 
-            _inner = null;
             inner.Memory.Span.Clear();
             inner.Dispose();
         }

--- a/src/NATS.Client.Core/Internal/ClearingMemoryPool.cs
+++ b/src/NATS.Client.Core/Internal/ClearingMemoryPool.cs
@@ -8,35 +8,47 @@ namespace NATS.Client.Core.Internal;
 /// </summary>
 internal sealed class ClearingMemoryPool : MemoryPool<byte>
 {
-    private readonly MemoryPool<byte> _inner = MemoryPool<byte>.Shared;
+    private readonly ObjectPool<ClearingMemoryOwner> _wrappers = new(256);
 
-    public override int MaxBufferSize => _inner.MaxBufferSize;
+    public override int MaxBufferSize => int.MaxValue;
 
     public override IMemoryOwner<byte> Rent(int minBufferSize = -1)
     {
-        return new ClearingMemoryOwner(_inner.Rent(minBufferSize));
+        if (!_wrappers.TryPop(out var wrapper))
+        {
+            wrapper = new ClearingMemoryOwner(this);
+        }
+
+        wrapper.SetArray(ArrayPool<byte>.Shared.Rent(minBufferSize == -1 ? 4096 : minBufferSize));
+        return wrapper;
     }
 
     protected override void Dispose(bool disposing)
     {
     }
 
-    private sealed class ClearingMemoryOwner : IMemoryOwner<byte>
+    private sealed class ClearingMemoryOwner : IMemoryOwner<byte>, IObjectPoolNode<ClearingMemoryOwner>
     {
-        private IMemoryOwner<byte>? _inner;
+        private readonly ClearingMemoryPool _pool;
+        private ClearingMemoryOwner? _nextNode;
+        private byte[]? _array;
 
-        public ClearingMemoryOwner(IMemoryOwner<byte> inner) => _inner = inner;
+        public ClearingMemoryOwner(ClearingMemoryPool pool) => _pool = pool;
 
-        public Memory<byte> Memory => _inner?.Memory ?? Memory<byte>.Empty;
+        public ref ClearingMemoryOwner? NextNode => ref _nextNode;
+
+        public Memory<byte> Memory => _array;
+
+        public void SetArray(byte[] array) => _array = array;
 
         public void Dispose()
         {
-            var inner = Interlocked.Exchange(ref _inner, null);
-            if (inner == null)
+            var array = Interlocked.Exchange(ref _array, null);
+            if (array == null)
                 return;
 
-            inner.Memory.Span.Clear();
-            inner.Dispose();
+            ArrayPool<byte>.Shared.Return(array, clearArray: true);
+            _pool._wrappers.TryPush(this);
         }
     }
 }

--- a/src/NATS.Client.Core/Internal/SeqeunceBuilder.cs
+++ b/src/NATS.Client.Core/Internal/SeqeunceBuilder.cs
@@ -138,7 +138,7 @@ internal class SequenceSegment : ReadOnlySequenceSegment<byte>
         // guranteed does not add another segment in same memory so can return buffer in this.
         if (MemoryMarshal.TryGetArray(Memory, out var array) && array.Array != null)
         {
-            ArrayPool<byte>.Shared.Return(array.Array);
+            ArrayPool<byte>.Shared.Return(array.Array, clearArray: true);
         }
 
         Memory = default;

--- a/src/NATS.Client.Core/NatsBufferWriter.cs
+++ b/src/NATS.Client.Core/NatsBufferWriter.cs
@@ -275,7 +275,7 @@ public sealed class NatsBufferWriter<T> : IBufferWriter<T>, IMemoryOwner<T>
 
         _array = null;
 
-        _pool.Return(array);
+        _pool.Return(array, clearArray: true);
     }
 
     /// <inheritdoc/>
@@ -391,7 +391,7 @@ internal static class NatsBufferWriterExtensions
     /// <param name="clearArray">Indicates whether the contents of the array should be cleared before reuse.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newSize"/> is less than 0.</exception>
     /// <remarks>When this method returns, the caller must not use any references to the old array anymore.</remarks>
-    public static void Resize<T>(this ArrayPool<T> pool, [NotNull] ref T[]? array, int newSize, bool clearArray = false)
+    public static void Resize<T>(this ArrayPool<T> pool, [NotNull] ref T[]? array, int newSize, bool clearArray = true)
     {
         // If the old array is null, just create a new one with the requested size
         if (array is null)

--- a/src/NATS.Client.Core/NatsBufferWriter.cs
+++ b/src/NATS.Client.Core/NatsBufferWriter.cs
@@ -391,7 +391,7 @@ internal static class NatsBufferWriterExtensions
     /// <param name="clearArray">Indicates whether the contents of the array should be cleared before reuse.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newSize"/> is less than 0.</exception>
     /// <remarks>When this method returns, the caller must not use any references to the old array anymore.</remarks>
-    public static void Resize<T>(this ArrayPool<T> pool, [NotNull] ref T[]? array, int newSize, bool clearArray = true)
+    public static void Resize<T>(this ArrayPool<T> pool, [NotNull] ref T[]? array, int newSize, bool clearArray = false)
     {
         // If the old array is null, just create a new one with the requested size
         if (array is null)

--- a/src/NATS.Client.Core/NatsMemoryOwner.cs
+++ b/src/NATS.Client.Core/NatsMemoryOwner.cs
@@ -307,7 +307,7 @@ public struct NatsMemoryOwner<T> : IMemoryOwner<T>
 
         _array = null;
 
-        _pool.Return(array);
+        _pool.Return(array, clearArray: true);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Pooled byte arrays carrying credentials (passwords, tokens, JWT, nkey signatures) were returned to `ArrayPool` without clearing, allowing sensitive data to leak into subsequent buffer rentals. This adds `clearArray: true` to all `ArrayPool.Return()` calls and introduces a `ClearingMemoryPool` for the `Pipe` in `CommandWriter` so `CONNECT` message buffers are also zeroed.

- Verify no performance regression in publish/subscribe hot paths