### PR TITLE
Fix repeated idle heartbeat timeout notifications

### DIFF
--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -46,6 +46,7 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
     private long _pendingMsgs;
     private long _pendingBytes;
     private int _consecutive503Errors;
+    private int _timeoutNotified;
 
     public NatsJSConsume(
         long maxMsgs,
@@ -110,7 +111,10 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
             static state =>
             {
                 var self = (NatsJSConsume<TMsg>)state!;
-                self._notificationChannel?.Notify(NatsJSTimeoutNotification.Default);
+                if (Interlocked.Exchange(ref self._timeoutNotified, 1) == 0)
+                {
+                    self._notificationChannel?.Notify(NatsJSTimeoutNotification.Default);
+                }
 
                 if (self._cancellationToken.IsCancellationRequested)
                 {
@@ -194,7 +198,11 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
 
     public void StopHeartbeatTimer() => _timer.Change(Timeout.Infinite, Timeout.Infinite);
 
-    public void ResetHeartbeatTimer() => _timer.Change(_hbTimeout, _hbTimeout);
+    public void ResetHeartbeatTimer()
+    {
+        Interlocked.Exchange(ref _timeoutNotified, 0);
+        _timer.Change(_hbTimeout, _hbTimeout);
+    }
 
     public void Delivered(int msgSize)
     {

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -51,6 +51,7 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
     private long _pendingBytes;
     private int _consecutive503Errors;
     private volatile bool _draining;
+    private int _timeoutNotified;
 
     public NatsJSConsume(
         long maxMsgs,
@@ -122,7 +123,10 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
                 if (self._draining)
                     return;
 
-                self._notificationChannel?.Notify(NatsJSTimeoutNotification.Default);
+                if (Interlocked.Exchange(ref self._timeoutNotified, 1) == 0)
+                {
+                    self._notificationChannel?.Notify(NatsJSTimeoutNotification.Default);
+                }
 
                 if (self._cancellationToken.IsCancellationRequested)
                 {
@@ -213,6 +217,7 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
         if (_draining)
             return;
 
+        Interlocked.Exchange(ref _timeoutNotified, 0);
         _timer.Change(_hbTimeout, _hbTimeout);
     }
 


### PR DESCRIPTION
`NatsJSConsume` keeps its idle heartbeat timer periodic so pulls keep getting re-issued during long silences, but it was also firing `NatsJSTimeoutNotification` on every tick. The notification carries no payload, so the repeats added no information past the first one. Track an edge-triggered flag so the notification is emitted once when silence starts and cleared on the next received message (data or heartbeat). Timer cadence is unchanged, so behaviour around pulls is unaffected.

Fixes #952