### PR TITLE
Add v2.12 to test matrix, drop v2.10

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.10'
+          - branch: 'v2.12'
           - branch: 'latest'
           - branch: 'main'
     runs-on: ubuntu-latest

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.10'
           - branch: 'v2.11'
+          - branch: 'v2.12'
           - branch: 'latest'
           - branch: 'main'
     runs-on: ubuntu-latest

--- a/.github/workflows/test_linux_core.yml
+++ b/.github/workflows/test_linux_core.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.10'
           - branch: 'v2.11'
+          - branch: 'v2.12'
           - branch: 'latest'
           - branch: 'main'
     runs-on: ubuntu-latest

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - branch: 'v2.10'
           - branch: 'v2.11'
+          - branch: 'v2.12'
           - branch: 'latest'
           - branch: 'main'
     runs-on: windows-latest


### PR DESCRIPTION
Bump nats-server test matrix in the Linux, Linux Core, Windows, and Perf workflows to run against v2.12 and drop v2.10.