### PR TITLE
Clarify DI package descriptions

### DIFF
--- a/src/NATS.Client.Hosting/NATS.Client.Hosting.csproj
+++ b/src/NATS.Client.Hosting/NATS.Client.Hosting.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- NuGet Packaging -->
     <PackageTags>pubsub;messaging;cloud-native;aspnetcore;hosting;nats</PackageTags>
-    <Description>ASP.NET Core and Generic Host integration for the NATS .NET core client. Registers NatsConnection in the .NET Generic Host service collection.</Description>
+    <Description>NATS .NET dependency injection with minimal dependencies and AOT support. Registers NatsConnection on the Microsoft service collection. For ad-hoc JSON serialization, see NATS.Extensions.Microsoft.DependencyInjection.</Description>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NATS.Extensions.Microsoft.DependencyInjection.csproj
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NATS.Extensions.Microsoft.DependencyInjection.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <!-- NuGet Packaging -->
         <PackageTags>pubsub;messaging;cloud-native;aspnetcore;hosting;dependency-injection;nats</PackageTags>
-        <Description>Microsoft dependency injection extension for NATS .NET. Configures NatsClient with the Generic Host and ASP.NET Core service collection.</Description>
+        <Description>NATS .NET dependency injection with ad-hoc JSON serialization enabled by default. Registers NatsConnection and INatsClient on the Microsoft service collection. For AOT or minimal dependencies, see NATS.Client.Hosting.</Description>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">


### PR DESCRIPTION
Update the NuGet <Description> for the two DI packages to state what each one is for: NATS.Client.Hosting (minimal deps, AOT) vs NATS.Extensions.Microsoft.DependencyInjection (ad-hoc JSON by default), each pointing at the other.