### PR TITLE
Make pinned client Pin ID handling tolerant of duplicate headers

### DIFF
--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -173,7 +173,16 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
 
         if (_debug)
         {
-            _logger.LogDebug(NatsJSLogEvents.PullRequest, "Sending pull request for {Origin} {Msgs}, {Bytes}", origin, request.Batch, request.MaxBytes);
+            _logger.LogDebug(
+                NatsJSLogEvents.PullRequest,
+                "Sending pull request for {Origin} {Msgs}, {Bytes}, pinId={PinId}, expires={Expires}, idleHeartbeat={IdleHeartbeat}, group={Group}",
+                origin,
+                request.Batch,
+                request.MaxBytes,
+                request.Id,
+                request.Expires,
+                request.IdleHeartbeat,
+                request.Group);
         }
 
         return Connection.PublishAsync(

--- a/src/NATS.Client.JetStream/Internal/NatsJSExtensionsInternal.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSExtensionsInternal.cs
@@ -26,9 +26,8 @@ internal static class NatsJSExtensionsInternal
     /// <param name="jsConsumer">The consumer to set the pin ID on.</param>
     public static void TrySetPinIdFromHeaders(NatsHeaders? headers, NatsJSConsumer? jsConsumer)
     {
-        if (jsConsumer != null && headers != null && headers.TryGetValue(NatsPinIdHeader, out var pinIdValues))
+        if (jsConsumer != null && headers != null && headers.TryGetLastValue(NatsPinIdHeader, out var pinId))
         {
-            var pinId = pinIdValues.ToString();
             if (!string.IsNullOrEmpty(pinId))
             {
                 jsConsumer.SetPinId(pinId);

--- a/tests/NATS.Client.JetStream.Tests/PinnedClientTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PinnedClientTest.cs
@@ -1,6 +1,9 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Primitives;
+using NATS.Client.Core;
 using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
+using NATS.Client.JetStream.Internal;
 using NATS.Client.JetStream.Models;
 using NATS.Client.TestUtilities;
 using NATS.Client.TestUtilities2;
@@ -520,6 +523,33 @@ public class PinnedClientTest
 
 public class PinnedClientMockServerTest
 {
+    [Fact]
+    public async Task Pin_id_from_headers_should_use_last_value_when_multiple_headers_present()
+    {
+        await using var ms = new MockServer((_, cmd) =>
+        {
+            if (cmd.Name == "PUB" && cmd.Subject.Contains("CONSUMER.INFO", StringComparison.Ordinal))
+            {
+                cmd.Reply(payload: """{"stream_name":"x","name":"x"}""");
+            }
+
+            return Task.CompletedTask;
+        });
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var nats = new NatsConnection(new NatsOpts { Url = ms.Url });
+        var js = nats.CreateJetStreamContext();
+        var consumer = (NatsJSConsumer)await js.GetConsumerAsync("x", "x", cts.Token);
+        var headers = new NatsHeaders
+        {
+            { "Nats-Pin-Id", new StringValues(["pin-stale", "pin-current"]) },
+        };
+
+        NatsJSExtensionsInternal.TrySetPinIdFromHeaders(headers, consumer);
+
+        Assert.Equal("pin-current", consumer.GetPinId());
+    }
+
     [Fact]
     public async Task Queued_consume_pull_request_should_use_latest_pin_id_when_sent()
     {


### PR DESCRIPTION
  This PR makes pinned client Pin ID handling more robust when multiple Nats-Pin-Id header values are present.

  This was discovered while testing an echo service. The echo service returns incoming headers as-is, so if a request already contains a Nats-Pin-Id the client can observe multiple Nats-Pin-Id values in the same header collection.


  The previous code was not necessarily wrong for the normal case, but it assumed Nats-Pin-Id behaved as a single-value header. With duplicate values, converting the full StringValues to string could use a combined value instead of the current pin id.

  This change updates the client to use the last Nats-Pin-Id value when multiple values are present, matching the latest value appended by the server and making pinned client handling more defensive.

  Changes

  - Use TryGetLastValue("Nats-Pin-Id", out var pinId) when updating the consumer pin id.
  - Add a regression test covering duplicate Nats-Pin-Id headers.
  - Keep existing behavior unchanged for the common single-header case.

  Why
  This is primarily a robustness improvement rather than a fix for the standard path. It protects the client from stale pin ids when server responses preserve previous headers and append a newer Nats-Pin-Id.

  Testing

  - Added coverage for multiple Nats-Pin-Id values and verified that the latest value is used.
