### PR TITLE
Fix durable consumer create when only DurableName is set

### DIFF
--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -263,6 +263,7 @@ public partial class NatsJSContext : INatsJSContext
 
         if (!string.IsNullOrWhiteSpace(name))
         {
+            ThrowIfInvalidConsumerName(name!);
             subject += $".{name}";
         }
 

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -255,9 +255,15 @@ public partial class NatsJSContext : INatsJSContext
     {
         var subject = $"{Opts.Prefix}.CONSUMER.CREATE.{stream}";
 
-        if (!string.IsNullOrWhiteSpace(config.Name))
+        var name = config.Name;
+        if (string.IsNullOrWhiteSpace(name))
         {
-            subject += $".{config.Name}";
+            name = config.DurableName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            subject += $".{name}";
         }
 
         if (!string.IsNullOrWhiteSpace(config.FilterSubject))

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -11,7 +11,7 @@ namespace NATS.Client.JetStream;
 /// <summary>Provides management and access to NATS JetStream streams and consumers.</summary>
 public partial class NatsJSContext
 {
-    private static readonly char[] InvalidConsumerNameChars = { ' ', '.', '*', '>', '/', '\\', '\t', '\n', '\r' };
+    private static readonly char[] InvalidConsumerNameChars = { '.', '*', '>' };
 
     private readonly ILogger _logger;
 
@@ -387,10 +387,11 @@ public partial class NatsJSContext
     internal static void ThrowIfInvalidConsumerName(string name, [CallerArgumentExpression("name")] string? paramName = null)
     {
         // The resolved name (Name, else DurableName) is appended to the CONSUMER.CREATE
-        // subject as a single token. Reject characters that are legal in a subject but
-        // would split or wildcard that token ('.', '*', '>', path separators) or break
-        // the protocol line (whitespace), so the server gets the name we intended rather
-        // than a structurally different request. Mirrors the server's name rules.
+        // subject as a single token. Reject only the characters that are legal in a
+        // subject but restructure that token ('.' adds tokens, '*'/'>' are wildcards),
+        // so the server gets the name we intended rather than a structurally different
+        // request it cannot diagnose. Other invalid characters (whitespace, path
+        // separators) are caught by subject validation or the server's own name checks.
         if (name.IndexOfAny(InvalidConsumerNameChars) >= 0)
         {
             ThrowInvalidConsumerNameException(paramName);
@@ -541,7 +542,7 @@ public partial class NatsJSContext
 
     [DoesNotReturn]
     private static void ThrowInvalidConsumerNameException(string? paramName) =>
-        throw new ArgumentException("Consumer name cannot contain ' ', '.', '*', '>', '/', '\\' or whitespace", paramName);
+        throw new ArgumentException("Consumer name cannot contain '.', '*', '>'", paramName);
 
     [DoesNotReturn]
     private static void ThrowEmptyException(string? paramName) =>

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -11,6 +11,8 @@ namespace NATS.Client.JetStream;
 /// <summary>Provides management and access to NATS JetStream streams and consumers.</summary>
 public partial class NatsJSContext
 {
+    private static readonly char[] InvalidConsumerNameChars = { ' ', '.', '*', '>', '/', '\\', '\t', '\n', '\r' };
+
     private readonly ILogger _logger;
 
     /// <inheritdoc cref="NatsJSContext(NATS.Client.Core.INatsConnection,NATS.Client.JetStream.NatsJSOpts)"/>>
@@ -382,6 +384,19 @@ public partial class NatsJSContext
         }
     }
 
+    internal static void ThrowIfInvalidConsumerName(string name, [CallerArgumentExpression("name")] string? paramName = null)
+    {
+        // The resolved name (Name, else DurableName) is appended to the CONSUMER.CREATE
+        // subject as a single token. Reject characters that are legal in a subject but
+        // would split or wildcard that token ('.', '*', '>', path separators) or break
+        // the protocol line (whitespace), so the server gets the name we intended rather
+        // than a structurally different request. Mirrors the server's name rules.
+        if (name.IndexOfAny(InvalidConsumerNameChars) >= 0)
+        {
+            ThrowInvalidConsumerNameException(paramName);
+        }
+    }
+
     internal async ValueTask<NatsJSResponse<TResponse>> JSRequestAsync<TRequest, TResponse>(
         string subject,
         TRequest? request,
@@ -523,6 +538,10 @@ public partial class NatsJSContext
     [DoesNotReturn]
     private static void ThrowInvalidStreamNameException(string? paramName) =>
         throw new ArgumentException("Stream name cannot contain ' ', '.'", paramName);
+
+    [DoesNotReturn]
+    private static void ThrowInvalidConsumerNameException(string? paramName) =>
+        throw new ArgumentException("Consumer name cannot contain ' ', '.', '*', '>', '/', '\\' or whitespace", paramName);
 
     [DoesNotReturn]
     private static void ThrowEmptyException(string? paramName) =>

--- a/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
@@ -52,6 +52,34 @@ public class ManageConsumerTest
     [Theory]
     [InlineData(NatsRequestReplyMode.Direct)]
     [InlineData(NatsRequestReplyMode.SharedInbox)]
+    public async Task Create_consumer_with_durable_only(NatsRequestReplyMode mode)
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(10), RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
+
+        var consumer = await js.CreateOrUpdateConsumerAsync(
+            $"{prefix}s1",
+            new ConsumerConfig
+            {
+                DurableName = $"{prefix}c1",
+                AckPolicy = ConsumerConfigAckPolicy.Explicit,
+            },
+            cts.Token);
+
+        Assert.Equal($"{prefix}s1", consumer.Info.StreamName);
+        Assert.Equal($"{prefix}c1", consumer.Info.Config.Name);
+        Assert.Equal($"{prefix}c1", consumer.Info.Config.DurableName);
+    }
+
+    [Theory]
+    [InlineData(NatsRequestReplyMode.Direct)]
+    [InlineData(NatsRequestReplyMode.SharedInbox)]
     public async Task List_delete_consumer(NatsRequestReplyMode mode)
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });

--- a/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
@@ -78,6 +78,38 @@ public class ManageConsumerTest
     }
 
     [Theory]
