### PR TITLE
Fix slow-consumer test first-ping RTT flap

### DIFF
--- a/tests/NATS.Client.JetStream.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/SlowConsumerTest.cs
@@ -86,6 +86,9 @@ public class SlowConsumerTest
         await consumeStarted.Task;
         await Task.Delay(500); // Give time for messages to arrive and channel to fill
 
+        // Warm up the ping path so the first measured RTT doesn't include cold-start cost.
+        await nats.PingAsync();
+
         // Run sequential pings every 100ms - these should NOT be blocked by the slow consumer
         var pingCount = 0;
         var pingErrors = 0;

--- a/tests/NATS.Client.JetStream.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/SlowConsumerTest.cs
@@ -87,7 +87,7 @@ public class SlowConsumerTest
         await Task.Delay(500); // Give time for messages to arrive and channel to fill
 
         // Warm up the ping path so the first measured RTT doesn't include cold-start cost.
-        await nats.PingAsync();
+        await nats.PingAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)); // warm up ping path; skip cold-start RTT cost
 
         // Run sequential pings every 100ms - these should NOT be blocked by the slow consumer
         var pingCount = 0;


### PR DESCRIPTION
The first measured ping in `JetStream_consume_slow_consumer_should_not_block_connection` occasionally clocks ~1000ms on Windows CI (against a `< 1000ms` threshold), while pings 2 through 20 come in under 0.25ms. Send one untimed ping after consume starts so the measurement loop excludes that cold-start cost. The slow-consumer-should-not-block invariant is preserved.