### PR TITLE
Move socket connection interfaces to NATS.Client.Abstractions

### DIFF
--- a/src/NATS.Client.Abstractions/INatsSocketConnection.cs
+++ b/src/NATS.Client.Abstractions/INatsSocketConnection.cs
@@ -1,0 +1,43 @@
+using System.Net.Sockets;
+
+namespace NATS.Client.Core;
+
+/// <summary>
+/// Represents a socket connection to a NATS server.
+/// </summary>
+/// <remarks>
+/// This interface defines the contract for low-level socket connections to NATS servers,
+/// providing methods for sending and receiving data and disposing the socket.
+/// Disposing should attempt to perform graceful shutdown of the socket.
+/// </remarks>
+public interface INatsSocketConnection : IAsyncDisposable
+{
+    /// <summary>
+    /// Sends data asynchronously over the connection.
+    /// </summary>
+    /// <param name="buffer">The buffer containing the data to send.</param>
+    /// <returns>A task representing the asynchronous send operation with the number of bytes sent.</returns>
+    ValueTask<int> SendAsync(ReadOnlyMemory<byte> buffer);
+
+    /// <summary>
+    /// Receives data asynchronously from the connection.
+    /// </summary>
+    /// <param name="buffer">The buffer to store the received data.</param>
+    /// <returns>A task representing the asynchronous receive operation with the number of bytes received.</returns>
+    ValueTask<int> ReceiveAsync(Memory<byte> buffer);
+}
+
+/// <summary>
+/// Represents a NATS socket connection that can be upgraded to use TLS.
+/// </summary>
+/// <remarks>
+/// This interface extends <see cref="INatsSocketConnection"/> to provide access to the underlying
+/// socket that is used to create a SslStream.
+/// </remarks>
+public interface INatsTlsUpgradeableSocketConnection : INatsSocketConnection
+{
+    /// <summary>
+    /// Gets the underlying Socket instance for the connection.
+    /// </summary>
+    Socket Socket { get; }
+}

--- a/src/NATS.Client.Abstractions/NATS.Client.Abstractions.csproj
+++ b/src/NATS.Client.Abstractions/NATS.Client.Abstractions.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.5"/>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
   </ItemGroup>
 
 </Project>

--- a/src/NATS.Client.Core/INatsSocketConnection.cs
+++ b/src/NATS.Client.Core/INatsSocketConnection.cs
@@ -1,31 +1,4 @@
-using System.Net.Sockets;
-
 namespace NATS.Client.Core;
-
-/// <summary>
-/// Represents a socket connection to a NATS server.
-/// </summary>
-/// <remarks>
-/// This interface defines the contract for low-level socket connections to NATS servers,
-/// providing methods for sending and receiving data and disposing the socket.
-/// Disposing should attempt to perform graceful shutdown of the socket.
-/// </remarks>
-public interface INatsSocketConnection : IAsyncDisposable
-{
-    /// <summary>
-    /// Sends data asynchronously over the connection.
-    /// </summary>
-    /// <param name="buffer">The buffer containing the data to send.</param>
-    /// <returns>A task representing the asynchronous send operation with the number of bytes sent.</returns>
-    ValueTask<int> SendAsync(ReadOnlyMemory<byte> buffer);
-
-    /// <summary>
-    /// Receives data asynchronously from the connection.
-    /// </summary>
-    /// <param name="buffer">The buffer to store the received data.</param>
-    /// <returns>A task representing the asynchronous receive operation with the number of bytes received.</returns>
-    ValueTask<int> ReceiveAsync(Memory<byte> buffer);
-}
 
 /// <summary>
 /// Obsolete, use <see cref="INatsSocketConnection"/> instead
@@ -38,19 +11,4 @@ public interface ISocketConnection : INatsSocketConnection
     void SignalDisconnected(Exception exception);
 
     ValueTask AbortConnectionAsync(CancellationToken cancellationToken);
-}
-
-/// <summary>
-/// Represents a NATS socket connection that can be upgraded to use TLS.
-/// </summary>
-/// <remarks>
-/// This interface extends <see cref="INatsSocketConnection"/> to provide access to the underlying
-/// socket that is used to create a SslStream.
-/// </remarks>
-public interface INatsTlsUpgradeableSocketConnection : INatsSocketConnection
-{
-    /// <summary>
-    /// Gets the underlying Socket instance for the connection.
-    /// </summary>
-    Socket Socket { get; }
 }

--- a/src/NATS.Client.Core/TypeForwarders.cs
+++ b/src/NATS.Client.Core/TypeForwarders.cs
@@ -5,3 +5,5 @@ using NATS.Client.Core;
 [assembly: TypeForwardedTo(typeof(INatsSerialize<>))]
 [assembly: TypeForwardedTo(typeof(INatsDeserialize<>))]
 [assembly: TypeForwardedTo(typeof(INatsSerializerRegistry))]
