### PR TITLE
Add explicit subscription and consumer drain

### DIFF
--- a/src/NATS.Client.Core/INatsSub.cs
+++ b/src/NATS.Client.Core/INatsSub.cs
@@ -39,7 +39,7 @@ public interface INatsSub<T> : IAsyncDisposable
     /// <see cref="UnsubscribeAsync"/>, drain does not drop messages still in the socket
     /// buffer. The connection stays open.
     /// </remarks>
-    /// <param name="cancellationToken">Bounds the best-effort PING/PONG fence wait.</param>
+    /// <param name="cancellationToken">Bounds the best-effort PING/PONG fence wait, which lasts at most <see cref="NatsOpts.DrainPingTimeout"/>; the token can only shorten it, not extend it past that timeout.</param>
     /// <returns>A <see cref="ValueTask"/> that represents the asynchronous drain operation.</returns>
     public ValueTask DrainAsync(CancellationToken cancellationToken = default);
 }

--- a/src/NATS.Client.Core/INatsSub.cs
+++ b/src/NATS.Client.Core/INatsSub.cs
@@ -27,4 +27,19 @@ public interface INatsSub<T> : IAsyncDisposable
     /// </summary>
     /// <returns>A <see cref="ValueTask"/> that represents the asynchronous server UNSUB operation.</returns>
     public ValueTask UnsubscribeAsync();
+
+    /// <summary>
+    /// Drain the subscription: stop receiving new messages while letting messages
+    /// already buffered be read, keeping the connection usable.
+    /// </summary>
+    /// <remarks>
+    /// Sends an unsubscribe to the server, waits for a PING/PONG round-trip so messages
+    /// already in flight are delivered, then completes <see cref="Msgs"/>. Keep reading
+    /// <see cref="Msgs"/> until it completes to process the buffered messages. Unlike
+    /// <see cref="UnsubscribeAsync"/>, drain does not drop messages still in the socket
+    /// buffer. The connection stays open.
+    /// </remarks>
+    /// <param name="cancellationToken">Bounds the best-effort PING/PONG fence wait.</param>
+    /// <returns>A <see cref="ValueTask"/> that represents the asynchronous drain operation.</returns>
+    public ValueTask DrainAsync(CancellationToken cancellationToken = default);
 }

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -1235,7 +1235,7 @@ public partial class NatsConnection : INatsConnection
 
         var tasks = new Task[remaining.Length];
         for (var i = 0; i < remaining.Length; i++)
-            tasks[i] = remaining[i].DrainAsync().AsTask();
+            tasks[i] = remaining[i].DrainOnDisposeAsync().AsTask();
 
         return new ValueTask(Task.WhenAll(tasks));
     }

--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -191,14 +191,15 @@ public sealed record NatsOpts
     public TimeSpan? ConsumerDrainOnDisposeTimeout { get; init; } = null;
 
     /// <summary>
-    /// Per-subscription PING/PONG timeout used during drain on dispose.
+    /// Per-subscription PING/PONG timeout used during drain.
     /// (default: 5 seconds)
     /// </summary>
     /// <remarks>
     /// Bounds how long drain will wait for the server to ack the UNSUB before
     /// completing the user channel anyway. Increase for high-latency networks
-    /// where a single round-trip can exceed the default. Only effective when
-    /// <see cref="DrainSubscriptionsOnDispose"/> is true.
+    /// where a single round-trip can exceed the default. Applies both to drain on
+    /// dispose (when <see cref="DrainSubscriptionsOnDispose"/> is true) and to the
+    /// explicit per-subscription drain API.
     /// </remarks>
     public TimeSpan DrainPingTimeout { get; init; } = TimeSpan.FromSeconds(5);
 

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -277,6 +277,23 @@ public abstract class NatsSubBase
     }
 
     /// <summary>
+    /// Drains the subscription: sends UNSUB so the server stops delivering new
+    /// messages, waits for a PING/PONG round-trip so messages already in flight
+    /// are received, then completes the message channel. Buffered messages stay
+    /// available to read and the connection remains usable.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="UnsubscribeAsync"/>, which completes the channel right
+    /// away and can drop messages still in the socket buffer, drain fences inbound
+    /// delivery with a PING/PONG so buffered messages are preserved. The fence is
+    /// best-effort and bounded by <paramref name="cancellationToken"/> and
+    /// <see cref="NatsOpts.DrainPingTimeout"/>.
+    /// </remarks>
+    /// <param name="cancellationToken">Bounds the best-effort PING/PONG fence wait.</param>
+    /// <returns>A <see cref="ValueTask"/> that represents the asynchronous drain operation.</returns>
+    public virtual ValueTask DrainAsync(CancellationToken cancellationToken = default) => DrainCoreAsync(cancellationToken);
+
+    /// <summary>
     /// Disposes the instance asynchronously.
     /// </summary>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous disposal operation.</returns>
@@ -403,10 +420,9 @@ public abstract class NatsSubBase
     internal void ClearException() => Interlocked.Exchange(ref _exception, null);
 
     /// <summary>
-    /// Sends UNSUB to the server, waits for PING/PONG round-trip to ensure
-    /// all in-flight messages are processed, then completes the channel.
-    /// This avoids the race where TryComplete() closes the channel while
-    /// the socket reader is still delivering messages.
+    /// Dispose-path drain. Runs the same UNSUB plus PING/PONG fence as
+    /// <see cref="DrainAsync"/>, then waits for an active user reader to drain
+    /// the channel before returning.
     /// </summary>
     /// <remarks>
     /// No-op unless <see cref="NatsOpts.DrainSubscriptionsOnDispose"/> is
