### PR TITLE
Fix unobserved task exception during dispose

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -321,6 +321,21 @@ public partial class NatsConnection : INatsConnection
             _disposedCts.Cancel();
             _initialConnectCts.Cancel();
 #endif
+
+            // Drain the reconnect loop so any exception it raises is observed here
+            // rather than leaking onto the finalizer thread.
+            var reconnectLoopTask = _reconnectLoopTask;
+            if (reconnectLoopTask is not null)
+            {
+                try
+                {
+                    await reconnectLoopTask.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(NatsLogEvents.Connection, ex, "Reconnect loop completed with exception during dispose");
+                }
+            }
         }
     }
 
@@ -513,7 +528,7 @@ public partial class NatsConnection : INatsConnection
 #pragma warning disable VSTHRD103
             _initialConnectCts.Cancel();
 #pragma warning restore VSTHRD103
-            _reconnectLoopTask = Task.Run(ReconnectLoop);
+            _reconnectLoopTask = Task.Run(ReconnectLoopAsync);
             _eventChannel.Writer.TryWrite((NatsEvent.ConnectionOpened, new NatsEventArgs(url?.ToString() ?? string.Empty)));
         }
     }
@@ -644,23 +659,45 @@ public partial class NatsConnection : INatsConnection
                     reconnectTask = _subscriptionManager.WriteReconnectCommandsAsync(priorityCommandWriter.CommandWriter).AsTask();
                 }
 
-                // receive COMMAND response (PONG or ERROR)
                 try
                 {
-                    await waitForPongOrErrorSignal.Task
-                        .WaitAsync(Opts.ConnectTimeout)
-                        .ConfigureAwait(false);
-                }
-                catch (TimeoutException)
-                {
-                    _logger.LogDebug(NatsLogEvents.Connection, "Timeout waiting for initial pong");
-                    throw;
-                }
+                    // receive COMMAND response (PONG or ERROR)
+                    try
+                    {
+                        await waitForPongOrErrorSignal.Task
+                            .WaitAsync(Opts.ConnectTimeout)
+                            .ConfigureAwait(false);
+                    }
+                    catch (TimeoutException)
+                    {
+                        _logger.LogDebug(NatsLogEvents.Connection, "Timeout waiting for initial pong");
+                        throw;
+                    }
 
-                if (reconnectTask != null)
+                    if (reconnectTask != null)
+                    {
+                        // wait for reconnect commands to complete
+                        await reconnectTask.ConfigureAwait(false);
+                    }
+                }
+                catch
                 {
-                    // wait for reconnect commands to complete
-                    await reconnectTask.ConfigureAwait(false);
+                    // The priority writer is about to be torn down on the way out;
+                    // observe the reconnect task so its fault can't surface later
+                    // as an UnobservedTaskException on the finalizer thread.
+                    if (reconnectTask != null)
+                    {
+                        try
+                        {
+                            await reconnectTask.ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogDebug(NatsLogEvents.Connection, ex, "Reconnect commands faulted during teardown");
+                        }
+                    }
+
+                    throw;
                 }
             }
 
@@ -705,7 +742,7 @@ public partial class NatsConnection : INatsConnection
         _logger.LogDebug(NatsLogEvents.Connection, "Setup reader and writer completed successfully");
     }
 
-    private async void ReconnectLoop()
+    private async Task ReconnectLoopAsync()
     {
         var reconnectCount = Interlocked.Increment(ref _reconnectCount);
         _logger.LogDebug(NatsLogEvents.Connection, "Reconnect loop started [{ReconnectCount}]", reconnectCount);
@@ -741,7 +778,9 @@ public partial class NatsConnection : INatsConnection
                 ConnectionState = NatsConnectionState.Reconnecting;
                 _waitForOpenConnection.TrySetCanceled();
                 _waitForOpenConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+#pragma warning disable VSTHRD103
                 _pingTimerCancellationTokenSource?.Cancel();
+#pragma warning restore VSTHRD103
             }
 
             // Invoke event after state changed
@@ -838,7 +877,7 @@ public partial class NatsConnection : INatsConnection
                 _pingTimerCancellationTokenSource = new CancellationTokenSource();
                 StartPingTimer(_pingTimerCancellationTokenSource.Token);
                 _waitForOpenConnection.TrySetResult();
