### PR TITLE
Fix subscription timeout overflow

### DIFF
--- a/src/NATS.Client.Core/Internal/ReplyTask.cs
+++ b/src/NATS.Client.Core/Internal/ReplyTask.cs
@@ -23,7 +23,9 @@ internal sealed class ReplyTask<T> : ReplyTaskBase, IDisposable
         Subject = subject;
         _connection = connection;
         _deserializer = deserializer;
-        _requestTimeout = requestTimeout;
+        _requestTimeout = requestTimeout > NatsSubBase.MaxSupportedTimeout
+            ? Timeout.InfiniteTimeSpan
+            : requestTimeout;
         _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _gate = new object();
     }

--- a/src/NATS.Client.Core/Internal/ReplyTask.cs
+++ b/src/NATS.Client.Core/Internal/ReplyTask.cs
@@ -23,9 +23,7 @@ internal sealed class ReplyTask<T> : ReplyTaskBase, IDisposable
         Subject = subject;
         _connection = connection;
         _deserializer = deserializer;
-        _requestTimeout = requestTimeout > NatsSubBase.MaxSupportedTimeout
-            ? Timeout.InfiniteTimeSpan
-            : requestTimeout;
+        _requestTimeout = TimeoutValidation.Validate(requestTimeout, nameof(requestTimeout), Timeout.InfiniteTimeSpan);
         _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         _gate = new object();
     }

--- a/src/NATS.Client.Core/Internal/TimeoutValidation.cs
+++ b/src/NATS.Client.Core/Internal/TimeoutValidation.cs
@@ -6,18 +6,18 @@ internal static class TimeoutValidation
     // TimeSpan.MaxValue and Timeout.InfiniteTimeSpan are accepted as explicit "no timeout" sentinels.
     public static readonly TimeSpan MaxSupportedTimeout = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
 
-    public static TimeSpan Validate(TimeSpan value, string paramName, TimeSpan noTimeoutResult)
+    public static TimeSpan Validate(TimeSpan? value, string paramName, TimeSpan noTimeoutResult)
     {
-        if (value == TimeSpan.MaxValue || value == Timeout.InfiniteTimeSpan)
+        if (value is not { } v || v == TimeSpan.MaxValue || v == Timeout.InfiniteTimeSpan)
             return noTimeoutResult;
-        if (value < TimeSpan.Zero || value > MaxSupportedTimeout)
+        if (v < TimeSpan.Zero || v > MaxSupportedTimeout)
         {
             throw new ArgumentOutOfRangeException(
                 paramName,
-                value,
+                v,
                 $"{paramName} must be between TimeSpan.Zero and {MaxSupportedTimeout}, or TimeSpan.MaxValue / Timeout.InfiniteTimeSpan for no timeout.");
         }
 
-        return value;
+        return v;
     }
 }

--- a/src/NATS.Client.Core/Internal/TimeoutValidation.cs
+++ b/src/NATS.Client.Core/Internal/TimeoutValidation.cs
@@ -1,0 +1,23 @@
+namespace NATS.Client.Core.Internal;
+
+internal static class TimeoutValidation
+{
+    // Timer.Change and Task.WaitAsync throw for dueTime > (uint.MaxValue - 1) ms (~49.7 days).
+    // TimeSpan.MaxValue and Timeout.InfiniteTimeSpan are accepted as explicit "no timeout" sentinels.
+    public static readonly TimeSpan MaxSupportedTimeout = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+
+    public static TimeSpan Validate(TimeSpan value, string paramName, TimeSpan noTimeoutResult)
+    {
+        if (value == TimeSpan.MaxValue || value == Timeout.InfiniteTimeSpan)
+            return noTimeoutResult;
+        if (value < TimeSpan.Zero || value > MaxSupportedTimeout)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                value,
+                $"{paramName} must be between TimeSpan.Zero and {MaxSupportedTimeout}, or TimeSpan.MaxValue / Timeout.InfiniteTimeSpan for no timeout.");
+        }
+
+        return value;
+    }
+}

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -30,10 +30,6 @@ public enum NatsSubEndReason
 /// </summary>
 public abstract class NatsSubBase
 {
-    // Timer.Change and Task.WaitAsync throw for dueTime > (uint.MaxValue - 1) ms (~49.7 days);
-    // values beyond this are treated as "no timeout".
-    internal static readonly TimeSpan MaxSupportedTimeout = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
-
     private static readonly byte[] NoRespondersHeaderSequence = { (byte)' ', (byte)'5', (byte)'0', (byte)'3' };
     private readonly ILogger _logger;
     private readonly object _gate = new();
@@ -84,9 +80,9 @@ public abstract class NatsSubBase
         _manager = manager;
         _pendingMsgs = opts is { MaxMsgs: > 0 } ? opts.MaxMsgs ?? -1 : -1;
         _countPendingMsgs = _pendingMsgs > 0;
-        _idleTimeout = NormalizeTimeout(opts?.IdleTimeout);
-        _startUpTimeout = NormalizeTimeout(opts?.StartUpTimeout);
-        _timeout = NormalizeTimeout(opts?.Timeout);
+        _idleTimeout = NormalizeTimeout(opts?.IdleTimeout, nameof(NatsSubOpts.IdleTimeout));
+        _startUpTimeout = NormalizeTimeout(opts?.StartUpTimeout, nameof(NatsSubOpts.StartUpTimeout));
+        _timeout = NormalizeTimeout(opts?.Timeout, nameof(NatsSubOpts.Timeout));
 
         Connection = connection;
         Subject = subject;
@@ -608,12 +604,8 @@ public abstract class NatsSubBase
 #pragma warning restore CA2012
     }
 