@@ -415,64 +431,12 @@ public abstract class NatsSubBase
     /// <see cref="NatsConnection.DisposeAsync"/>).
     /// </remarks>
     /// <returns>A <see cref="ValueTask"/> that represents the asynchronous drain operation.</returns>
-    internal async ValueTask DrainAsync()
+    internal async ValueTask DrainOnDisposeAsync()
     {
         if (!Connection.Opts.DrainSubscriptionsOnDispose)
             return;
 
-        var needsUnsub = false;
-        lock (_gate)
-        {
-            if (!_unsubscribed)
-            {
-                _unsubscribed = true;
-                needsUnsub = true;
-            }
-        }
-
-        if (needsUnsub)
-        {
-            DecrementActiveSubscription();
-
-            _timeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-            _idleTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-            _startUpTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-
-            // For the built-in SubscriptionManager: send UNSUB but keep the SID in the routing
-            // table until after the PING/PONG round-trip, so messages already in the socket
-            // buffer are delivered before the channel is completed.
-            // For external managers: fall back to RemoveAsync (routing removed before PING).
-            var mgr = _manager as SubscriptionManager;
-            var sid = mgr != null
-                ? await mgr.UnsubscribeForDrainAsync(this).ConfigureAwait(false)
-                : -1;
-            if (mgr == null)
-                await _manager.RemoveAsync(this).ConfigureAwait(false);
-
-            // PING/PONG round-trip: after we get the PONG back, we know the server
-            // has processed our UNSUB and the socket reader has processed all messages
-            // that were in-flight before the UNSUB was received by the server.
-            try
-            {
-                using var pingCts = new CancellationTokenSource(Connection.Opts.DrainPingTimeout);
-                await Connection.PingAsync(pingCts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                // Timeout via DrainPingTimeout. Expected on dispose path.
-            }
-            catch (NatsException)
-            {
-                // Connection failed or disconnected during drain. Drain is best-effort.
-            }
-
-            // Remove from routing now that no more messages can arrive for this SID.
-            if (sid != -1)
-                mgr?.RemoveFromRouting(sid);
-
-            // Now it's safe to complete the channel, no more messages will arrive.
-            TryComplete();
-        }
+        await DrainCoreAsync(CancellationToken.None).ConfigureAwait(false);
 
         // Always wait for an active user reader to drain the channel before
         // returning, even if the subscription was already ended (e.g. via
@@ -653,6 +617,71 @@ public abstract class NatsSubBase
     {
         if (Interlocked.Exchange(ref _telemetryActive, 0) == 1)
             Telemetry.ActiveSubscriptions.Add(-1, Telemetry.BuildMetricTags(Connection, Telemetry.Constants.OpSub));
+    }
+
+    /// <summary>
+    /// Sends UNSUB to the server, waits for a PING/PONG round-trip to ensure all
+    /// in-flight messages are processed, then completes the channel. This avoids
+    /// the race where TryComplete() closes the channel while the socket reader is
+    /// still delivering messages. Idempotent: a no-op once the subscription has
+    /// already been unsubscribed.
+    /// </summary>
+    private async ValueTask DrainCoreAsync(CancellationToken cancellationToken)
+    {
+        var needsUnsub = false;
+        lock (_gate)
+        {
+            if (!_unsubscribed)
+            {
+                _unsubscribed = true;
+                needsUnsub = true;
+            }
+        }
+
+        if (!needsUnsub)
+            return;
+
+        DecrementActiveSubscription();
+
+        _timeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+        _idleTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+        _startUpTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+
+        // For the built-in SubscriptionManager: send UNSUB but keep the SID in the routing
+        // table until after the PING/PONG round-trip, so messages already in the socket
+        // buffer are delivered before the channel is completed.
+        // For external managers: fall back to RemoveAsync (routing removed before PING).
+        var mgr = _manager as SubscriptionManager;
+        var sid = mgr != null
+            ? await mgr.UnsubscribeForDrainAsync(this).ConfigureAwait(false)
+            : -1;
+        if (mgr == null)
+            await _manager.RemoveAsync(this).ConfigureAwait(false);
+
+        // PING/PONG round-trip: after we get the PONG back, we know the server
+        // has processed our UNSUB and the socket reader has processed all messages
+        // that were in-flight before the UNSUB was received by the server.
+        try
+        {
+            using var pingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            pingCts.CancelAfter(Connection.Opts.DrainPingTimeout);
+            await Connection.PingAsync(pingCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Drain ping timed out (DrainPingTimeout) or was cancelled. Drain is best-effort.
+        }
+        catch (NatsException)
+        {
+            // Connection failed or disconnected during drain. Drain is best-effort.
+        }
+
+        // Remove from routing now that no more messages can arrive for this SID.
+        if (sid != -1)
+            mgr?.RemoveFromRouting(sid);
+
+        // Now it's safe to complete the channel, no more messages will arrive.
+        TryComplete();
     }
 
     private async ValueTask WaitForReaderDrainCoreAsync(Task task, TimeSpan timeout)

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -515,6 +515,18 @@ public abstract class NatsSubBase
     protected abstract ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer);
 
     /// <summary>
+    /// Stops any subclass-owned delivery machinery (e.g. a JetStream pull loop or
+    /// idle-heartbeat timer) as the first step of a drain, before the UNSUB and the
+    /// PING/PONG fence. The base implementation is a no-op; subclasses that keep
+    /// pulling or run a timer that can complete the message channel must override this
+    /// so drain does not leave that machinery running or let it skip the fence.
+    /// Called on both the explicit drain and the dispose-drain path; must be idempotent.
+    /// </summary>
+    protected virtual void StopDelivery()
+    {
+    }
+
+    /// <summary>
     /// Waits for the user-side reader to exit so buffered messages can be
     /// drained on dispose. No-op when the reader was never marked active or
     /// when <see cref="NatsOpts.ConsumerDrainOnDisposeTimeout"/> is unset.
@@ -636,6 +648,11 @@ public abstract class NatsSubBase
     /// </summary>
     private async ValueTask DrainCoreAsync(CancellationToken cancellationToken)
     {
+        // Stop any subclass-owned delivery engine (e.g. a JetStream pull/heartbeat loop)
+        // first so it can't keep pulling or complete the channel ahead of the fence below.
+        // Runs on both the explicit drain and the dispose-drain path.
+        StopDelivery();
+
         // Disarm the lifecycle timers before taking the unsubscribe gate so a
         // Timeout/IdleTimeout/StartUp callback that is about to fire is less likely to win
         // the gate and complete the channel without the drain fence. The gate below still

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -648,20 +648,6 @@ public abstract class NatsSubBase
     /// </summary>
     private async ValueTask DrainCoreAsync(CancellationToken cancellationToken)
     {
-        // Stop any subclass-owned delivery engine (e.g. a JetStream pull/heartbeat loop)
-        // first so it can't keep pulling or complete the channel ahead of the fence below.
-        // Runs on both the explicit drain and the dispose-drain path.
-        StopDelivery();
-
-        // Disarm the lifecycle timers before taking the unsubscribe gate so a
-        // Timeout/IdleTimeout/StartUp callback that is about to fire is less likely to win
-        // the gate and complete the channel without the drain fence. The gate below still
-        // guarantees correctness if a callback was already in flight; this just narrows the
-        // window where an explicit drain races those timers.
-        _timeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-        _idleTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-        _startUpTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-
         var needsUnsub = false;
         lock (_gate)
         {
@@ -675,12 +661,22 @@ public abstract class NatsSubBase
         if (!needsUnsub)
             return;
 
-        DecrementActiveSubscription();
-
         var mgr = _manager as SubscriptionManager;
         var sid = -1;
         try
         {
+            DecrementActiveSubscription();
+
+            // Stop the subclass-owned delivery engine (e.g. a JetStream pull/heartbeat loop)
+            // and disarm the lifecycle timers before the fence so they can't keep pulling or
+            // complete the channel ahead of it. These run inside the try so that if any of
+            // them throw (e.g. a timer disposed by a racing DisposeAsync) the finally below
+            // still completes the channel and no reader is left waiting forever.
+            StopDelivery();
+            _timeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            _idleTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            _startUpTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+
             // For the built-in SubscriptionManager: send UNSUB but keep the SID in the routing
             // table until after the PING/PONG round-trip, so messages already in the socket
             // buffer are delivered before the channel is completed.
@@ -714,7 +710,7 @@ public abstract class NatsSubBase
         finally
         {
             // Remove from routing now that no more messages can arrive for this SID, then
-            // complete the channel. This runs even if UNSUB or PING threw, so a reader
+            // complete the channel. This runs even if anything in the try threw, so a reader
             // blocked on the channel (e.g. the drain-on-cancel consume loop reading with
             // CancellationToken.None) is never left waiting forever.
             if (sid != -1)

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -288,8 +288,14 @@ public abstract class NatsSubBase
     /// delivery with a PING/PONG so buffered messages are preserved. The fence is
     /// best-effort and bounded by <paramref name="cancellationToken"/> and
     /// <see cref="NatsOpts.DrainPingTimeout"/>.
+    /// <para>
+    /// Cancellation only shortens the PING/PONG fence wait; it cannot abort the
+    /// drain. Once <see cref="DrainAsync"/> is entered the subscription is always
+    /// committed to the drained state, and cancelling the token does not throw or
+    /// keep the subscription alive.
+    /// </para>
     /// </remarks>
-    /// <param name="cancellationToken">Bounds the best-effort PING/PONG fence wait.</param>
+    /// <param name="cancellationToken">Bounds the best-effort PING/PONG fence wait. Cancellation does not abort the drain.</param>
     /// <returns>A <see cref="ValueTask"/> that represents the asynchronous drain operation.</returns>
     public virtual ValueTask DrainAsync(CancellationToken cancellationToken = default) => DrainCoreAsync(cancellationToken);
 

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -297,7 +297,7 @@ public abstract class NatsSubBase
     /// keep the subscription alive.
     /// </para>
     /// </remarks>
-    /// <param name="cancellationToken">Bounds the best-effort PING/PONG fence wait. Cancellation does not abort the drain.</param>
+    /// <param name="cancellationToken">Bounds the best-effort PING/PONG fence wait, which lasts at most <see cref="NatsOpts.DrainPingTimeout"/>; the token can only shorten it, not extend it past that timeout. Cancellation does not abort the drain.</param>
     /// <returns>A <see cref="ValueTask"/> that represents the asynchronous drain operation.</returns>
     public virtual ValueTask DrainAsync(CancellationToken cancellationToken = default) => DrainCoreAsync(cancellationToken);
 

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -636,6 +636,15 @@ public abstract class NatsSubBase
     /// </summary>
     private async ValueTask DrainCoreAsync(CancellationToken cancellationToken)
     {
+        // Disarm the lifecycle timers before taking the unsubscribe gate so a
+        // Timeout/IdleTimeout/StartUp callback that is about to fire is less likely to win
+        // the gate and complete the channel without the drain fence. The gate below still
+        // guarantees correctness if a callback was already in flight; this just narrows the
+        // window where an explicit drain races those timers.
+        _timeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+        _idleTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+        _startUpTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+
         var needsUnsub = false;
         lock (_gate)
         {
@@ -651,26 +660,22 @@ public abstract class NatsSubBase
 
         DecrementActiveSubscription();
 
-        _timeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-        _idleTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-        _startUpTimeoutTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-
-        // For the built-in SubscriptionManager: send UNSUB but keep the SID in the routing
-        // table until after the PING/PONG round-trip, so messages already in the socket
-        // buffer are delivered before the channel is completed.
-        // For external managers: fall back to RemoveAsync (routing removed before PING).
         var mgr = _manager as SubscriptionManager;
-        var sid = mgr != null
-            ? await mgr.UnsubscribeForDrainAsync(this).ConfigureAwait(false)
-            : -1;
-        if (mgr == null)
-            await _manager.RemoveAsync(this).ConfigureAwait(false);
-
-        // PING/PONG round-trip: after we get the PONG back, we know the server
-        // has processed our UNSUB and the socket reader has processed all messages
-        // that were in-flight before the UNSUB was received by the server.
+        var sid = -1;
         try
         {
+            // For the built-in SubscriptionManager: send UNSUB but keep the SID in the routing
+            // table until after the PING/PONG round-trip, so messages already in the socket
+            // buffer are delivered before the channel is completed.
+            // For external managers: fall back to RemoveAsync (routing removed before PING).
+            if (mgr != null)
+                sid = await mgr.UnsubscribeForDrainAsync(this).ConfigureAwait(false);
+            else
+                await _manager.RemoveAsync(this).ConfigureAwait(false);
+
+            // PING/PONG round-trip: after we get the PONG back, we know the server
+            // has processed our UNSUB and the socket reader has processed all messages
+            // that were in-flight before the UNSUB was received by the server.
             using var pingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             pingCts.CancelAfter(Connection.Opts.DrainPingTimeout);
             await Connection.PingAsync(pingCts.Token).ConfigureAwait(false);
@@ -683,13 +688,23 @@ public abstract class NatsSubBase
         {
             // Connection failed or disconnected during drain. Drain is best-effort.
         }
+        catch (ObjectDisposedException)
+        {
+            // The connection or its command writer was disposed mid-drain (e.g. a connection
+            // dispose racing an explicit drain). Drain is best-effort; fall through and still
+            // complete the channel below.
+        }
+        finally
+        {
+            // Remove from routing now that no more messages can arrive for this SID, then
+            // complete the channel. This runs even if UNSUB or PING threw, so a reader
+            // blocked on the channel (e.g. the drain-on-cancel consume loop reading with
+            // CancellationToken.None) is never left waiting forever.
+            if (sid != -1)
+                mgr?.RemoveFromRouting(sid);
 
-        // Remove from routing now that no more messages can arrive for this SID.
-        if (sid != -1)
-            mgr?.RemoveFromRouting(sid);
-
-        // Now it's safe to complete the channel, no more messages will arrive.
-        TryComplete();
+            TryComplete();
+        }
     }
 
     private async ValueTask WaitForReaderDrainCoreAsync(Task task, TimeSpan timeout)

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -50,6 +50,7 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
     private long _pendingMsgs;
     private long _pendingBytes;
     private int _consecutive503Errors;
+    private volatile bool _draining;
 
     public NatsJSConsume(
         long maxMsgs,
@@ -114,6 +115,13 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
             static state =>
             {
                 var self = (NatsJSConsume<TMsg>)state!;
+
+                // A drain is completing the subscription behind a PING/PONG fence. Don't let
+                // the heartbeat callback complete the channel (CompleteStop) and skip the
+                // fence, which would drop in-flight messages the drain is meant to preserve.
+                if (self._draining)
+                    return;
+
                 self._notificationChannel?.Notify(NatsJSTimeoutNotification.Default);
 
                 if (self._cancellationToken.IsCancellationRequested)
@@ -198,13 +206,22 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
 
     public override ValueTask DrainAsync(CancellationToken cancellationToken = default)
     {
+        _draining = true;
         StopHeartbeatTimer();
         return base.DrainAsync(cancellationToken);
     }
 
     public void StopHeartbeatTimer() => _timer.Change(Timeout.Infinite, Timeout.Infinite);
 
-    public void ResetHeartbeatTimer() => _timer.Change(_hbTimeout, _hbTimeout);
+    public void ResetHeartbeatTimer()
+    {
+        // Once draining, the heartbeat timer stays stopped so it can't re-arm and complete
+        // the channel ahead of the drain fence.
+        if (_draining)
+            return;
+
+        _timer.Change(_hbTimeout, _hbTimeout);
+    }
 
     public void Delivered(int msgSize)
     {
@@ -535,6 +552,12 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
             state =>
             {
                 var self = (NatsJSConsume<TMsg>)state!;
+
+                // If a drain started after this stop was queued, leave completion to the
+                // drain fence rather than dropping in-flight messages here.
+                if (self._draining)
+                    return;
+
                 self._userMsgs.Writer.TryComplete();
                 self.EndSubscription(NatsSubEndReason.None);
             },

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -222,7 +222,7 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
     {
         try
         {
-            await DrainAsync().ConfigureAwait(false);
+            await DrainOnDisposeAsync().ConfigureAwait(false);
             await base.DisposeAsync().ConfigureAwait(false);
         }
         finally

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -196,6 +196,12 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
             cancellationToken: cancellationToken);
     }
 
+    public override ValueTask DrainAsync(CancellationToken cancellationToken = default)
+    {
+        StopHeartbeatTimer();
+        return base.DrainAsync(cancellationToken);
+    }
+
     public void StopHeartbeatTimer() => _timer.Change(Timeout.Infinite, Timeout.Infinite);
 
     public void ResetHeartbeatTimer() => _timer.Change(_hbTimeout, _hbTimeout);

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -204,13 +204,6 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
             cancellationToken: cancellationToken);
     }
 
-    public override ValueTask DrainAsync(CancellationToken cancellationToken = default)
-    {
-        _draining = true;
-        StopHeartbeatTimer();
-        return base.DrainAsync(cancellationToken);
-    }
-
     public void StopHeartbeatTimer() => _timer.Change(Timeout.Infinite, Timeout.Infinite);
 
     public void ResetHeartbeatTimer()
@@ -320,6 +313,15 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
 
             ResetPending();
         }
+    }
+
+    protected override void StopDelivery()
+    {
+        // Mark draining first so the heartbeat callback, its re-arm, and CompleteStop
+        // defer to the drain fence, then stop the timer so it can't pull or complete the
+        // channel during the drain.
+        _draining = true;
+        StopHeartbeatTimer();
     }
 
     protected override async ValueTask ReceiveInternalAsync(

--- a/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
@@ -163,7 +163,7 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
     {
         try
         {
-            await DrainAsync().ConfigureAwait(false);
+            await DrainOnDisposeAsync().ConfigureAwait(false);
             await base.DisposeAsync().ConfigureAwait(false);
         }
         finally

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
@@ -140,7 +140,7 @@ internal class NatsJSOrderedConsume<TMsg> : NatsSubBase
         _context.Connection.ConnectionDisconnected -= ConnectionOnConnectionDisconnected;
         try
         {
-            await DrainAsync().ConfigureAwait(false);
+            await DrainOnDisposeAsync().ConfigureAwait(false);
             await base.DisposeAsync().ConfigureAwait(false);
         }
         finally

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -80,16 +80,10 @@ public class NatsJSConsumer : INatsJSConsumer
         {
             while (true)
             {
-                if (cancellationToken.IsCancellationRequested && !draining)
-                {
-                    if (!drainOnCancel)
-                        yield break;
-
-                    draining = true;
-                    drainTask = cc.DrainAsync();
-                }
-
                 // We have to check calls individually since we can't use yield return in try-catch blocks.
+                // WaitToReadAsync throws if the token is already canceled (even with buffered
+                // messages), so the catch below is the single place that reacts to cancellation:
+                // start the drain when DrainOnCancel is set, otherwise stop.
                 bool ready;
                 try
                 {

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -66,20 +66,44 @@ public class NatsJSConsumer : INatsJSConsumer
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         opts ??= _context.Opts.DefaultConsumeOpts;
+        var drainOnCancel = opts.DrainOnCancel;
         await using var cc = await ConsumeInternalAsync<T>(serializer, opts, cancellationToken).ConfigureAwait(false);
         cc.MarkReaderActive();
+
+        // When draining on cancel we keep reading buffered messages until the channel
+        // completes instead of bailing out immediately. The drain stops pulling, fences
+        // in-flight messages with a PING/PONG and completes the channel, leaving the
+        // connection usable so handlers can still ACK the messages they receive.
+        var draining = false;
+        var drainTask = default(ValueTask);
         try
         {
-            while (!cancellationToken.IsCancellationRequested)
+            while (true)
             {
+                if (cancellationToken.IsCancellationRequested && !draining)
+                {
+                    if (!drainOnCancel)
+                        yield break;
+
+                    draining = true;
+                    drainTask = cc.DrainAsync();
+                }
+
                 // We have to check calls individually since we can't use yield return in try-catch blocks.
                 bool ready;
                 try
                 {
-                    ready = await cc.Msgs.WaitToReadAsync(cancellationToken).ConfigureAwait(false);
+                    ready = await cc.Msgs.WaitToReadAsync(draining ? CancellationToken.None : cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
+                    if (drainOnCancel && !draining)
+                    {
+                        draining = true;
+                        drainTask = cc.DrainAsync();
+                        continue;
+                    }
+
                     ready = false;
                 }
                 catch (NatsConnectionFailedException)
@@ -96,8 +120,13 @@ public class NatsJSConsumer : INatsJSConsumer
                 if (!ready)
                     yield break;
 
-                while (!cancellationToken.IsCancellationRequested)
+                while (true)
                 {
+                    // Stop promptly on cancel unless we are draining, in which case we
+                    // keep reading the buffered messages until the channel completes.
+                    if (!draining && cancellationToken.IsCancellationRequested)
+                        break;
+
                     bool read;
                     NatsJSMsg<T> jsMsg;
                     try
@@ -135,6 +164,11 @@ public class NatsJSConsumer : INatsJSConsumer
         finally
         {
             cc.MarkReaderInactive();
+
+            // Observe the drain completion. DrainAsync swallows cancellation and
+            // connection errors internally, so this does not throw on the normal path.
+            if (draining)
+                await drainTask.ConfigureAwait(false);
         }
     }
 

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -167,6 +167,11 @@ public record NatsJSConsumeOpts
     /// then complete) and leaves the connection usable, instead of stopping
     /// immediately. (default: false)
     /// </summary>
+    /// <remarks>
+    /// Only the standard pull consumer's ConsumeAsync honors this. Ordered consumers
+    /// (see <see cref="NatsJSOrderedConsumer"/>) do not ACK and always stop promptly
+    /// on cancel, so the option has no effect there.
+    /// </remarks>
     public bool DrainOnCancel { get; init; }
 }
 

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -160,6 +160,14 @@ public record NatsJSConsumeOpts
     /// Set to -1 to disable this check. (default: 10)
     /// </summary>
     public int MaxConsecutive503Errors { get; init; } = 10;
+
+    /// <summary>
+    /// When true, cancelling the token passed to ConsumeAsync drains the consumer
+    /// gracefully (stop pulling, deliver buffered messages so handlers can ACK,
+    /// then complete) and leaves the connection usable, instead of stopping
+    /// immediately. (default: false)
+    /// </summary>
+    public bool DrainOnCancel { get; init; }
 }
 
 /// <summary>

--- a/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
@@ -66,6 +66,9 @@ public class SubscriptionDrainTest
         await foreach (var msg in sub.Msgs.ReadAllAsync(cancellationToken))
             received.Add(msg.Data);
 
+        // Check the count first so a dropped message surfaces as a count mismatch rather
+        // than a confusing order-equality failure.
+        Assert.Equal(count, received.Count);
         Assert.Equal(Enumerable.Range(0, count), received);
     }
 

--- a/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
@@ -1,0 +1,92 @@
+using NATS.Client.Core2.Tests;
+
+namespace NATS.Client.Core.Tests;
+
+[Collection("nats-server")]
+public class SubscriptionDrainTest
+{
+    private readonly ITestOutputHelper _output;
+    private readonly NatsServerFixture _server;
+
+    public SubscriptionDrainTest(ITestOutputHelper output, NatsServerFixture server)
+    {
+        _output = output;
+        _server = server;
+    }
+
+    [Fact]
+    public async Task Drain_preserves_buffered_messages_and_completes_channel()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        var subject = $"foo.{Guid.NewGuid():N}";
+        var sub = await nats.SubscribeCoreAsync<int>(subject, cancellationToken: cancellationToken);
+
+        const int count = 10;
+        for (var i = 0; i < count; i++)
+            await nats.PublishAsync(subject, i, cancellationToken: cancellationToken);
+
+        // PING/PONG round-trip guarantees the published messages have been
+        // delivered back to our subscription channel before we drain.
+        await nats.PingAsync(cancellationToken);
+
+        await sub.DrainAsync(cancellationToken);
+
+        // All buffered messages are still readable and the channel completes.
+        var received = new List<int>();
+        await foreach (var msg in sub.Msgs.ReadAllAsync(cancellationToken))
+            received.Add(msg.Data);
+
+        Assert.Equal(Enumerable.Range(0, count), received);
+    }
+
+    [Fact]
+    public async Task Drain_stops_new_messages_but_connection_stays_usable()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        var subject = $"foo.{Guid.NewGuid():N}";
+        var sub = await nats.SubscribeCoreAsync<int>(subject, cancellationToken: cancellationToken);
+
+        await nats.PublishAsync(subject, 1, cancellationToken: cancellationToken);
+        await nats.PingAsync(cancellationToken);
+
+        await sub.DrainAsync(cancellationToken);
+
+        // Published after the UNSUB; must not reach the drained subscription.
+        await nats.PublishAsync(subject, 2, cancellationToken: cancellationToken);
+        await nats.PingAsync(cancellationToken);
+
+        var received = new List<int>();
+        await foreach (var msg in sub.Msgs.ReadAllAsync(cancellationToken))
+            received.Add(msg.Data);
+
+        Assert.Equal(new[] { 1 }, received);
+
+        // The connection is still usable for a fresh subscription and publish.
+        var sub2 = await nats.SubscribeCoreAsync<int>(subject, cancellationToken: cancellationToken);
+        await nats.PublishAsync(subject, 42, cancellationToken: cancellationToken);
+        var next = await sub2.Msgs.ReadAsync(cancellationToken);
+        Assert.Equal(42, next.Data);
+        await sub2.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Drain_is_idempotent_and_dispose_after_drain_is_safe()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        var subject = $"foo.{Guid.NewGuid():N}";
+        var sub = await nats.SubscribeCoreAsync<int>(subject, cancellationToken: cancellationToken);
+
+        await sub.DrainAsync(cancellationToken);
+        await sub.DrainAsync(cancellationToken);
+        await sub.DisposeAsync();
+    }
+}

--- a/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
@@ -5,12 +5,10 @@ namespace NATS.Client.Core.Tests;
 [Collection("nats-server")]
 public class SubscriptionDrainTest
 {
-    private readonly ITestOutputHelper _output;
     private readonly NatsServerFixture _server;
 
-    public SubscriptionDrainTest(ITestOutputHelper output, NatsServerFixture server)
+    public SubscriptionDrainTest(NatsServerFixture server)
     {
-        _output = output;
         _server = server;
     }
 

--- a/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
@@ -41,6 +41,35 @@ public class SubscriptionDrainTest
     }
 
     [Fact]
+    public async Task Drain_delivers_messages_still_in_flight_after_unsub()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        var subject = $"foo.{Guid.NewGuid():N}";
+        var sub = await nats.SubscribeCoreAsync<int>(subject, cancellationToken: cancellationToken);
+
+        // Kept below the default SubPendingChannelCapacity so nothing is dropped for being
+        // over capacity; what is under test is the drain fence, not back-pressure.
+        const int count = 1000;
+        for (var i = 0; i < count; i++)
+            await nats.PublishAsync(subject, i, cancellationToken: cancellationToken);
+
+        // Unlike the test above there is no PING/PONG before draining, so messages the
+        // server sent before it processed our UNSUB are still in flight (not yet in the
+        // channel). The drain fences inbound delivery with its own PING/PONG so they all
+        // land before the channel completes; without that fence the tail would be dropped.
+        await sub.DrainAsync(cancellationToken);
+
+        var received = new List<int>();
+        await foreach (var msg in sub.Msgs.ReadAllAsync(cancellationToken))
+            received.Add(msg.Data);
+
+        Assert.Equal(Enumerable.Range(0, count), received);
+    }
+
+    [Fact]
     public async Task Drain_stops_new_messages_but_connection_stays_usable()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });

--- a/tests/NATS.Client.JetStream.Tests/ConsumeDrainTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumeDrainTest.cs
@@ -6,14 +6,9 @@ namespace NATS.Client.JetStream.Tests;
 [Collection("nats-server")]
 public class ConsumeDrainTest
 {
-    private readonly ITestOutputHelper _output;
     private readonly NatsServerFixture _server;
 
-    public ConsumeDrainTest(ITestOutputHelper output, NatsServerFixture server)
-    {
-        _output = output;
-        _server = server;
-    }
+    public ConsumeDrainTest(NatsServerFixture server) => _server = server;
 
     [Fact]
     public async Task Consume_drain_on_cancel_delivers_buffered_and_keeps_connection()
@@ -109,7 +104,8 @@ public class ConsumeDrainTest
 #endif
         }
 
-        // Without drain the buffered messages are abandoned when the token is cancelled.
-        Assert.True(received < total, $"expected fewer than {total} messages, got {received}");
+        // Without drain the loop stops promptly on cancel (fired after the first
+        // message) and abandons the buffered messages rather than delivering them.
+        Assert.True(received <= 5, $"expected a prompt stop (<= 5 messages), got {received} of {total}");
     }
 }

--- a/tests/NATS.Client.JetStream.Tests/ConsumeDrainTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumeDrainTest.cs
@@ -1,0 +1,115 @@
+using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
+
+namespace NATS.Client.JetStream.Tests;
+
+[Collection("nats-server")]
+public class ConsumeDrainTest
+{
+    private readonly ITestOutputHelper _output;
+    private readonly NatsServerFixture _server;
+
+    public ConsumeDrainTest(ITestOutputHelper output, NatsServerFixture server)
+    {
+        _output = output;
+        _server = server;
+    }
+
+    [Fact]
+    public async Task Consume_drain_on_cancel_delivers_buffered_and_keeps_connection()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await js.CreateStreamAsync($"{prefix}s1", new[] { $"{prefix}s1.*" }, cts.Token);
+        await js.CreateOrUpdateConsumerAsync($"{prefix}s1", $"{prefix}c1", cancellationToken: cts.Token);
+
+        const int total = 100;
+        for (var i = 0; i < total; i++)
+        {
+            var ack = await js.PublishAsync($"{prefix}s1.foo", new TestData { Test = i }, serializer: TestDataJsonSerializer<TestData>.Default, cancellationToken: cts.Token);
+            ack.EnsureSuccess();
+        }
+
+        // MaxMsgs above the published count so a single pull buffers all messages.
+        var consumerOpts = new NatsJSConsumeOpts { MaxMsgs = 100, DrainOnCancel = true };
+        var consumer = (NatsJSConsumer)await js.GetConsumerAsync($"{prefix}s1", $"{prefix}c1", cts.Token);
+
+        var received = 0;
+        await foreach (var msg in consumer.ConsumeAsync(serializer: TestDataJsonSerializer<TestData>.Default, consumerOpts, cancellationToken: cts.Token))
+        {
+            // Simulate some processing time.
+            await Task.Delay(10, CancellationToken.None);
+
+            // ACK after cancellation must still succeed since the connection stays open.
+            await msg.AckAsync(cancellationToken: CancellationToken.None);
+            received++;
+
+            // Cancel once consumption is under way; drain must still deliver the
+            // remaining buffered/in-flight messages instead of dropping them.
+            if (received == 1)
+#if NET8_0_OR_GREATER
+                await cts.CancelAsync();
+#else
+                cts.Cancel();
+#endif
+        }
+
+        Assert.Equal(total, received);
+
+        // Connection is left usable after the drain completes.
+        Assert.Equal(NatsConnectionState.Open, nats.ConnectionState);
+        await nats.PingAsync(CancellationToken.None);
+        var ack2 = await js.PublishAsync($"{prefix}s1.foo", new TestData { Test = total }, serializer: TestDataJsonSerializer<TestData>.Default, cancellationToken: CancellationToken.None);
+        ack2.EnsureSuccess();
+    }
+
+    [Fact]
+    public async Task Consume_without_drain_on_cancel_drops_buffered_messages()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await js.CreateStreamAsync($"{prefix}s1", new[] { $"{prefix}s1.*" }, cts.Token);
+        await js.CreateOrUpdateConsumerAsync($"{prefix}s1", $"{prefix}c1", cancellationToken: cts.Token);
+
+        const int total = 100;
+        for (var i = 0; i < total; i++)
+        {
+            var ack = await js.PublishAsync($"{prefix}s1.foo", new TestData { Test = i }, serializer: TestDataJsonSerializer<TestData>.Default, cancellationToken: cts.Token);
+            ack.EnsureSuccess();
+        }
+
+        // DrainOnCancel defaults to false: cancelling stops promptly and does not
+        // deliver the messages still buffered in the consumer.
+        var consumerOpts = new NatsJSConsumeOpts { MaxMsgs = 100 };
+        var consumer = (NatsJSConsumer)await js.GetConsumerAsync($"{prefix}s1", $"{prefix}c1", cts.Token);
+
+        var received = 0;
+        await foreach (var msg in consumer.ConsumeAsync(serializer: TestDataJsonSerializer<TestData>.Default, consumerOpts, cancellationToken: cts.Token))
+        {
+            await msg.AckAsync(cancellationToken: CancellationToken.None);
+            received++;
+
+            if (received == 1)
+#if NET8_0_OR_GREATER
+                await cts.CancelAsync();
+#else
+                cts.Cancel();
+#endif
+        }
+
+        // Without drain the buffered messages are abandoned when the token is cancelled.
+        Assert.True(received < total, $"expected fewer than {total} messages, got {received}");
+    }
+}

--- a/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
@@ -295,9 +295,22 @@ public class OpenTelemetryTest
         await nats.ReconnectAsync();
         await openedTwice.Task.WaitAsync(TimeSpan.FromSeconds(30));
 
-        var reconnects = meter.LongMeasurements
-            .Where(m => m.Name == "nats.client.reconnects")
-            .ToList();
+        // The reconnects counter is incremented just after the ConnectionOpened event is
+        // queued, so the measurement can land slightly after the event we awaited. Poll
+        // for it rather than reading once and racing the increment.
+        List<(string Name, long Value, KeyValuePair<string, object?>[] Tags)> reconnects = new();
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            reconnects = meter.LongMeasurements
+                .Where(m => m.Name == "nats.client.reconnects")
+                .ToList();
+
+            if (reconnects.Count > 0)
+                break;
+
+            await Task.Delay(25);
+        }
 
         reconnects.Sum(m => m.Value).Should().Be(1);
 
@@ -536,6 +549,9 @@ public class OpenTelemetryTest
     private sealed class MeterTracker : IDisposable
     {
         private readonly MeterListener _listener;
+        private readonly object _sync = new();
+        private readonly List<(string Name, long Value, KeyValuePair<string, object?>[] Tags)> _longMeasurements = new();
+        private readonly List<(string Name, double Value, KeyValuePair<string, object?>[] Tags)> _doubleMeasurements = new();
 
         public MeterTracker()
         {
@@ -548,17 +564,39 @@ public class OpenTelemetryTest
                 },
             };
 
+            // Measurement callbacks fire on background threads (e.g. the reconnect loop),
+            // so guard the lists and hand out snapshots to readers.
             _listener.SetMeasurementEventCallback<long>((inst, val, tags, _) =>
-                LongMeasurements.Add((inst.Name, val, tags.ToArray())));
+            {
+                lock (_sync)
+                    _longMeasurements.Add((inst.Name, val, tags.ToArray()));
+            });
             _listener.SetMeasurementEventCallback<double>((inst, val, tags, _) =>
-                DoubleMeasurements.Add((inst.Name, val, tags.ToArray())));
+            {
+                lock (_sync)
+                    _doubleMeasurements.Add((inst.Name, val, tags.ToArray()));
+            });
 
             _listener.Start();
         }
 
