### PR TITLE
Unify subscription channel overflow defaults

### DIFF
--- a/src/NATS.Client.Core/NatsOpts.cs
+++ b/src/NATS.Client.Core/NatsOpts.cs
@@ -228,9 +228,9 @@ public sealed record NatsOpts
 
     /// <summary>
     /// This value will be used for subscriptions internal bounded message channel capacity.
-    /// The default subscriber pending message limit is 1024.
+    /// The default subscriber pending message limit is 16384.
     /// </summary>
-    public int SubPendingChannelCapacity { get; init; } = 1024;
+    public int SubPendingChannelCapacity { get; init; } = 16384;
 
     /// <summary>
     /// This value will be used for subscriptions internal bounded message channel <c>FullMode</c>.

--- a/src/NATS.Client.Simplified/NatsClient.cs
+++ b/src/NATS.Client.Simplified/NatsClient.cs
@@ -1,4 +1,3 @@
-using System.Threading.Channels;
 using NATS.Client.Core;
 
 namespace NATS.Net;
@@ -40,7 +39,6 @@ public class NatsClient : INatsClient
             Name = name,
             Url = url,
             SerializerRegistry = NatsClientDefaultSerializerRegistry.Default,
-            SubPendingChannelFullMode = BoundedChannelFullMode.Wait,
             AuthOpts = new NatsAuthOpts { CredsFile = credsFile },
         };
 
@@ -51,13 +49,11 @@ public class NatsClient : INatsClient
     /// Initializes a new instance of the <see cref="NatsClient"/> class.
     /// </summary>
     /// <param name="opts">NATS client options.</param>
-    /// <param name="pending">Sets `SubPendingChannelFullMode` option. (default: wait)</param>
     /// <remarks>
     /// By default, the <paramref name="opts"/> will be merged with the default options
-    /// overriding SerializationRegistry with <see cref="NatsClientDefaultSerializerRegistry.Default"/>
-    /// and SubPendingChannelFullMode with <see cref="BoundedChannelFullMode.Wait"/>.
+    /// overriding SerializationRegistry with <see cref="NatsClientDefaultSerializerRegistry.Default"/>.
     /// </remarks>
-    public NatsClient(NatsOpts opts, BoundedChannelFullMode pending = BoundedChannelFullMode.Wait)
+    public NatsClient(NatsOpts opts)
     {
         if (ReferenceEquals(opts.SerializerRegistry, NatsOpts.Default.SerializerRegistry))
         {
@@ -66,8 +62,6 @@ public class NatsClient : INatsClient
                 SerializerRegistry = NatsClientDefaultSerializerRegistry.Default,
             };
         }
-
-        opts = opts with { SubPendingChannelFullMode = pending };
 
         Connection = new NatsConnection(opts);
     }

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
@@ -37,7 +37,6 @@ public class NatsBuilder
             opts.Opts = opts.Opts with
             {
                 LoggerFactory = provider.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance,
-                SubPendingChannelFullMode = BoundedChannelFullMode.Wait,
             };
 
             if (ReferenceEquals(opts.Opts.SerializerRegistry, NatsOpts.Default.SerializerRegistry))
@@ -130,8 +129,8 @@ public class NatsBuilder
     /// <returns>Builder to allow method chaining.</returns>
     /// <remarks>
     /// This will be applied to options overriding values set for <c>SubPendingChannelFullMode</c> in options.