-    private static TimeSpan NormalizeTimeout(TimeSpan? value)
-    {
-        if (value is not { } v || v <= TimeSpan.Zero || v > MaxSupportedTimeout)
-            return TimeSpan.Zero;
-        return v;
-    }
+    private static TimeSpan NormalizeTimeout(TimeSpan? value, string paramName)
+        => value is { } v ? TimeoutValidation.Validate(v, paramName, TimeSpan.Zero) : TimeSpan.Zero;
 
     private async ValueTask WaitForReaderDrainCoreAsync(Task task, TimeSpan timeout)
     {

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -30,6 +30,10 @@ public enum NatsSubEndReason
 /// </summary>
 public abstract class NatsSubBase
 {
+    // Timer.Change and Task.WaitAsync throw for dueTime > (uint.MaxValue - 1) ms (~49.7 days);
+    // values beyond this are treated as "no timeout".
+    internal static readonly TimeSpan MaxSupportedTimeout = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+
     private static readonly byte[] NoRespondersHeaderSequence = { (byte)' ', (byte)'5', (byte)'0', (byte)'3' };
     private readonly ILogger _logger;
     private readonly object _gate = new();
@@ -80,9 +84,9 @@ public abstract class NatsSubBase
         _manager = manager;
         _pendingMsgs = opts is { MaxMsgs: > 0 } ? opts.MaxMsgs ?? -1 : -1;
         _countPendingMsgs = _pendingMsgs > 0;
-        _idleTimeout = opts?.IdleTimeout ?? TimeSpan.Zero;
-        _startUpTimeout = opts?.StartUpTimeout ?? TimeSpan.Zero;
-        _timeout = opts?.Timeout ?? TimeSpan.Zero;
+        _idleTimeout = NormalizeTimeout(opts?.IdleTimeout);
+        _startUpTimeout = NormalizeTimeout(opts?.StartUpTimeout);
+        _timeout = NormalizeTimeout(opts?.Timeout);
 
         Connection = connection;
         Subject = subject;
@@ -602,6 +606,13 @@ public abstract class NatsSubBase
         UnsubscribeAsync();
 #pragma warning restore VSTHRD110
 #pragma warning restore CA2012
+    }
+
+    private static TimeSpan NormalizeTimeout(TimeSpan? value)
+    {
+        if (value is not { } v || v <= TimeSpan.Zero || v > MaxSupportedTimeout)
+            return TimeSpan.Zero;
+        return v;
     }
 
     private async ValueTask WaitForReaderDrainCoreAsync(Task task, TimeSpan timeout)

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -80,9 +80,9 @@ public abstract class NatsSubBase
         _manager = manager;
         _pendingMsgs = opts is { MaxMsgs: > 0 } ? opts.MaxMsgs ?? -1 : -1;
         _countPendingMsgs = _pendingMsgs > 0;
-        _idleTimeout = NormalizeTimeout(opts?.IdleTimeout, nameof(NatsSubOpts.IdleTimeout));
-        _startUpTimeout = NormalizeTimeout(opts?.StartUpTimeout, nameof(NatsSubOpts.StartUpTimeout));
-        _timeout = NormalizeTimeout(opts?.Timeout, nameof(NatsSubOpts.Timeout));
+        _idleTimeout = TimeoutValidation.Validate(opts?.IdleTimeout, nameof(NatsSubOpts.IdleTimeout), TimeSpan.Zero);
+        _startUpTimeout = TimeoutValidation.Validate(opts?.StartUpTimeout, nameof(NatsSubOpts.StartUpTimeout), TimeSpan.Zero);
+        _timeout = TimeoutValidation.Validate(opts?.Timeout, nameof(NatsSubOpts.Timeout), TimeSpan.Zero);
 
         Connection = connection;
         Subject = subject;
@@ -603,9 +603,6 @@ public abstract class NatsSubBase
 #pragma warning restore VSTHRD110
 #pragma warning restore CA2012
     }
