### PR TITLE
Remove stale net6.0 references

### DIFF
--- a/scripts/apicompat.sh
+++ b/scripts/apicompat.sh
@@ -61,8 +61,7 @@ echo "======================="
 
 exit_code=0
 
-# Only check against net8.0 as the target TFM
-# net6.0 has known differences with init accessors
+# Compare the netstandard surfaces against net8.0 as the baseline TFM
 check_compat "netstandard2.0" "net8.0" || exit_code=1
 check_compat "netstandard2.1" "net8.0" || exit_code=1
 

--- a/src/NATS.Client.JetStream/NATS.Client.JetStream.csproj
+++ b/src/NATS.Client.JetStream/NATS.Client.JetStream.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
-  <!--  Dependencies for net6.0 only -->
+  <!--  System.Text.Json for netstandard only; net8.0+ ships it in the shared framework -->
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5"/>
   </ItemGroup>

--- a/src/NATS.Client.Serializers.Json/NATS.Client.Serializers.Json.csproj
+++ b/src/NATS.Client.Serializers.Json/NATS.Client.Serializers.Json.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\NATS.Client.Abstractions\NATS.Client.Abstractions.csproj" />
   </ItemGroup>
 
-    <!--  Dependencies for net6.0 and net8.0 only -->
+    <!--  System.Text.Json for netstandard only; net8.0+ ships it in the shared framework -->
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'">
         <PackageReference Include="System.Text.Json" Version="8.0.5"/>
     </ItemGroup>

--- a/tools/site_src/documentation/advanced/platform-compatibility.md
+++ b/tools/site_src/documentation/advanced/platform-compatibility.md
@@ -4,8 +4,8 @@ NATS.Net targets multiple .NET platforms to provide broad compatibility:
 
 - `netstandard2.0` - .NET Framework 4.6.1+, .NET Core 2.0+, Mono, Xamarin, Unity
 - `netstandard2.1` - .NET Core 3.0+
-- `net6.0` - .NET 6
 - `net8.0` - .NET 8
+- `net10.0` - .NET 10
 
 While the API surface is designed to be consistent across all target frameworks, there are some
 intentional differences due to platform capabilities. This page documents these differences.
@@ -20,7 +20,7 @@ property allows you to configure TLS client authentication options.
 | Target Framework | Type |
 |-----------------|------|
 | `netstandard2.0` | `NATS.Client.Core.SslClientAuthenticationOptions` (polyfill) |
-| `netstandard2.1`, `net6.0`, `net8.0` | `System.Net.Security.SslClientAuthenticationOptions` (BCL) |
+| `netstandard2.1`, `net8.0`, `net10.0` | `System.Net.Security.SslClientAuthenticationOptions` (BCL) |
 
 On `netstandard2.0`, the library provides a polyfill type `NATS.Client.Core.SslClientAuthenticationOptions`
 because the BCL type doesn't exist in that target framework. The polyfill provides a subset of the
@@ -42,7 +42,7 @@ If you need the full `SslClientAuthenticationOptions` functionality, consider ta
 The [`AddNats`](xref:NATS.Client.Hosting.NatsHostingExtensions.AddNats*) extension method has different
 signatures depending on the target framework:
 
-**netstandard2.0, netstandard2.1, net6.0:**
+**netstandard2.0, netstandard2.1:**
 ```csharp
 public static IServiceCollection AddNats(
     this IServiceCollection services,
@@ -51,7 +51,7 @@ public static IServiceCollection AddNats(
     Action<NatsConnection>? configureConnection = null)
 ```
 
-**net8.0:**
+**net8.0, net10.0:**
 ```csharp
 public static IServiceCollection AddNats(
     this IServiceCollection services,


### PR DESCRIPTION
net6.0 was already dropped from the target frameworks (now netstandard2.0, netstandard2.1, net8.0, net10.0). This removes leftover net6.0 mentions from the platform-compatibility docs and corrects csproj and script comments that still labelled netstandard-only dependency groups as net6.0.

Part of #948.