-    /// By default, the pending messages channel will wait for space to be available when full.
-    /// Note that this is not the same as <c>NatsOpts</c> default <c>SubPendingChannelFullMode</c> which is <c>DropNewest</c>.
+    /// When not set, the pending messages channel uses the <c>NatsOpts</c> default
+    /// (<c>BoundedChannelFullMode.DropNewest</c>).
     /// </remarks>
     public NatsBuilder WithSubPendingChannelFullMode(BoundedChannelFullMode pending) =>
         ConfigureOptions(builder => builder.Configure(opts => opts.Opts = opts.Opts with

--- a/tests/NATS.Client.Simplified.Tests/ClientTest.cs
+++ b/tests/NATS.Client.Simplified.Tests/ClientTest.cs
@@ -230,14 +230,14 @@ public class ClientTest
     public void Client_opts_default_pending()
     {
         var client = new NatsClient(new NatsOpts());
-        Assert.Equal(BoundedChannelFullMode.Wait, client.Connection.Opts.SubPendingChannelFullMode);
+        Assert.Equal(BoundedChannelFullMode.DropNewest, client.Connection.Opts.SubPendingChannelFullMode);
     }
 
     [Fact]
-    public void Client_opts_set_pending()
+    public void Client_opts_pending_respected()
     {
-        var client = new NatsClient(new NatsOpts(), pending: BoundedChannelFullMode.DropNewest);
-        Assert.Equal(BoundedChannelFullMode.DropNewest, client.Connection.Opts.SubPendingChannelFullMode);
+        var client = new NatsClient(new NatsOpts { SubPendingChannelFullMode = BoundedChannelFullMode.Wait });
+        Assert.Equal(BoundedChannelFullMode.Wait, client.Connection.Opts.SubPendingChannelFullMode);
     }
 
     private record MyData(int Id, string Name);

--- a/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/NatsHostingExtensionsTests.cs
+++ b/tests/NATS.Extensions.Microsoft.DependencyInjection.Tests/NatsHostingExtensionsTests.cs
@@ -77,10 +77,10 @@ public class NatsHostingExtensionsTests
 
         Assert.Same(NullLoggerFactory.Instance, nats.Opts.LoggerFactory);
 
-        // These defaults are different from NatsOptions defaults but same as NatsClient defaults
-        // for ease of use for new users
+        // The serializer registry default matches NatsClient (JSON) for ease of use for new users.
+        // The overflow mode inherits the NatsOpts default (DropNewest), same as NatsClient and NatsConnection.
         Assert.Same(NatsClientDefaultSerializerRegistry.Default, nats.Opts.SerializerRegistry);
-        Assert.Equal(BoundedChannelFullMode.Wait, nats.Opts.SubPendingChannelFullMode);
+        Assert.Equal(BoundedChannelFullMode.DropNewest, nats.Opts.SubPendingChannelFullMode);
 
         return Task.CompletedTask;
     }
@@ -123,8 +123,8 @@ public class NatsHostingExtensionsTests
 
         Assert.Same(mySerializerRegistry, nats.Opts.SerializerRegistry);
 
-        // You can only override this using .WithSubPendingChannelFullMode() on builder above
-        Assert.Equal(BoundedChannelFullMode.Wait, nats.Opts.SubPendingChannelFullMode);
+        // Inherits the NatsOpts default; override with .WithSubPendingChannelFullMode() on builder above
+        Assert.Equal(BoundedChannelFullMode.DropNewest, nats.Opts.SubPendingChannelFullMode);
 
         return Task.CompletedTask;
     }
@@ -146,8 +146,8 @@ public class NatsHostingExtensionsTests
 
         Assert.Same(mySerializerRegistry, nats.Opts.SerializerRegistry);
 
-        // You can only override this using .WithSubPendingChannelFullMode() on builder above
-        Assert.Equal(BoundedChannelFullMode.Wait, nats.Opts.SubPendingChannelFullMode);
+        // Inherits the NatsOpts default; override with .WithSubPendingChannelFullMode() on builder above
+        Assert.Equal(BoundedChannelFullMode.DropNewest, nats.Opts.SubPendingChannelFullMode);
 
         return Task.CompletedTask;
     }

--- a/tests/NATS.Net.DocsExamples/Advanced/IntroPage.cs
+++ b/tests/NATS.Net.DocsExamples/Advanced/IntroPage.cs
@@ -79,9 +79,9 @@ public class IntroPage
 
             NatsOpts opts = new NatsOpts
             {
-                // You need to set pending in the constructor and not use
-                // the option here, as it will be ignored.
-                SubPendingChannelFullMode = BoundedChannelFullMode.DropOldest,
+                // Set the subscriber channel overflow behavior here; it is
+                // respected by both NatsClient and NatsConnection.
+                SubPendingChannelFullMode = BoundedChannelFullMode.DropNewest,
 
                 // Your custom options
                 SerializerRegistry = new MyProtoBufSerializerRegistry(),
@@ -89,7 +89,7 @@ public class IntroPage
                 // ...
             };
 
