### PR TITLE
Add $JS.FC support to JS metadata parser

### DIFF
--- a/src/NATS.Client.JetStream/Internal/ReplyToDateTimeAndSeq.cs
+++ b/src/NATS.Client.JetStream/Internal/ReplyToDateTimeAndSeq.cs
@@ -33,7 +33,7 @@ internal static class ReplyToDateTimeAndSeq
             return null;
         }
 
-        if (originalTokens[0] != "$JS" || originalTokens[1] != "ACK")
+        if (originalTokens[0] != "$JS" || (originalTokens[1] != "ACK" && originalTokens[1] != "FC"))
         {
             return null;
         }

--- a/tests/NATS.Client.JetStream.Tests/Internal/ReplyToDateTimeAndSeqTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/Internal/ReplyToDateTimeAndSeqTest.cs
@@ -35,6 +35,21 @@ public class ReplyToDateTimeAndSeqTest
     }
 
     [Fact]
+    public void ShouldParseV2FlowControlReplyToDateTimeAndSeq()
+    {
+        var natsJSMsgMetadata = ReplyToDateTimeAndSeq.Parse("$JS.FC.MyDomain.1234.UnitTest.GetEvents_0.1.100.1.1696023331771188000.0");
+
+        natsJSMsgMetadata!.Value.Timestamp.ToString("O").Should().Be("2023-09-29T21:35:31.7710000+00:00");
+        natsJSMsgMetadata.Value.Sequence.Stream.Should().Be(100);
+        natsJSMsgMetadata.Value.Sequence.Consumer.Should().Be(1);
+        natsJSMsgMetadata.Value.NumDelivered.Should().Be(1);
+        natsJSMsgMetadata.Value.NumPending.Should().Be(0);
+        natsJSMsgMetadata.Value.Stream.Should().Be("UnitTest");
+        natsJSMsgMetadata.Value.Consumer.Should().Be("GetEvents_0");
+        natsJSMsgMetadata.Value.Domain.Should().Be("MyDomain");
+    }
+
+    [Fact]
     public void ShouldSetNullForReturnWhenReplyToIsNull()
     {
         var natsJSMsgMetadata = ReplyToDateTimeAndSeq.Parse(null);

--- a/tests/NATS.Client.JetStream.Tests/MetadataParserTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/MetadataParserTests.cs
@@ -31,6 +31,8 @@ public class MetadataParserTests
             [new TestData(Name: "parse v2 ignore two", Subject: "$JS.ACK.domain.hash-123.stream.cons.100.200.150.513553500000000000.400.token.1.2", Metadata: expected)],
             [new TestData(Name: "parse v2 underscore", Subject: "$JS.ACK._.hash-123.stream.cons.100.200.150.513553500000000000.400.token", Metadata: expectedNoDomain)],
             [new TestData(Name: "parse v1 successful", Subject: "$JS.ACK.stream.cons.100.200.150.513553500000000000.400", Metadata: expectedNoDomain)],
+            [new TestData(Name: "parse v2 fc successful", Subject: "$JS.FC.domain.hash-123.stream.cons.100.200.150.513553500000000000.400.token", Metadata: expected)],
+            [new TestData(Name: "parse v2 fc underscore", Subject: "$JS.FC._.hash-123.stream.cons.100.200.150.513553500000000000.400.token", Metadata: expectedNoDomain)],
             [new TestData(Name: "invalid no subject1", Subject: string.Empty, Metadata: null)],
             [new TestData(Name: "invalid no subject2", Subject: null, Metadata: null)],
             [new TestData(Name: "invalid less than 9", Subject: "$JS.ACK.2.3.4.5.6.7", Metadata: null)],


### PR DESCRIPTION
NATS server 2.14 introduces the `js_ack_fc_v2` feature flag, which switches JetStream flow-control reply subjects from `$JS.ACK.*` to `$JS.FC.*`. The metadata parser currently rejects anything where the second token isn't `ACK`, so `NatsJSMsg.Metadata` is `null` for FC messages on servers with the flag enabled. The flag is off by default in 2.14 and expected to be on by default in 2.15.

Equivalent fix in nats.java: nats-io/nats.java#1563. nats.go has the same bug at `internal/parser/parse.go:88` and is not yet patched.