### PR TITLE
Add consumer field on stream source/mirror

### DIFF
--- a/src/NATS.Client.JetStream/Models/ConsumerConfigAckPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigAckPolicy.cs
@@ -5,5 +5,9 @@ public enum ConsumerConfigAckPolicy
     Explicit = 0,
     All = 1,
     None = 2,
+
+    /// <summary>
+    /// Acks based on flow control responses. Used for durable consumers driving mirror or source replication (server 2.14+).
+    /// </summary>
     FlowControl = 3,
 }

--- a/src/NATS.Client.JetStream/Models/ConsumerConfigAckPolicy.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerConfigAckPolicy.cs
@@ -5,4 +5,5 @@ public enum ConsumerConfigAckPolicy
     Explicit = 0,
     All = 1,
     None = 2,
+    FlowControl = 3,
 }

--- a/src/NATS.Client.JetStream/Models/StreamConsumerSource.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConsumerSource.cs
@@ -1,0 +1,25 @@
+namespace NATS.Client.JetStream.Models;
+
+/// <summary>
+/// Identifies a pre-created durable consumer used for stream sourcing or mirroring.
+/// When set on a StreamSource, the server uses this consumer instead of creating
+/// an ephemeral one. Available on server 2.14+.
+/// </summary>
+public record StreamConsumerSource
+{
+    /// <summary>
+    /// Name of the durable consumer to use.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("name")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
+    [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^.*>]+$")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The subject the server delivers messages to.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("deliver_subject")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public string? DeliverSubject { get; set; }
+}

--- a/src/NATS.Client.JetStream/Models/StreamConsumerSource.cs
+++ b/src/NATS.Client.JetStream/Models/StreamConsumerSource.cs
@@ -11,10 +11,17 @@ public record StreamConsumerSource
     /// Name of the durable consumer to use.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("name")]
-    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
+    [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
     [System.ComponentModel.DataAnnotations.StringLength(int.MaxValue, MinimumLength = 1)]
     [System.ComponentModel.DataAnnotations.RegularExpression(@"^[^.*>]+$")]
-    public string? Name { get; set; }
+#if NET6_0
+    public string Name { get; set; } = default!;
+#else
+#pragma warning disable SA1206
+    public required string Name { get; set; }
+#pragma warning restore SA1206
+#endif
 
     /// <summary>
     /// The subject the server delivers messages to.

--- a/src/NATS.Client.JetStream/Models/StreamSource.cs
+++ b/src/NATS.Client.JetStream/Models/StreamSource.cs
@@ -57,6 +57,13 @@ public record StreamSource
     public ExternalStreamSource? External { get; set; }
 
     /// <summary>
+    /// Configures durable sourcing using a pre-created consumer.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("consumer")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public StreamConsumerSource? Consumer { get; set; }
+
+    /// <summary>
     /// This field is a convenience for setting up an ExternalStream.
     /// If set, the value here is used to calculate the JetStreamAPI prefix.
     /// This field is never serialized to the server. This value cannot be set

--- a/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
+++ b/src/NATS.Client.JetStream/NatsJSJsonSerializer.cs
@@ -74,6 +74,7 @@ public static class NatsJSJsonSerializer<T>
 [JsonSerializable(typeof(StreamRestoreResponse))]
 [JsonSerializable(typeof(StreamSnapshotRequest))]
 [JsonSerializable(typeof(StreamSnapshotResponse))]
+[JsonSerializable(typeof(StreamConsumerSource))]
 [JsonSerializable(typeof(StreamSource))]
 [JsonSerializable(typeof(StreamSourceInfo))]
 [JsonSerializable(typeof(StreamState))]
@@ -154,6 +155,8 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
                 return (TEnum)(object)ConsumerConfigAckPolicy.All;
             case "explicit":
                 return (TEnum)(object)ConsumerConfigAckPolicy.Explicit;
+            case "flow_control":
+                return (TEnum)(object)ConsumerConfigAckPolicy.FlowControl;
             }
         }
 
@@ -294,6 +297,9 @@ internal class NatsJSJsonStringEnumConverter<TEnum> : JsonConverter<TEnum>
                 return;
             case ConsumerConfigAckPolicy.Explicit:
                 writer.WriteStringValue("explicit");