-                _reconnectLoopTask = Task.Run(ReconnectLoop);
+                _reconnectLoopTask = Task.Run(ReconnectLoopAsync);
                 _eventChannel.Writer.TryWrite((NatsEvent.ConnectionOpened, new NatsEventArgs(url.ToString())));
             }
         }

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -70,7 +70,7 @@ public partial class NatsConnection : INatsConnection
     private string _lastAuthError = string.Empty;
     private bool _stopRetries;
     private Task? _publishEventsTask;
-    private Task? _reconnectLoopTask;
+    private volatile Task? _reconnectLoopTask;
 
     public NatsConnection()
         : this(NatsOpts.Default)

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -79,7 +79,7 @@ public partial class NatsConnection : INatsConnection
     private string _lastAuthError = string.Empty;
     private bool _stopRetries;
     private Task? _publishEventsTask;
-    private Task? _reconnectLoopTask;
+    private volatile Task? _reconnectLoopTask;
 
     public NatsConnection()
         : this(NatsOpts.Default)

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -376,6 +376,21 @@ public partial class NatsConnection : INatsConnection
             _disposedCts.Cancel();
             _initialConnectCts.Cancel();
 #endif
+
+            // Drain the reconnect loop so any exception it raises is observed here
+            // rather than leaking onto the finalizer thread.
+            var reconnectLoopTask = _reconnectLoopTask;
+            if (reconnectLoopTask is not null)
+            {
+                try
+                {
+                    await reconnectLoopTask.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(NatsLogEvents.Connection, ex, "Reconnect loop completed with exception during dispose");
+                }
+            }
         }
     }
 
@@ -578,7 +593,7 @@ public partial class NatsConnection : INatsConnection
 #pragma warning disable VSTHRD103
             _initialConnectCts.Cancel();
 #pragma warning restore VSTHRD103
-            _reconnectLoopTask = Task.Run(ReconnectLoop);
+            _reconnectLoopTask = Task.Run(ReconnectLoopAsync);
             PushEvent(NatsEvent.ConnectionOpened, new NatsEventArgs(url?.ToString() ?? string.Empty));
         }
     }
@@ -709,23 +724,45 @@ public partial class NatsConnection : INatsConnection
                     reconnectTask = _subscriptionManager.WriteReconnectCommandsAsync(priorityCommandWriter.CommandWriter).AsTask();
                 }
 
-                // receive COMMAND response (PONG or ERROR)
                 try
                 {
-                    await waitForPongOrErrorSignal.Task
-                        .WaitAsync(Opts.ConnectTimeout)
-                        .ConfigureAwait(false);
-                }
-                catch (TimeoutException)
-                {
-                    _logger.LogDebug(NatsLogEvents.Connection, "Timeout waiting for initial pong");
-                    throw;
-                }
+                    // receive COMMAND response (PONG or ERROR)
+                    try
+                    {
+                        await waitForPongOrErrorSignal.Task
+                            .WaitAsync(Opts.ConnectTimeout)
+                            .ConfigureAwait(false);
+                    }
+                    catch (TimeoutException)
+                    {
+                        _logger.LogDebug(NatsLogEvents.Connection, "Timeout waiting for initial pong");
+                        throw;
+                    }
 
-                if (reconnectTask != null)
+                    if (reconnectTask != null)
+                    {
+                        // wait for reconnect commands to complete
+                        await reconnectTask.ConfigureAwait(false);
+                    }
+                }
+                catch
                 {
-                    // wait for reconnect commands to complete
-                    await reconnectTask.ConfigureAwait(false);
+                    // The priority writer is about to be torn down on the way out;
+                    // observe the reconnect task so its fault can't surface later
+                    // as an UnobservedTaskException on the finalizer thread.
+                    if (reconnectTask != null)
+                    {
+                        try
+                        {
+                            await reconnectTask.ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogDebug(NatsLogEvents.Connection, ex, "Reconnect commands faulted during teardown");
+                        }
+                    }
+
+                    throw;
                 }
             }
 
@@ -770,7 +807,7 @@ public partial class NatsConnection : INatsConnection
         _logger.LogDebug(NatsLogEvents.Connection, "Setup reader and writer completed successfully");
     }
 