-
-    private static TimeSpan NormalizeTimeout(TimeSpan? value, string paramName)
-        => value is { } v ? TimeoutValidation.Validate(v, paramName, TimeSpan.Zero) : TimeSpan.Zero;
 
     private async ValueTask WaitForReaderDrainCoreAsync(Task task, TimeSpan timeout)
     {

--- a/src/NATS.Client.Core/NatsSubOpts.cs
+++ b/src/NATS.Client.Core/NatsSubOpts.cs
@@ -18,9 +18,12 @@ public record NatsSubOpts
     /// </summary>
     /// <remarks>
     /// If not set, all published messages will be received until explicitly
-    /// unsubscribed or disposed. Values greater than ~49.7 days (the maximum
-    /// supported by <see cref="System.Threading.Timer"/>) are treated as
-    /// "no timeout".
+    /// unsubscribed or disposed. Use <see cref="TimeSpan.MaxValue"/> or
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to explicitly
+    /// disable the timeout. Other values must be between zero and
+    /// ~49.7 days (the maximum supported by <see cref="System.Threading.Timer"/>);
+    /// out-of-range values throw <see cref="ArgumentOutOfRangeException"/>
+    /// when the subscription starts.
     /// </remarks>
     public TimeSpan? Timeout { get; init; }
 
@@ -30,9 +33,12 @@ public record NatsSubOpts
     /// </summary>
     /// <remarks>
     /// If not set, all published messages will be received until explicitly
-    /// unsubscribed or disposed. Values greater than ~49.7 days (the maximum
-    /// supported by <see cref="System.Threading.Timer"/>) are treated as
-    /// "no timeout".
+    /// unsubscribed or disposed. Use <see cref="TimeSpan.MaxValue"/> or
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to explicitly
+    /// disable the timeout. Other values must be between zero and
+    /// ~49.7 days (the maximum supported by <see cref="System.Threading.Timer"/>);
+    /// out-of-range values throw <see cref="ArgumentOutOfRangeException"/>
+    /// when the subscription starts.
     /// </remarks>
     public TimeSpan? StartUpTimeout { get; init; }
 
@@ -42,9 +48,12 @@ public record NatsSubOpts
     /// </summary>
     /// <remarks>
     /// If not set, all published messages will be received until explicitly
-    /// unsubscribed or disposed. Values greater than ~49.7 days (the maximum
-    /// supported by <see cref="System.Threading.Timer"/>) are treated as
-    /// "no timeout".
+    /// unsubscribed or disposed. Use <see cref="TimeSpan.MaxValue"/> or
+    /// <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to explicitly
+    /// disable the timeout. Other values must be between zero and
+    /// ~49.7 days (the maximum supported by <see cref="System.Threading.Timer"/>);
+    /// out-of-range values throw <see cref="ArgumentOutOfRangeException"/>
+    /// when the subscription starts.
     /// </remarks>
     public TimeSpan? IdleTimeout { get; init; }
 

--- a/src/NATS.Client.Core/NatsSubOpts.cs
+++ b/src/NATS.Client.Core/NatsSubOpts.cs
@@ -18,7 +18,9 @@ public record NatsSubOpts
     /// </summary>
     /// <remarks>
     /// If not set, all published messages will be received until explicitly
-    /// unsubscribed or disposed.
+    /// unsubscribed or disposed. Values greater than ~49.7 days (the maximum
+    /// supported by <see cref="System.Threading.Timer"/>) are treated as
+    /// "no timeout".
     /// </remarks>
     public TimeSpan? Timeout { get; init; }
 
@@ -28,7 +30,9 @@ public record NatsSubOpts
     /// </summary>
     /// <remarks>
     /// If not set, all published messages will be received until explicitly
-    /// unsubscribed or disposed.
+    /// unsubscribed or disposed. Values greater than ~49.7 days (the maximum
+    /// supported by <see cref="System.Threading.Timer"/>) are treated as
+    /// "no timeout".
     /// </remarks>
     public TimeSpan? StartUpTimeout { get; init; }
 
@@ -38,7 +42,9 @@ public record NatsSubOpts
     /// </summary>
     /// <remarks>
     /// If not set, all published messages will be received until explicitly
-    /// unsubscribed or disposed.
+    /// unsubscribed or disposed. Values greater than ~49.7 days (the maximum
+    /// supported by <see cref="System.Threading.Timer"/>) are treated as
+    /// "no timeout".
     /// </remarks>
     public TimeSpan? IdleTimeout { get; init; }
 

--- a/tests/NATS.Client.Core.Tests/SubscriptionTest.cs
+++ b/tests/NATS.Client.Core.Tests/SubscriptionTest.cs
@@ -204,6 +204,28 @@ public class SubscriptionTest
     }
 
     [Fact]
