### PR TITLE
Cap KV duplicate_window at max_age

### DIFF
--- a/src/NATS.Client.KeyValueStore/NatsKVContext.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVContext.cs
@@ -195,6 +195,13 @@ public class NatsKVContext : INatsKVContext
 
         var replicas = config.NumberOfReplicas > 0 ? config.NumberOfReplicas : 1;
 
+        // ADR-8: cap duplicate_window at max_age when a Key TTL is set.
+        var duplicateWindow = TimeSpan.FromMinutes(2);
+        if (config.MaxAge > TimeSpan.Zero && config.MaxAge < duplicateWindow)
+        {
+            duplicateWindow = config.MaxAge;
+        }
+
         string[]? subjects;
         StreamSource? mirror;
         ICollection<StreamSource>? sources;
@@ -263,6 +270,7 @@ public class NatsKVContext : INatsKVContext
             MaxMsgsPerSubject = history,
             MaxBytes = config.MaxBytes,
             MaxAge = config.MaxAge,
+            DuplicateWindow = duplicateWindow,
             MaxMsgSize = config.MaxValueSize,
             Compression = config.Compression ? StreamConfigCompression.S2 : StreamConfigCompression.None,
             Storage = storage,

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueContextTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueContextTest.cs
@@ -95,6 +95,49 @@ public class KeyValueContextTest
         updatedStatus.Info.Config.Description.Should().Be(natsKVConfig.Description);
     }
 
+    [Theory]
+    [InlineData(0, 120)] // MaxAge unset -> duplicate_window = 2 min
+    [InlineData(30, 30)] // MaxAge <= 2 min -> duplicate_window = MaxAge
+    [InlineData(600, 120)] // MaxAge > 2 min -> duplicate_window capped at 2 min
+    public async Task Duplicate_window_capped_by_max_age_on_create(int maxAgeSeconds, int expectedDuplicateWindowSeconds)
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var js = new NatsJSContext(nats);
+        var kv = new NatsKVContext(js);
+
+        var config = new NatsKVConfig("kv1") { MaxAge = TimeSpan.FromSeconds(maxAgeSeconds) };
+        var store = await kv.CreateStoreAsync(config, cancellationToken);
+        var status = await store.GetStatusAsync(cancellationToken);
+
+        status.Info.Config.DuplicateWindow.Should().Be(TimeSpan.FromSeconds(expectedDuplicateWindowSeconds));
+    }
+
+    [Fact]
+    public async Task Duplicate_window_recapped_on_update()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var js = new NatsJSContext(nats);
+        var kv = new NatsKVContext(js);
+
+        var store = await kv.CreateStoreAsync(new NatsKVConfig("kv1") { MaxAge = TimeSpan.FromSeconds(30) }, cancellationToken);
+        var status = await store.GetStatusAsync(cancellationToken);
+        status.Info.Config.DuplicateWindow.Should().Be(TimeSpan.FromSeconds(30));
+
+        await kv.UpdateStoreAsync(new NatsKVConfig("kv1") { MaxAge = TimeSpan.FromMinutes(10) }, cancellationToken);
+        var updated = await store.GetStatusAsync(cancellationToken);
+        updated.Info.Config.DuplicateWindow.Should().Be(TimeSpan.FromMinutes(2));
+    }
+
     [Fact]
     public async Task Delete_store_test()
     {


### PR DESCRIPTION
Per ADR-8 rev 9, when a KV bucket has a Key TTL the client must cap `duplicate_window` so it never exceeds the TTL: leave the server default (2 min) when `MaxAge` is unset or greater than 2 min, and set it equal to `MaxAge` when `MaxAge` is between 0 and 2 min. Applies on create, update, and create-or-update since all three paths build the stream config in one place. Matches the fix already shipped in nats.go and nats.java.

Fixes #823