### PR TITLE
Reset state on credential loading failure

### DIFF
--- a/src/NATS.Client.Core/Internal/UserCredentials.cs
+++ b/src/NATS.Client.Core/Internal/UserCredentials.cs
@@ -159,7 +159,7 @@ internal class UserCredentials
             using var reader = new StreamReader(path);
             return ParseCreds(reader);
         }
-        catch (NatsException e)
+        catch (Exception e)
         {
             throw new NatsException($"Error loading creds file '{path}': {e.Message}", e);
         }

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -394,9 +394,26 @@ public partial class NatsConnection : INatsConnection
                 throw new NatsException($"URI {uri} requires TLS but TlsMode is set to Disable");
         }
 
-        if (!Opts.AuthOpts.IsAnonymous)
+        try
         {
-            _userCredentials = new UserCredentials(Opts.AuthOpts);
+            if (!Opts.AuthOpts.IsAnonymous)
+            {
+                _userCredentials = new UserCredentials(Opts.AuthOpts);
+            }
+        }
+        catch (Exception ex)
+        {
+            var exception = ex as NatsException ?? new NatsException($"Failed to load credentials: {ex.Message}", ex);
+            lock (_gate)
+            {
+                ConnectionState = NatsConnectionState.Closed; // allow retry connect
+
+                // throw for the waiter
+                _waitForOpenConnection.TrySetObservedException(exception);
+                _waitForOpenConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+
+            throw exception;
         }
 
         var attemptedUris = new List<NatsUri>();

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionAuthTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionAuthTests.cs
@@ -1,0 +1,27 @@
+namespace NATS.Client.CoreUnit.Tests;
+
+public class NatsConnectionAuthTests
+{
+    [Fact]
+    public async Task ConnectAsync_MissingCredsFile_SecondCallDoesNotHang()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"nats-missing-{Guid.NewGuid():N}.creds");
+        var opts = NatsOpts.Default with
+        {
+            Url = "nats://127.0.0.1:4222",
+            RetryOnInitialConnect = false,
+            AuthOpts = NatsAuthOpts.Default with { CredsFile = missingPath },
+        };
+
+        await using var nats = new NatsConnection(opts);
+
+        var first = async () => await nats.ConnectAsync();
+        await first.Should().ThrowAsync<NatsException>();
+
+        var secondTask = nats.ConnectAsync().AsTask();
+        var completed = await Task.WhenAny(secondTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        completed.Should().BeSameAs(secondTask, "second ConnectAsync must not hang");
+        var second = async () => await secondTask;
+        await second.Should().ThrowAsync<NatsException>();
+    }
+}


### PR DESCRIPTION
When ConnectAsync throws during credential loading (e.g. missing creds file), ConnectionState stays at Connecting and the waiter TCS is never completed. A second ConnectAsync call then hangs forever waiting on that TCS.

Wrap credential loading in InitialConnectAsync with a try-catch that resets ConnectionState to Closed and faults the waiter, matching the existing pattern for socket and setup failures. Also broaden the catch in LoadCredsFile from NatsException to Exception so IO errors like FileNotFoundException are wrapped properly.

fixes #1104