+    public async Task Subscribe_with_max_timespan_timeouts_does_not_throw()
+    {
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        const string subject = "foo-max";
+        var opts = new NatsSubOpts
+        {
+            Timeout = TimeSpan.MaxValue,
+            IdleTimeout = TimeSpan.MaxValue,
+            StartUpTimeout = TimeSpan.MaxValue,
+        };
+
+        await using var sub = await nats.SubscribeCoreAsync<int>(subject, opts: opts);
+
+        await nats.PublishAsync(subject, 42);
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var msg = await sub.Msgs.ReadAsync(cts.Token);
+        Assert.Equal(42, msg.Data);
+    }
+
+    [Fact]
     public async Task Manual_unsubscribe_test()
     {
         await using var server = await NatsServerProcess.StartAsync();

--- a/tests/NATS.Client.Core.Tests/SubscriptionTest.cs
+++ b/tests/NATS.Client.Core.Tests/SubscriptionTest.cs
@@ -9,6 +9,23 @@ public class SubscriptionTest
 
     public SubscriptionTest(ITestOutputHelper output) => _output = output;
 
+    public static IEnumerable<object[]> OutOfRangeTimeoutCases()
+    {
+        var setters = new (string ParamName, Func<TimeSpan, NatsSubOpts> Setter)[]
+        {
+            (nameof(NatsSubOpts.Timeout), t => new NatsSubOpts { Timeout = t }),
+            (nameof(NatsSubOpts.IdleTimeout), t => new NatsSubOpts { IdleTimeout = t }),
+            (nameof(NatsSubOpts.StartUpTimeout), t => new NatsSubOpts { StartUpTimeout = t }),
+        };
+        var badValues = new[] { TimeSpan.FromDays(50), TimeSpan.FromMilliseconds(-2) };
+
+        foreach (var (paramName, setter) in setters)
+        {
+            foreach (var bad in badValues)
+                yield return new object[] { paramName, setter, bad };
+        }
+    }
+
     [Fact]
     public async Task Subscription_periodic_cleanup_test()
     {
@@ -204,7 +221,7 @@ public class SubscriptionTest
     }
 
     [Fact]
-    public async Task Subscribe_with_max_timespan_timeouts_does_not_throw()
+    public async Task Subscribe_with_no_timeout_sentinels_does_not_throw()
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
@@ -213,7 +230,7 @@ public class SubscriptionTest
         var opts = new NatsSubOpts
         {
             Timeout = TimeSpan.MaxValue,
-            IdleTimeout = TimeSpan.MaxValue,
+            IdleTimeout = Timeout.InfiniteTimeSpan,
             StartUpTimeout = TimeSpan.MaxValue,
         };
 
@@ -223,6 +240,19 @@ public class SubscriptionTest
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var msg = await sub.Msgs.ReadAsync(cts.Token);
         Assert.Equal(42, msg.Data);
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfRangeTimeoutCases))]
+    public async Task Subscribe_with_out_of_range_timeout_throws(string paramName, Func<TimeSpan, NatsSubOpts> withTimeout, TimeSpan badValue)
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = "nats://127.0.0.1:1" });
+
+        var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+        {
+            await using var sub = await nats.SubscribeCoreAsync<int>("foo-bad", opts: withTimeout(badValue));
+        });
+        Assert.Equal(paramName, ex.ParamName);
     }
 
     [Fact]

