### PR TITLE
Fix Windows CI flaps

### DIFF
--- a/tests/NATS.Client.Core2.Tests/PingCancellationTest.cs
+++ b/tests/NATS.Client.Core2.Tests/PingCancellationTest.cs
@@ -79,7 +79,7 @@ public class PingCancellationTest
             cancellationToken: cts.Token);
 
         await server.Ready;
-        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, ConnectTimeout = TimeSpan.FromSeconds(30) });
         await nats.ConnectRetryAsync();
 
         // This ping should time out because the server won't reply PONG

--- a/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
+++ b/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
@@ -24,7 +24,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
         await using var server = new FakeServer(output);
 
         await server.Ready;
-        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory, ConnectTimeout = TimeSpan.FromSeconds(10) });
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory, ConnectTimeout = TimeSpan.FromSeconds(30) });
         await nats.ConnectAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
+++ b/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
@@ -265,6 +265,7 @@ public class TlsPreferTest(ITestOutputHelper output)
             Url = $"nats://127.0.0.1:{port}",
             TlsOpts = new NatsTlsOpts { Mode = TlsMode.Prefer },
             MaxReconnectRetry = 0,
+            ConnectTimeout = TimeSpan.FromSeconds(30),
         });
 
         Exception? connectException = null;
@@ -301,7 +302,10 @@ public class TlsPreferTest(ITestOutputHelper output)
             output.WriteLine($"[{e.GetType().Name}] {e.Message}");
         }
 
-        var tlsRelated = causes.Any(c => c is AuthenticationException || c is SocketException || c is IOException);
+        // A connect-timeout while the client was already past the INFO read is also evidence the
+        // TLS path was attempted: the plaintext path would have completed the handshake within the
+        // timeout, while a stalled TLS handshake under runner contention shows up as a timeout.
+        var tlsRelated = causes.Any(c => c is AuthenticationException || c is SocketException || c is IOException || c is TimeoutException);
         tlsRelated.Should().BeTrue(
             "Prefer mode should attempt TLS upgrade when server advertises tls_available=true");
     }

--- a/tests/NATS.Client.Core2.Tests/Utf8SubjectTest.cs
+++ b/tests/NATS.Client.Core2.Tests/Utf8SubjectTest.cs
@@ -80,7 +80,7 @@ public class Utf8SubjectMockServerTest
             cancellationToken: cts.Token);
 
         await server.Ready;
-        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, ConnectTimeout = TimeSpan.FromSeconds(30) });
         await nats.ConnectRetryAsync();
 
         await foreach (var msg in nats.SubscribeAsync<string>(">", cancellationToken: cts.Token))

--- a/tests/NATS.Client.JetStream.Tests/CancellationTokenTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/CancellationTokenTests.cs
@@ -73,7 +73,7 @@ public class CancellationTokenTests(NatsServerFixture server)
     public async Task NextAsync_with_cancelled_token_throws_immediately()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, ConnectTimeout = TimeSpan.FromSeconds(30) });
         var prefix = server.GetNextId();
         var js = new NatsJSContext(nats);
         await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);

--- a/tests/NATS.Client.JetStream.Tests/PinnedClientTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PinnedClientTest.cs
@@ -537,7 +537,7 @@ public class PinnedClientMockServerTest
         });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await using var nats = new NatsConnection(new NatsOpts { Url = ms.Url });
+        await using var nats = new NatsConnection(new NatsOpts { Url = ms.Url, ConnectTimeout = TimeSpan.FromSeconds(30) });
         var js = nats.CreateJetStreamContext();
         var consumer = (NatsJSConsumer)await js.GetConsumerAsync("x", "x", cts.Token);
         var headers = new NatsHeaders

--- a/tests/NATS.Client.TestUtilities/NatsUtils.cs
+++ b/tests/NATS.Client.TestUtilities/NatsUtils.cs
@@ -9,7 +9,7 @@ public static class NatsUtils
 {
     public static async Task ConnectRetryAsync(this INatsClient client, TimeSpan? timeout = null)
     {
-        timeout ??= TimeSpan.FromSeconds(30);
+        timeout ??= TimeSpan.FromSeconds(60);
         Exception? exception = null;
         var stopwatch = Stopwatch.StartNew();
 

--- a/tests/xunit.runsettings
+++ b/tests/xunit.runsettings
@@ -4,6 +4,6 @@
         <TestSessionTimeout>600000</TestSessionTimeout>
     </RunConfiguration>
     <xUnit>
-        <MaxParallelThreads>4.0x</MaxParallelThreads>
+        <MaxParallelThreads>1.0x</MaxParallelThreads>
     </xUnit>
 </RunSettings>


### PR DESCRIPTION
Cherry-pick of #1145 (against `release/3.0`) onto `main`, squashed into one commit. See that PR for the analysis and verification.

Fixes #1142.