-            await using NatsClient nc = new NatsClient(opts, pending: BoundedChannelFullMode.DropNewest);
+            await using NatsClient nc = new NatsClient(opts);
             #endregion
         }
 

--- a/tools/site_src/documentation/advanced/dependency-injection.md
+++ b/tools/site_src/documentation/advanced/dependency-injection.md
@@ -172,12 +172,10 @@ a serializer.
 
 ### Channel Full Mode
 
-`NATS.Extensions.Microsoft.DependencyInjection` sets `SubPendingChannelFullMode` to
-`BoundedChannelFullMode.Wait` by default (matching `NatsClient` behavior). This means
-a slow subscriber will apply backpressure instead of dropping messages.
-
-`NATS.Client.Hosting` uses the `NatsOpts` default of `BoundedChannelFullMode.DropNewest`,
-which drops the newest messages when the subscriber's channel is full.
+Both `NATS.Extensions.Microsoft.DependencyInjection` and `NATS.Client.Hosting` use the
+`NatsOpts` default of `BoundedChannelFullMode.DropNewest`, which drops the newest messages
+when the subscriber's channel is full. Use `WithSubPendingChannelFullMode(...)` on the
+builder to change it.
 
 ### Options Pattern
 

--- a/tools/site_src/documentation/advanced/intro.md
+++ b/tools/site_src/documentation/advanced/intro.md
@@ -32,10 +32,10 @@ instantiate a `NatsConnection` with default options, you would only have basic s
 for `int`, `string`, and `byte[]` types, and you would need to set up the serializers for your data classes
 if you want to use e.g., JSON serialization.
 
-The other difference is that `NatsClient` sets `SubPendingChannelFullMode` internal channel option to
-`BoundedChannelFullMode.Wait` to avoid dropping messages when the subscriber's internal channel is full.
-This is a good default for most cases, but you can change it by setting the `SubPendingChannelFullMode` option
-in `NatsClient` constructor.
+`NatsClient` and `NatsConnection` share the same overflow behavior: the subscriber's internal channel
+defaults to `BoundedChannelFullMode.DropNewest`, so a slow subscriber drops the newest messages rather
+than blocking the connection. You can change it by setting the `SubPendingChannelFullMode` option in
+`NatsOpts`.
 
 [!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/IntroPage.cs#opts)]
 

--- a/tools/site_src/documentation/advanced/slow-consumers.md
+++ b/tools/site_src/documentation/advanced/slow-consumers.md
@@ -18,7 +18,7 @@ It resets after the subscription catches up (channel drains), so it will fire ag
 
 ## Tuning Channel Capacity
 
-Each subscription has an internal bounded channel with a default capacity of 1024 messages.
+Each subscription has an internal bounded channel with a default capacity of 16384 messages.
 You can tune this globally or per subscription:
 
 [!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/SlowConsumerPage.cs#tuning)]
@@ -27,8 +27,8 @@ You can tune this globally or per subscription:
 
 The `SubPendingChannelFullMode` option controls what happens when the channel is full:
 
-- `BoundedChannelFullMode.DropNewest` (default for `NatsConnection`) - newest messages are dropped
-- `BoundedChannelFullMode.Wait` (default for `NatsClient`) - backpressure is applied, but the server may disconnect you as a slow consumer
+- `BoundedChannelFullMode.DropNewest` (the default) - newest messages are dropped
+- `BoundedChannelFullMode.Wait` - backpressure is applied, but the server may disconnect you as a slow consumer
 
 > [!WARNING]
 > Using `BoundedChannelFullMode.Wait` prevents message loss at the client level, but if the subscriber


### PR DESCRIPTION
All entry points now share one subscriber-channel overflow policy. NatsClient and the DI builder previously forced Wait while NatsConnection used DropNewest; Wait can stall the socket read loop and get the client disconnected as a slow consumer. They now inherit the NatsOpts default DropNewest, and the default channel capacity goes from 1024 to 16384 so overflow stays rare. Breaking for NatsClient and DI users under sustained overload: newest messages are dropped (surfaced via MessageDropped) instead of blocking.

Fixes #1161