### PR TITLE
Fix NuidTests flaky timeouts

### DIFF
--- a/tests/NATS.Client.CoreUnit.Tests/NuidTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NuidTests.cs
@@ -137,7 +137,7 @@ public class NuidTests
         });
 
         executionThread.Start();
-        executionThread.Join(1_000);
+        Assert.True(executionThread.Join(10_000), $"Thread {executionThread.ManagedThreadId} did not complete within the timeout.");
 
         // Assert
         Assert.Equal(2, Interlocked.CompareExchange(ref _result, 0, 0));
@@ -175,7 +175,7 @@ public class NuidTests
             Volatile.Write(ref completedSuccessfully, didWrite && isMatch);
         });
         t.Start();
-        t.Join(1_000);
+        Assert.True(t.Join(10_000), $"Thread {t.ManagedThreadId} did not complete within the timeout.");
 
         Assert.True(completedSuccessfully);
     }
@@ -202,7 +202,10 @@ public class NuidTests
             threads.Add(t);
         }
 
-        threads.ForEach(t => t.Join(1_000));
+        foreach (var thread in threads)
+        {
+            Assert.True(thread.Join(10_000), $"Thread {thread.ManagedThreadId} did not complete within the timeout.");
+        }
 
         // Assert
         var uniquePrefixes = new HashSet<string>();


### PR DESCRIPTION
Increase thread join timeouts from 1s to 10s and assert the result with a diagnostic message. The short timeouts caused flaky failures on slow CI runners.

- [x] CI green