### PR TITLE
Release 3.0.0-preview.6

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-3.0.0-preview.5
+3.0.0-preview.6


### PR DESCRIPTION
Preview release on the 3.0 line bumping version to 3.0.0-preview.6. Brings in everything merged to main since preview.5 via the latest release/3.0 sync: a new server error event on `NatsConnection`, slnx solution-format migration, README and example docs additions, and a CI matrix bump to nats-server v2.12. No 3.0-only changes.

From main:
- Add server error event (#745)
- Migrate solution to slnx format (#1131)
- Add Client and Orbit section to README (#1133)
- Add Example Docs (#1119)
- ci: test against v2.12, drop v2.10 (#1136)

Note for reviewer: Windows non-net8.0 CI is flapping on `TlsPreferTest`, `Utf8SubjectMockServerTest`, and `PingCancellationTest`. Linux and Windows net8.0 are green. The pattern correlates with #745 (now in this release), but the failures look like a test-side sync/timing issue rather than a runtime regression: static read of #745 says no-op for the TLS path, and the test relies on a tight race between the server reading the client's first byte and the client tearing down on a TLS-upgrade failure. Tracked in #1142.