### PR TITLE
Release 3.0.0-preview.4

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-3.0.0-preview.3
+3.0.0-preview.4


### PR DESCRIPTION
Preview release on the 3.0 line bumping version to 3.0.0-preview.4. Brings in everything from 2.8.0-preview.2 via the latest main sync, plus the 3.0-only switch to `System.Threading.Lock` on net9.0+. Adds nats-server v2.14 support for fast-ingest batch publishing via the new `AllowBatchPublish` field on `StreamConfig` (ADR-50).

3.0-only since preview.3:
- Use System.Threading.Lock on NET9_0_OR_GREATER (#1118)

From main (also in 2.8.0-preview.2):
- Add AllowBatchPublish stream config field (#1120)
- Bump OpenTelemetry and OpenTelemetry.Exporter.OpenTelemetryProtocol (#1121)
- Fix setting wrong pin id from status header (#1116)
- Fix slow-consumer test first-ping RTT flap (#1115)
- Fix net481 TLS test flakes (#1111)
- Rewrite README intro (#1114)