+    [InlineData("foo.bar")]
+    [InlineData("foo*")]
+    [InlineData("foo>")]
+    [InlineData("foo bar")]
+    public async Task Create_consumer_with_invalid_name_throws(string badName)
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
+
+        // A dot or wildcard in the name would split or wildcard the CONSUMER.CREATE
+        // subject token, so it must be rejected client-side rather than sent.
+
+        // Name path.
+        await Assert.ThrowsAsync<ArgumentException>(() => js.CreateOrUpdateConsumerAsync(
+            $"{prefix}s1",
+            new ConsumerConfig { Name = badName, AckPolicy = ConsumerConfigAckPolicy.Explicit },
+            cts.Token).AsTask());
+
+        // DurableName fallback path (Name unset).
+        await Assert.ThrowsAsync<ArgumentException>(() => js.CreateOrUpdateConsumerAsync(
+            $"{prefix}s1",
+            new ConsumerConfig { DurableName = badName, AckPolicy = ConsumerConfigAckPolicy.Explicit },
+            cts.Token).AsTask());
+    }
+
+    [Theory]
     [InlineData(NatsRequestReplyMode.Direct)]
     [InlineData(NatsRequestReplyMode.SharedInbox)]
     public async Task List_delete_consumer(NatsRequestReplyMode mode)

--- a/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
@@ -81,7 +81,6 @@ public class ManageConsumerTest
     [InlineData("foo.bar")]
     [InlineData("foo*")]
     [InlineData("foo>")]
-    [InlineData("foo bar")]
     public async Task Create_consumer_with_invalid_name_throws(string badName)
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(10) });

--- a/tests/NATS.Net.DocsExamples/JetStream/ManagingPage.cs
+++ b/tests/NATS.Net.DocsExamples/JetStream/ManagingPage.cs
@@ -67,7 +67,6 @@ public class ManagingPage
             // Same as above
             durableConfig = new ConsumerConfig
             {
-                Name = "durable_processor",
                 DurableName = "durable_processor",
             };
 

--- a/tests/NATS.Net.DocsExamples/JetStream/ManagingPage.cs
+++ b/tests/NATS.Net.DocsExamples/JetStream/ManagingPage.cs
@@ -64,7 +64,7 @@ public class ManagingPage
             // Create a durable consumer
             ConsumerConfig durableConfig = new ConsumerConfig("durable_processor");
 
-            // Same as above
+            // Same as above (on NATS .NET 2.8.0 and earlier, Name must also be set to the same value)
             durableConfig = new ConsumerConfig
             {
                 DurableName = "durable_processor",


### PR DESCRIPTION
`NatsJSContext.CreateOrUpdateConsumerAsync` only inspected `ConsumerConfig.Name` when building the create subject. With `DurableName` set but `Name` empty, the request went to `$JS.API.CONSUMER.CREATE.<stream>` and the server rejected it with `consumer expected to be ephemeral but a durable name was set in request`. Fall back to `DurableName` to match the Go (`upsertConsumer`) and Java (`_createConsumer`) clients.

Previously surfaced in discussion #234 and resolved with a "set both Name and DurableName" workaround rather than a code change.

Fixes #1137