-    private async void ReconnectLoop()
+    private async Task ReconnectLoopAsync()
     {
         var reconnectCount = Interlocked.Increment(ref _reconnectCount);
         _logger.LogDebug(NatsLogEvents.Connection, "Reconnect loop started [{ReconnectCount}]", reconnectCount);
@@ -806,7 +843,9 @@ public partial class NatsConnection : INatsConnection
                 ConnectionState = NatsConnectionState.Reconnecting;
                 _waitForOpenConnection.TrySetCanceled();
                 _waitForOpenConnection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+#pragma warning disable VSTHRD103
                 _pingTimerCancellationTokenSource?.Cancel();
+#pragma warning restore VSTHRD103
             }
 
             // Invoke event after state changed
@@ -905,7 +944,7 @@ public partial class NatsConnection : INatsConnection
                 _pingTimerCancellationTokenSource = new CancellationTokenSource();
                 StartPingTimer(_pingTimerCancellationTokenSource.Token);
                 _waitForOpenConnection.TrySetResult();
-                _reconnectLoopTask = Task.Run(ReconnectLoop);
+                _reconnectLoopTask = Task.Run(ReconnectLoopAsync);
                 PushEvent(NatsEvent.ConnectionOpened, new NatsEventArgs(url.ToString()));
             }
 

--- a/tests/NATS.Client.Core2.Tests/DisposeUnobservedExceptionTests.cs
+++ b/tests/NATS.Client.Core2.Tests/DisposeUnobservedExceptionTests.cs
@@ -1,0 +1,135 @@
+using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
+using Synadia.Orbit.Testing.NatsServerProcessManager;
+
+namespace NATS.Client.Core2.Tests;
+
+public class DisposeUnobservedExceptionTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task Dispose_after_connect_does_not_cause_UnobservedTaskException()
+    {
+        var unobserved = new List<Exception>();
+
+        void Handler(object? sender, UnobservedTaskExceptionEventArgs args)
+        {
+            if (args.Exception is null)
+                return;
+
+            foreach (var inner in args.Exception.InnerExceptions)
+            {
+                if ((inner.StackTrace ?? string.Empty).Contains("NATS.Client.Core"))
+                    unobserved.Add(inner);
+            }
+        }
+
+        TaskScheduler.UnobservedTaskException += Handler;
+        try
+        {
+            await using (var server = await NatsServerProcess.StartAsync())
+            {
+                var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+                await nats.ConnectRetryAsync();
+                await using var sub = await nats.SubscribeCoreAsync<int>("regression.test");
+                await nats.DisposeAsync();
+            }
+
+            await Task.Delay(200);
+            for (var i = 0; i < 3; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= Handler;
+        }
+
+        unobserved.Should().BeEmpty(because: "dispose should observe all background tasks");
+    }
+
+    [Fact]
+    public async Task Dispose_during_reconnect_does_not_cause_UnobservedTaskException()
+    {
+        // Reproduce the orphan-reconnect-task path: complete the initial handshake,
+        // disconnect to push the client into the reconnect loop, then refuse PONG so
+        // the PONG wait inside SetupReaderWriterAsync(true) times out. Without the
+        // fix, the reconnectTask spawned beforehand is abandoned and faults later.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var pingCount = 0;
+
+        await using var server = new MockServer(
+            handler: async (client, cmd) =>
+            {
+                if (cmd.Name == "PING")
+                {
+                    var n = Interlocked.Increment(ref pingCount);
+                    if (n == 1)
+                    {
+                        // initial handshake: reply PONG, then drop the socket
+                        await client.Writer.WriteAsync("PONG\r\n");
+                        await client.Writer.FlushAsync();
+                        client.Close();
+                    }
+
+                    // subsequent PINGs: stay silent so PONG wait times out
+                }
+            },
+            logger: m => output.WriteLine(m),
+            autoPong: false,
+            cancellationToken: cts.Token);
+
+        await server.Ready;
+
+        var nats = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            ConnectTimeout = TimeSpan.FromMilliseconds(500),
+            ReconnectWaitMin = TimeSpan.FromMilliseconds(50),
+            ReconnectWaitMax = TimeSpan.FromMilliseconds(50),
+        });
+
+        var unobserved = new List<Exception>();
+
+        void Handler(object? sender, UnobservedTaskExceptionEventArgs args)
+        {
+            if (args.Exception is null)
+                return;
+
+            foreach (var inner in args.Exception.InnerExceptions)
+            {
+                if ((inner.StackTrace ?? string.Empty).Contains("NATS.Client.Core"))
+                    unobserved.Add(inner);
+            }
+        }
+
+        TaskScheduler.UnobservedTaskException += Handler;
+        try
+        {
+            await nats.ConnectAsync();
+
+            // Subscribe so WriteReconnectCommandsAsync has work to do on the reconnect
+            // attempt that gets orphaned.
+            _ = await nats.SubscribeCoreAsync<int>("regression.test");
+
+            // Wait long enough for at least one reconnect attempt to time out.
+            await Task.Delay(1500);
+
+            await nats.DisposeAsync();
+
+            await Task.Delay(200);
+            for (var i = 0; i < 3; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+        }
+        finally
+        {
+            TaskScheduler.UnobservedTaskException -= Handler;
+        }
+
+        unobserved.Should().BeEmpty(because: "the orphaned reconnect task must be observed");
+    }
+}