--- a/tests/NATS.Client.Core2.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core2.Tests/RequestReplyTest.cs
@@ -452,4 +452,29 @@ public class RequestReplyTest
         var type = json["type"]!.GetValue<string>();
         Assert.Equal("io.nats.jetstream.api.v1.account_info_response", type);
     }
+
+    [Theory]
+    [InlineData(NatsRequestReplyMode.SharedInbox)]
+    [InlineData(NatsRequestReplyMode.Direct)]
+    public async Task Request_reply_max_timespan_timeout_does_not_throw(NatsRequestReplyMode mode)
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+
+        var subject = $"foo.{Guid.NewGuid():N}";
+        await using var sub = await nats.SubscribeCoreAsync<int>(subject);
+        var reg = sub.Register(async msg =>
+        {
+            await msg.ReplyAsync(msg.Data * 2);
+        });
+        await nats.PingAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var replyOpts = new NatsSubOpts { Timeout = TimeSpan.MaxValue };
+        var reply = await nats.RequestAsync<int, int>(subject, 21, replyOpts: replyOpts, cancellationToken: cts.Token);
+
+        Assert.Equal(42, reply.Data);
+
+        await sub.DisposeAsync();
+        await reg;
+    }
 }

--- a/tests/NATS.Client.Core2.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core2.Tests/RequestReplyTest.cs
@@ -456,7 +456,7 @@ public class RequestReplyTest
     [Theory]
     [InlineData(NatsRequestReplyMode.SharedInbox)]
     [InlineData(NatsRequestReplyMode.Direct)]
-    public async Task Request_reply_max_timespan_timeout_does_not_throw(NatsRequestReplyMode mode)
+    public async Task Request_reply_no_timeout_sentinels_do_not_throw(NatsRequestReplyMode mode)
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
 
@@ -469,12 +469,31 @@ public class RequestReplyTest
         await nats.PingAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var replyOpts = new NatsSubOpts { Timeout = TimeSpan.MaxValue };
-        var reply = await nats.RequestAsync<int, int>(subject, 21, replyOpts: replyOpts, cancellationToken: cts.Token);
 
-        Assert.Equal(42, reply.Data);
+        var replyOptsMax = new NatsSubOpts { Timeout = TimeSpan.MaxValue };
+        var replyMax = await nats.RequestAsync<int, int>(subject, 21, replyOpts: replyOptsMax, cancellationToken: cts.Token);
+        Assert.Equal(42, replyMax.Data);
+
+        var replyOptsInf = new NatsSubOpts { Timeout = Timeout.InfiniteTimeSpan };
+        var replyInf = await nats.RequestAsync<int, int>(subject, 21, replyOpts: replyOptsInf, cancellationToken: cts.Token);
+        Assert.Equal(42, replyInf.Data);
 
         await sub.DisposeAsync();
         await reg;
+    }
+
+    [Theory]
+    [InlineData(NatsRequestReplyMode.SharedInbox)]
+    [InlineData(NatsRequestReplyMode.Direct)]
+    public async Task Request_reply_out_of_range_timeout_throws(NatsRequestReplyMode mode)
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+
+        var replyOpts = new NatsSubOpts { Timeout = TimeSpan.FromDays(50) };
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+        {
+            await nats.RequestAsync<int, int>($"foo.{Guid.NewGuid():N}", 1, replyOpts: replyOpts);
+        });
     }
 }


### PR DESCRIPTION
`NatsSubOpts.Timeout = TimeSpan.MaxValue` (and the matching idle/start-up fields, plus the direct request-reply path) threw `ArgumentOutOfRangeException` because `System.Threading.Timer.Change` and `Task.WaitAsync` reject dueTimes above `uint.MaxValue - 1` ms (~49.7 days). `TimeSpan.MaxValue` and `Timeout.InfiniteTimeSpan` are now accepted as explicit "no timeout" sentinels at both sites; other out-of-range values throw `ArgumentOutOfRangeException` from the subscription/request constructor with a clear message, instead of crashing later inside the timer. Validation lives in a single internal `TimeoutValidation` helper.

Fixes #1125