+[assembly: TypeForwardedTo(typeof(INatsSocketConnection))]
+[assembly: TypeForwardedTo(typeof(INatsTlsUpgradeableSocketConnection))]

--- a/tests/NATS.Client.CheckAbi/Program.cs
+++ b/tests/NATS.Client.CheckAbi/Program.cs
@@ -23,10 +23,14 @@ Check("INatsSerializerRegistry", "NATS.Client.Abstractions", typeof(INatsSeriali
 Check("INatsSerializeWithContext<>", "NATS.Client.Abstractions", typeof(INatsSerializeWithContext<>).Assembly.GetName().Name!);
 Check("INatsDeserializeWithContext<>", "NATS.Client.Abstractions", typeof(INatsDeserializeWithContext<>).Assembly.GetName().Name!);
 Check("NatsMsgContext", "NATS.Client.Abstractions", typeof(NatsMsgContext).Assembly.GetName().Name!);
+Check("INatsSocketConnection", "NATS.Client.Abstractions", typeof(INatsSocketConnection).Assembly.GetName().Name!);
+Check("INatsTlsUpgradeableSocketConnection", "NATS.Client.Abstractions", typeof(INatsTlsUpgradeableSocketConnection).Assembly.GetName().Name!);
 Console.WriteLine();
 
 Console.WriteLine("Types as seen by TransientLib (compiled against 2.6.0):");
 Check("INatsSerialize<> (transient)", "NATS.Client.Abstractions", MySerializer.GetSerializerInterfaceAssembly());
+Check("INatsSocketConnection (transient)", "NATS.Client.Abstractions", MySocketConnection.GetSocketConnectionInterfaceAssembly());
+Check("INatsTlsUpgradeableSocketConnection (transient)", "NATS.Client.Abstractions", MySocketConnection.GetTlsUpgradeableInterfaceAssembly());
 Console.WriteLine();
 
 Console.WriteLine("Assembly versions at runtime:");
@@ -51,6 +55,16 @@ var deserialized = serializer.Deserialize(new ReadOnlySequence<byte>(buffer.Writ
 Console.WriteLine($"  Deserialized: '{deserialized}'");
 if (deserialized != "hello from transient dependency")
     errors.Add($"Round-trip failed: got '{deserialized}'");
+
+Console.WriteLine();
+
+Console.WriteLine("Testing TransientLib.MySocketConnection (compiled against 2.6.0):");
+INatsSocketConnection connection = new MySocketConnection();
+var sent = await connection.SendAsync(new ReadOnlyMemory<byte>(new byte[7]));
+Console.WriteLine($"  SendAsync reported {sent} bytes");
+if (sent != 7)
+    errors.Add($"SendAsync failed: got {sent}");
+await connection.DisposeAsync();
 
 Console.WriteLine();
 

--- a/tests/NATS.Client.CheckAbiTransientLib/MySocketConnection.cs
+++ b/tests/NATS.Client.CheckAbiTransientLib/MySocketConnection.cs
@@ -1,0 +1,30 @@
+using System.Net.Sockets;
+using NATS.Client.Core;
+
+namespace NATS.Client.CheckAbiTransientLib;
+
+/// <summary>
+/// Compiled against NATS.Net 2.6.0 where INatsSocketConnection and
+/// INatsTlsUpgradeableSocketConnection live in NATS.Client.Core. When used with a newer
+/// build, type forwarding should redirect both to NATS.Client.Abstractions.
+/// </summary>
+public class MySocketConnection : INatsTlsUpgradeableSocketConnection
+{
+    public Socket Socket => throw new NotSupportedException();
+
+    public static string GetSocketConnectionInterfaceAssembly()
+    {
+        return typeof(INatsSocketConnection).Assembly.GetName().Name!;
+    }
+
+    public static string GetTlsUpgradeableInterfaceAssembly()
+    {
+        return typeof(INatsTlsUpgradeableSocketConnection).Assembly.GetName().Name!;
+    }
+
+    public ValueTask<int> SendAsync(ReadOnlyMemory<byte> buffer) => new(buffer.Length);
+
+    public ValueTask<int> ReceiveAsync(Memory<byte> buffer) => new(0);
+
+    public ValueTask DisposeAsync() => default;
+}


### PR DESCRIPTION
Move the socket transport contracts INatsSocketConnection and INatsTlsUpgradeableSocketConnection to NATS.Client.Abstractions so custom transport implementers can depend on the contract without referencing Core, matching the serialization interfaces already there. The types keep the NATS.Client.Core namespace and are forwarded via TypeForwardedTo to preserve source and binary compatibility; the obsolete ISocketConnection and INatsSocketConnectionFactory stay in Core. The ABI compatibility harness is extended to cover both moved interfaces through a transient dependency compiled against an older release.

Fixes #1185
