### PR TITLE
Fix nonce signing when auth_required is omitted

### DIFF
--- a/src/NATS.Client.Core/Internal/UserCredentials.cs
+++ b/src/NATS.Client.Core/Internal/UserCredentials.cs
@@ -138,7 +138,9 @@ internal class UserCredentials
             opts.AuthToken = Token;
         }
 
-        opts.Sig = info is { AuthRequired: true, Nonce: { } } ? Sign(info.Nonce, seed) : null;
+        // Sign whenever the server sends a nonce: servers with no_auth_user defined
+        // omit auth_required from INFO but still expect a signature from NKey clients.
+        opts.Sig = info is { Nonce: { } } ? Sign(info.Nonce, seed) : null;
     }
 
     private (string, string) LoadCredsContent(string creds)

--- a/tests/NATS.Client.TestUtilities/resources/configs/auth/nkey-no-auth-user.conf
+++ b/tests/NATS.Client.TestUtilities/resources/configs/auth/nkey-no-auth-user.conf
@@ -1,0 +1,13 @@
+accounts: {
+  AUTH: {
+    users: [
+      { nkey: UALQSMXRSAA7ZXIGDDJBJ2JOYJVQIWM3LQVDM5KYIPG4EP3FAGJ47BOJ }
+    ]
+  }
+  ANON: {
+    users: [
+      { user: anonymous }
+    ]
+  }
+}
+no_auth_user: anonymous

--- a/tests/NATS.Slow.Tests/NatsConnectionTest.Auth.cs
+++ b/tests/NATS.Slow.Tests/NatsConnectionTest.Auth.cs
@@ -307,6 +307,36 @@ public abstract partial class NatsConnectionTest
         await register;
     }
 
+    [Fact]
+    public async Task NKeyAuthWithNoAuthUserTest()
+    {
+        // Server with no_auth_user defined omits auth_required from INFO but still sends a nonce.
+        // An NKey-configured client must still respond with a signature.
+        var serverOpts = new NatsServerOptsBuilder()
+            .UseTransport(_transportType)
+            .AddServerConfig("resources/configs/auth/nkey-no-auth-user.conf")
+            .Build();
+
+        var clientOpts = NatsOpts.Default with
+        {
+            AuthOpts = NatsAuthOpts.Default with
+            {
+                NKey = "UALQSMXRSAA7ZXIGDDJBJ2JOYJVQIWM3LQVDM5KYIPG4EP3FAGJ47BOJ",
+                Seed = "SUAAVWRZG6M5FA5VRRGWSCIHKTOJC7EWNIT4JV3FTOIPO4OBFR5WA7X5TE",
+            },
+        };
+
+        await using var server = await NatsServer.StartAsync(_output, serverOpts, clientOpts);
+
+        // Anonymous connection should succeed (mapped to no_auth_user).
+        await using var anonConnection = await server.CreateClientConnectionAsync();
+        await anonConnection.PingAsync();
+
+        // NKey-authenticated connection should also succeed.
+        await using var authConnection = await server.CreateClientConnectionAsync(clientOpts);
+        await authConnection.PingAsync();
+    }
+
     public class Auth
     {
         public Auth(string name, string serverConfig, NatsOpts clientOpts, string? urlAuth = null)


### PR DESCRIPTION
When the server is configured with `no_auth_user`, it omits `auth_required` from the INFO message but still sends a `nonce`. The client was gating signature generation on `AuthRequired: true`, so an NKey-configured client would send `nkey` without `sig` and the server would reject the connection with `Authorization Violation`. Other clients (Go, Python) sign whenever a nonce is present; this aligns the .NET client with that behaviour.

Fixes #1087