### PR TITLE
Fix net481 TLS test flakes

### DIFF
--- a/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
+++ b/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Authentication;
 using System.Text;
 using Synadia.Orbit.Testing.GoHarness;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
@@ -202,6 +203,7 @@ public class TlsPreferTest(ITestOutputHelper output)
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
         var clientAttemptedTls = false;
+        var clientSentConnect = false;
 
         var serverTask = Task.Run(
             async () =>
@@ -241,6 +243,7 @@ public class TlsPreferTest(ITestOutputHelper output)
                 }
                 else if (read == 1 && firstByte[0] == (byte)'C')
                 {
+                    clientSentConnect = true;
                     using var sr = new StreamReader(stream, encoding);
                     var rest = await sr.ReadLineAsync();
                     var line = "C" + rest;
@@ -264,19 +267,42 @@ public class TlsPreferTest(ITestOutputHelper output)
             MaxReconnectRetry = 0,
         });
 
+        Exception? connectException = null;
         try
         {
             await nats.ConnectAsync();
         }
-        catch
+        catch (Exception ex)
         {
             // Expected: TLS handshake fails because server can't do TLS
+            connectException = ex;
         }
 
         await serverTask;
         listener.Stop();
 
-        clientAttemptedTls.Should().BeTrue(
+        // Guard against the actual bug: Prefer mode skipping TLS upgrade and sending plaintext CONNECT.
+        clientSentConnect.Should().BeFalse(
+            "Prefer mode must not send plaintext CONNECT when server advertises tls_available=true");
+
+        if (clientAttemptedTls)
+        {
+            return;
+        }
+
+        // On net481 the client can tear the TCP socket down (RST) after a very early
+        // TLS init failure, so the ClientHello byte is sometimes never observed by the
+        // server. Fall back to ConnectAsync's exception chain as evidence that the
+        // client went down the TLS upgrade path.
+        var causes = new List<Exception>();
+        for (var e = connectException; e != null; e = e.InnerException)
+        {
+            causes.Add(e);
+            output.WriteLine($"[{e.GetType().Name}] {e.Message}");
+        }
+
+        var tlsRelated = causes.Any(c => c is AuthenticationException || c is SocketException || c is IOException);
+        tlsRelated.Should().BeTrue(
             "Prefer mode should attempt TLS upgrade when server advertises tls_available=true");
     }
 

--- a/tests/NATS.Client.Platform.Windows.Tests/TlsTests.cs
+++ b/tests/NATS.Client.Platform.Windows.Tests/TlsTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using NATS.Client.Core;
@@ -23,8 +22,16 @@ public class TlsTests : IClassFixture<TlsTestsNatsServerFixture>
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
 
         var exception = await Assert.ThrowsAsync<NatsException>(async () => await nats.ConnectAsync());
-        Assert.Matches("TLS authentication failed|Unable to read data from the transport", exception.InnerException?.Message);
-        Assert.True(exception.InnerException?.InnerException is SocketException or AuthenticationException);
+
+        // The TLS handshake failure surfaces differently across runtimes and races
+        // (AuthenticationException, SocketException, or IOException on net481 when
+        // the server resets the connection). Walk the exception chain and accept
+        // any of these as evidence that the TLS upgrade was rejected.
+        var causes = Unwrap(exception).ToList();
+        foreach (var cause in causes)
+            _output.WriteLine($"[{cause.GetType().Name}] {cause.Message}");
+
+        Assert.Contains(causes, c => c is AuthenticationException or SocketException or IOException);
     }
 
     [Fact]
@@ -48,6 +55,15 @@ public class TlsTests : IClassFixture<TlsTestsNatsServerFixture>
         {
             await nats.PublishAsync($"{prefix}.foo", i);
             Assert.Equal(i, (await sub.Msgs.ReadAsync()).Data);
+        }
+    }
+
+    private static IEnumerable<Exception> Unwrap(Exception? ex)
+    {
+        while (ex != null)
+        {
+            yield return ex;
+            ex = ex.InnerException;
         }
     }
 }


### PR DESCRIPTION
Two net481-only TLS test flakes caused by the same root cause: on net481 under load, the client can tear down the TCP socket (RST) before the ClientHello is observed at the server, so the usual synchronous `AuthenticationException` path isn't what the assertions see.

`Tls_fails_without_certificates` (Platform.Windows.Tests): the strict `exception.InnerException?.Message` regex compared against `null` when the cause was anywhere but the first inner slot. Walk the exception chain and accept any of `AuthenticationException`, `SocketException`, or `IOException` as evidence the TLS upgrade was rejected.

`Prefer_mode_attempts_tls_upgrade_when_server_advertises_tls_available` (Core2.Tests): the assertion relied on the server reading the ClientHello byte (0x16) first, but on the RST race the server sometimes reads 0 bytes. Fail only when the server observes a plaintext CONNECT (the actual bug this test guards against); otherwise accept either the 0x16 byte or a TLS-related exception chain from `ConnectAsync` as evidence the upgrade was attempted.