+                return;
+            case ConsumerConfigAckPolicy.FlowControl:
+                writer.WriteStringValue("flow_control");
                 return;
             }
         }

--- a/tests/NATS.Client.JetStream.Tests/ManageStreamTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageStreamTest.cs
@@ -468,6 +468,100 @@ public class ManageStreamTest
         Assert.Equal(10, promoted.Info.State.Messages);
     }
 
+    [SkipIfNatsServer(versionEarlierThan: "2.14")]
+    public async Task Mirror_and_source_with_durable_consumer()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var prefix = _server.GetNextId();
+        await nats.ConnectRetryAsync();
+
+        var js = new NatsJSContext(nats);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var sourceName = $"{prefix}SOURCE";
+        await js.CreateStreamAsync(new StreamConfig(sourceName, [$"{prefix}foo"]), cts.Token);
+
+        await js.CreateOrUpdateConsumerAsync(
+            sourceName,
+            new ConsumerConfig("C")
+            {
+                AckPolicy = ConsumerConfigAckPolicy.FlowControl,
+                IdleHeartbeat = TimeSpan.FromSeconds(1),
+                DeliverSubject = $"{prefix}deliver.mirror",
+            },
+            cts.Token);
+        await js.CreateOrUpdateConsumerAsync(
+            sourceName,
+            new ConsumerConfig("C2")
+            {
+                AckPolicy = ConsumerConfigAckPolicy.FlowControl,
+                IdleHeartbeat = TimeSpan.FromSeconds(1),
+                DeliverSubject = $"{prefix}deliver.source",
+            },
+            cts.Token);
+
+        var mirror = await js.CreateStreamAsync(
+            new StreamConfig
+            {
+                Name = $"{prefix}MIRROR",
+                Mirror = new StreamSource
+                {
+                    Name = sourceName,
+                    Consumer = new StreamConsumerSource { Name = "C", DeliverSubject = $"{prefix}deliver.mirror" },
+                },
+            },
+            cts.Token);
+
+        Assert.NotNull(mirror.Info.Config.Mirror);
+        Assert.NotNull(mirror.Info.Config.Mirror!.Consumer);
+        Assert.Equal("C", mirror.Info.Config.Mirror.Consumer!.Name);
+        Assert.Equal($"{prefix}deliver.mirror", mirror.Info.Config.Mirror.Consumer.DeliverSubject);
+
+        var sourced = await js.CreateStreamAsync(
+            new StreamConfig
+            {
+                Name = $"{prefix}SOURCED",
+                Sources = new[]
+                {
+                    new StreamSource
+                    {
+                        Name = sourceName,
+                        Consumer = new StreamConsumerSource { Name = "C2", DeliverSubject = $"{prefix}deliver.source" },
+                    },
+                },
+            },
+            cts.Token);
+
+        Assert.NotNull(sourced.Info.Config.Sources);
+        var sourceEntry = sourced.Info.Config.Sources!.Single();
+        Assert.NotNull(sourceEntry.Consumer);
+        Assert.Equal("C2", sourceEntry.Consumer!.Name);
+        Assert.Equal($"{prefix}deliver.source", sourceEntry.Consumer.DeliverSubject);
+
+        for (var i = 0; i < 3; i++)
+        {
+            await js.PublishAsync($"{prefix}foo", new byte[] { (byte)i }, cancellationToken: cts.Token);
+        }
+
+        await Retry.Until(
+            "mirror caught up",
+            async () =>
+            {
+                await mirror.RefreshAsync(cts.Token);
+                return mirror.Info.State.Messages == 3;
+            },
+            timeout: TimeSpan.FromSeconds(10));
+
+        await Retry.Until(
+            "sourced caught up",
+            async () =>
+            {
+                await sourced.RefreshAsync(cts.Token);
+                return sourced.Info.State.Messages == 3;
+            },
+            timeout: TimeSpan.FromSeconds(10));
+    }
+
     [SkipIfNatsServer(versionEarlierThan: "2.12.5")]
     public async Task Snapshot_request_with_chunk_and_window_size()
     {


### PR DESCRIPTION
Adds `Consumer` to `StreamSource` so the server uses a pre-created durable consumer to drive mirror or source replication, plus the `flow_control` ack policy that those consumers require. Available on server 2.14+.