### PR TITLE
Simplify ordered push consumer sub teardown

### DIFF
--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
@@ -182,11 +182,11 @@ internal class NatsJSOrderedPushConsumer<T>
         // by now, so no new subscription can be created. Without this the sub's
         // ConnectionOpened handler stays attached to the connection, rooting the
         // sub for the connection's lifetime (memory leak).
+        // DisposeAsync unsubscribes internally, so a single call covers both.
         var sub = _sub;
         if (sub != null)
         {
-            await sub.UnsubscribeAsync();
-            await sub.DisposeAsync();
+            await sub.DisposeAsync().ConfigureAwait(false);
         }
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken);


### PR DESCRIPTION
Follow-up to the ordered push consumer dispose fix. NatsSubBase.DisposeAsync already calls UnsubscribeAsync internally, so the explicit UnsubscribeAsync before DisposeAsync was redundant. Collapse to a single DisposeAsync and add ConfigureAwait(false) to match the surrounding awaits.