### PR TITLE
NatsConnection: fix 'occured' -> 'occurred' in error log messages

### DIFF
--- a/src/NATS.Client.Core/Internal/NatsPipeliningWriteProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsPipeliningWriteProtocolProcessor.cs
@@ -300,7 +300,7 @@
 //         }
 //         catch (Exception ex)
 //         {
-//             logger.LogError(ex, "Unexpected error occured in write loop");
+//             logger.LogError(ex, "Unexpected error occurred in write loop");
 //             throw;
 //         }
 //

--- a/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
+++ b/src/NATS.Client.Core/Internal/NatsReadProtocolProcessor.cs
@@ -329,7 +329,7 @@ internal sealed class NatsReadProtocolProcessor : IAsyncDisposable
             }
             catch (Exception ex)
             {
-                _logger.LogError(NatsLogEvents.Protocol, ex, "Error occured during read loop");
+                _logger.LogError(NatsLogEvents.Protocol, ex, "Error occurred during read loop");
                 continue;
             }
         }

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -900,7 +900,7 @@ public partial class NatsConnection : INatsConnection
         }
         catch (Exception ex)
         {
-            _logger.LogError(NatsLogEvents.Connection, ex, "Error occured when publishing events");
+            _logger.LogError(NatsLogEvents.Connection, ex, "Error occurred when publishing events");
             if (!_disposedCts.IsCancellationRequested)
                 _publishEventsTask = Task.Run(PublishEventsAsync, _disposedCts.Token);
         }
@@ -1089,7 +1089,7 @@ public partial class NatsConnection : INatsConnection
         {
             try
             {
-                _logger.LogError(NatsLogEvents.Connection, ex, $"Error occured when disposing {description}");
+                _logger.LogError(NatsLogEvents.Connection, ex, $"Error occurred when disposing {description}");
             }
             catch
             {


### PR DESCRIPTION
Two `LogError` calls in `src/NATS.Client.Core/NatsConnection.cs` (lines 903, 1092) read `Error occured when`. Fixed to `occurred`. Log-string-only change.