--- a/tests/NATS.Client.Core2.Tests/DisposeUnobservedExceptionTests.cs
+++ b/tests/NATS.Client.Core2.Tests/DisposeUnobservedExceptionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using NATS.Client.TestUtilities;
 using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
@@ -9,7 +10,7 @@ public class DisposeUnobservedExceptionTests(ITestOutputHelper output)
     [Fact]
     public async Task Dispose_after_connect_does_not_cause_UnobservedTaskException()
     {
-        var unobserved = new List<Exception>();
+        var unobserved = new ConcurrentBag<Exception>();
 
         void Handler(object? sender, UnobservedTaskExceptionEventArgs args)
         {
@@ -90,7 +91,7 @@ public class DisposeUnobservedExceptionTests(ITestOutputHelper output)
             ReconnectWaitMax = TimeSpan.FromMilliseconds(50),
         });
 
-        var unobserved = new List<Exception>();
+        var unobserved = new ConcurrentBag<Exception>();
 
         void Handler(object? sender, UnobservedTaskExceptionEventArgs args)
         {

--- a/tests/NATS.Client.Core2.Tests/DisposeUnobservedExceptionTests.cs
+++ b/tests/NATS.Client.Core2.Tests/DisposeUnobservedExceptionTests.cs
@@ -68,13 +68,20 @@ public class DisposeUnobservedExceptionTests(ITestOutputHelper output)
                     var n = Interlocked.Increment(ref pingCount);
                     if (n == 1)
                     {
-                        // initial handshake: reply PONG, then drop the socket
+                        // initial handshake: reply PONG so the connection opens.
+                        // Don't drop the socket here: ConnectAsync must observe the
+                        // Open state first, otherwise it re-waits for a reconnect
+                        // that never succeeds and the test hangs.
                         await client.Writer.WriteAsync("PONG\r\n");
                         await client.Writer.FlushAsync();
-                        client.Close();
                     }
 
                     // subsequent PINGs: stay silent so PONG wait times out
+                }
+                else if (cmd is { Name: "PUB", Subject: "drop.connection" })
+                {
+                    // deterministic disconnect once the test is fully set up
+                    client.Close();
                 }
             },
             logger: m => output.WriteLine(m),
@@ -113,6 +120,10 @@ public class DisposeUnobservedExceptionTests(ITestOutputHelper output)
             // Subscribe so WriteReconnectCommandsAsync has work to do on the reconnect
             // attempt that gets orphaned.
             _ = await nats.SubscribeCoreAsync<int>("regression.test");
+
+            // Tell the mock server to drop the socket, pushing the client into the
+            // reconnect loop where every PONG wait times out.
+            await nats.PublishAsync("drop.connection");
 
             // Wait long enough for at least one reconnect attempt to time out.
             await Task.Delay(1500);


### PR DESCRIPTION
Reported by @xwang-dev: disposing a `NatsConnection` could leak an `UnobservedTaskException` to the finalizer thread. Two related issues addressed: (1) the `reconnectTask` spawned inside `SetupReaderWriterAsync` was abandoned when the PONG wait threw, so any later fault went unobserved; (2) `ReconnectLoop` was `async void`, so its lifecycle could not be awaited from `DisposeAsync`. Now the orphan task is observed in a catch path before rethrow, the loop is `async Task ReconnectLoopAsync`, and `DisposeAsync` awaits `_reconnectLoopTask` and swallows-with-log.

Fixes #1124