-        public List<(string Name, long Value, KeyValuePair<string, object?>[] Tags)> LongMeasurements { get; } = new();
+        public IReadOnlyList<(string Name, long Value, KeyValuePair<string, object?>[] Tags)> LongMeasurements
+        {
+            get
+            {
+                lock (_sync)
+                    return _longMeasurements.ToArray();
+            }
+        }
 
-        public List<(string Name, double Value, KeyValuePair<string, object?>[] Tags)> DoubleMeasurements { get; } = new();
+        public IReadOnlyList<(string Name, double Value, KeyValuePair<string, object?>[] Tags)> DoubleMeasurements
+        {
+            get
+            {
+                lock (_sync)
+                    return _doubleMeasurements.ToArray();
+            }
+        }
 
         public void Dispose() => _listener.Dispose();
     }

--- a/tests/xunit.runsettings
+++ b/tests/xunit.runsettings
@@ -4,6 +4,6 @@
         <TestSessionTimeout>600000</TestSessionTimeout>
     </RunConfiguration>
     <xUnit>
-        <MaxParallelThreads>1.0x</MaxParallelThreads>
+        <MaxParallelThreads>1</MaxParallelThreads>
     </xUnit>
 </RunSettings>


### PR DESCRIPTION
Adds explicit, dispose-independent subscription draining. `INatsSub<T>.DrainAsync` drains a single core subscription: stop new deliveries, fence in-flight messages with a PING/PONG, complete the channel, and keep the connection open. For JetStream pull consumers, a new opt-in `DrainOnCancel` makes cancelling a consume drain gracefully (stop pulling, deliver buffered messages so handlers can still ack on the open connection) instead of stopping abruptly; the default preserves the previous behavior.

Also runs the xUnit suite single-threaded (MaxParallelThreads 1) to remove the cross-collection parallelism behind several earlier integration-test flaps.

Fixes #1176.
