### PR TITLE
Gate positive-path test connections with ConnectRetryAsync

### DIFF
--- a/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
+++ b/tests/NATS.Client.Core.Tests/LowLevelApiTest.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Text;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.Core.Tests;
@@ -15,6 +16,7 @@ public class LowLevelApiTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var subject = "foo.*";
         var builder = new NatsSubCustomTestBuilder(_output);

--- a/tests/NATS.Client.Core.Tests/ProtocolTest.cs
+++ b/tests/NATS.Client.Core.Tests/ProtocolTest.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.Core.Tests;
@@ -16,6 +17,7 @@ public class ProtocolTest
         var logger = new InMemoryTestLoggerFactory(LogLevel.Error);
         var opts = new NatsOpts { Url = server.Url, LoggerFactory = logger };
         var nats = new NatsConnection(opts);
+        await nats.ConnectRetryAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
 

--- a/tests/NATS.Client.Core.Tests/SubscriptionTest.cs
+++ b/tests/NATS.Client.Core.Tests/SubscriptionTest.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.Core.Tests;
@@ -35,6 +36,7 @@ public class SubscriptionTest
         // SharedInbox so the connection doesn't open an inbox subscription at connect,
         // which would make the SUB frame count below never settle at 1.
         var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", SubscriptionCleanUpInterval = TimeSpan.FromSeconds(1), RequestReplyMode = NatsRequestReplyMode.SharedInbox });
+        await nats.ConnectRetryAsync();
 
         async Task Isolator()
         {
@@ -75,6 +77,7 @@ public class SubscriptionTest
         // SharedInbox so the connection doesn't open an inbox subscription at connect,
         // which would make the SUB frame count below never settle at 1.
         var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", SubscriptionCleanUpInterval = TimeSpan.MaxValue, RequestReplyMode = NatsRequestReplyMode.SharedInbox });
+        await nats.ConnectRetryAsync();
 
         async Task Isolator()
         {
@@ -108,6 +111,7 @@ public class SubscriptionTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var subject = nats.NewInbox();
 
         await using var sub1 = await nats.SubscribeCoreAsync<int>(subject, opts: new NatsSubOpts { MaxMsgs = 1 });
@@ -147,6 +151,7 @@ public class SubscriptionTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         const string subject = "foo1";
         const int maxMsgs = 99;
         var opts = new NatsSubOpts { MaxMsgs = maxMsgs };
@@ -177,6 +182,7 @@ public class SubscriptionTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         const string subject = "foo2";
         var opts = new NatsSubOpts { Timeout = TimeSpan.FromSeconds(1) };
@@ -200,6 +206,7 @@ public class SubscriptionTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         const string subject = "foo3";
         var opts = new NatsSubOpts { IdleTimeout = TimeSpan.FromSeconds(3) };
 
@@ -231,6 +238,7 @@ public class SubscriptionTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         const string subject = "foo-max";
         var opts = new NatsSubOpts
@@ -266,6 +274,7 @@ public class SubscriptionTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         const string subject = "foo4";
         await using var sub = await nats.SubscribeCoreAsync<int>(subject);
 
@@ -352,6 +361,7 @@ public class SubscriptionTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 

--- a/tests/NATS.Client.Core2.Tests/ErrorHandlerTest.cs
+++ b/tests/NATS.Client.Core2.Tests/ErrorHandlerTest.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core.Tests;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.Core2.Tests;
 
@@ -29,6 +30,7 @@ public class ErrorHandlerTest
             LoggerFactory = logger,
             AuthOpts = new NatsAuthOpts { Username = "u" },
         });
+        await nats.ConnectRetryAsync();
 
         var errors = new List<NatsServerErrorEventArgs>();
 

--- a/tests/NATS.Client.Core2.Tests/JsonSerializerTests.cs
+++ b/tests/NATS.Client.Core2.Tests/JsonSerializerTests.cs
@@ -1,5 +1,6 @@
 using NATS.Client.Core2.Tests;
 using NATS.Client.Serializers.Json;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.Core.Tests;
 
@@ -24,6 +25,7 @@ public class JsonSerializerTests
             SerializerRegistry = NatsJsonSerializerRegistry.Default,
         };
         await using var nats = new NatsConnection(natsOpts);
+        await nats.ConnectRetryAsync();
 
         // in local runs server start is taking too long when running
         // the whole suite.
@@ -39,6 +41,7 @@ public class JsonSerializerTests
 
         // Default serializer won't work with random types
         await using var nats1 = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats1.ConnectRetryAsync();
 
         var exception = await Assert.ThrowsAsync<NatsException>(() => nats1.PublishAsync(
             subject: "would.not.work",

--- a/tests/NATS.Client.Core2.Tests/MessageInterfaceTest.cs
+++ b/tests/NATS.Client.Core2.Tests/MessageInterfaceTest.cs
@@ -1,4 +1,5 @@
 using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.Core.Tests;
@@ -17,6 +18,7 @@ public class MessageInterfaceTest
     public async Task Sub_custom_builder_test()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var sync = 0;
         var sub = Task.Run(async () =>

--- a/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
+++ b/tests/NATS.Client.Core2.Tests/ProtocolParserSizeCheckTest.cs
@@ -25,7 +25,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
 
         await server.Ready;
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory, ConnectTimeout = TimeSpan.FromSeconds(30) });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
@@ -53,7 +53,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
 
         await server.Ready;
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory, ConnectTimeout = TimeSpan.FromSeconds(10) });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
@@ -81,7 +81,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
 
         await server.Ready;
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory, ConnectTimeout = TimeSpan.FromSeconds(10) });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
@@ -109,7 +109,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
 
         await server.Ready;
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory, ConnectTimeout = TimeSpan.FromSeconds(10) });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
@@ -138,7 +138,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
 
         // MaxReconnectRetry=0 because FakeServer only accepts one connection
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, LoggerFactory = logFactory, MaxReconnectRetry = 0 });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await nats.SubscribeCoreAsync<int>("foo", cancellationToken: cts.Token);
@@ -208,7 +208,7 @@ public class ProtocolParserSizeCheckTest(ITestOutputHelper output)
         // SharedInbox so the connection doesn't open an inbox subscription at connect;
         // the test injects an HMSG with sid 1, which must map to the "foo" subscription.
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, ConnectTimeout = TimeSpan.FromSeconds(10), RequestReplyMode = NatsRequestReplyMode.SharedInbox });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var sub = await nats.SubscribeCoreAsync<byte[]>("foo", cancellationToken: cts.Token);

--- a/tests/NATS.Client.Core2.Tests/ProtocolTest.cs
+++ b/tests/NATS.Client.Core2.Tests/ProtocolTest.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Text;
 using NATS.Client.Core2.Tests;
 using NATS.Client.Core2.Tests.ExtraUtils.FrameworkPolyfillExtensions;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.Core.Tests;
 
@@ -21,11 +22,13 @@ public class ProtocolTest
     public async Task Subscription_with_same_subject()
     {
         var nats1 = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats1.ConnectRetryAsync();
         var proxy = new NatsProxy(_server.Port);
 
         // SharedInbox so the connection doesn't open an inbox subscription at connect,
         // which would add an extra SUB frame to the proxy capture asserted below.
         var nats2 = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10), RequestReplyMode = NatsRequestReplyMode.SharedInbox });
+        await nats2.ConnectRetryAsync();
 
         var sub1 = await nats2.SubscribeCoreAsync<int>("foo.bar");
         var sub2 = await nats2.SubscribeCoreAsync<int>("foo.bar");
@@ -119,6 +122,7 @@ public class ProtocolTest
         // SharedInbox so the connection doesn't open an inbox subscription at connect,
         // which would shift the SUB frames asserted by index below.
         var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10), RequestReplyMode = NatsRequestReplyMode.SharedInbox });
+        await nats.ConnectRetryAsync();
         var subject = $"{_server.GetNextId()}.foo";
 
         await using var sub1 = await nats.SubscribeCoreAsync<int>(subject, queueGroup: "group1");
@@ -151,6 +155,7 @@ public class ProtocolTest
 
         var proxy = new NatsProxy(_server.Port);
         var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
 
         var prefix = $"{_server.GetNextId()}.foo";
 
@@ -223,6 +228,7 @@ public class ProtocolTest
         // SharedInbox so the connection doesn't open an inbox subscription at connect,
         // which would consume sid 1 and break the sid sequence asserted below.
         var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10), RequestReplyMode = NatsRequestReplyMode.SharedInbox });
+        await nats.ConnectRetryAsync();
         var sid = 0;
 
         Log("### Auto-unsubscribe after consuming max-msgs");
@@ -350,6 +356,7 @@ public class ProtocolTest
         // SharedInbox so the connection doesn't open an inbox subscription at connect,
         // which would add an extra SUB frame to the proxy capture asserted below.
         var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10), RequestReplyMode = NatsRequestReplyMode.SharedInbox });
+        await nats.ConnectRetryAsync();
 
         var subject = $"{_server.GetNextId()}.foo";
         var cmdSubject = $"{_server.GetNextId()}.bar";
@@ -406,6 +413,7 @@ public class ProtocolTest
     public async Task Proactively_reject_payloads_over_the_threshold_set_by_server()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 

--- a/tests/NATS.Client.Core2.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core2.Tests/RequestReplyTest.cs
@@ -24,6 +24,7 @@ public class RequestReplyTest
     public async Task Simple_request_reply_test()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         const string subject = "foo";
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -58,6 +59,7 @@ public class RequestReplyTest
                 Url = _server.Url,
                 RequestTimeout = TimeSpan.FromSeconds(1),
             });
+            await nats.ConnectRetryAsync();
 
             var sub = await nats.SubscribeCoreAsync<int>("foo");
             var reg = sub.Register(async msg =>
@@ -76,6 +78,7 @@ public class RequestReplyTest
         // Cancellation token usage
         {
             await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+            await nats.ConnectRetryAsync();
 
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
             var sub = await nats.SubscribeCoreAsync<int>("foo");
@@ -103,6 +106,7 @@ public class RequestReplyTest
         // Default mode (Direct transport, not set explicitly) throws on no-responders,
         // preserving the pre-3.x default behavior.
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         await Assert.ThrowsAsync<NatsNoRespondersException>(async () => await nats.RequestAsync<int, int>(Guid.NewGuid().ToString(), 0));
     }
 
@@ -110,6 +114,7 @@ public class RequestReplyTest
     public async Task Request_reply_no_responders_shared_inbox_throws_test()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = NatsRequestReplyMode.SharedInbox });
+        await nats.ConnectRetryAsync();
         await Assert.ThrowsAsync<NatsNoRespondersException>(async () => await nats.RequestAsync<int, int>(Guid.NewGuid().ToString(), 0));
     }
 
@@ -119,6 +124,7 @@ public class RequestReplyTest
         // Explicitly selecting Direct preserves the pre-3.x Direct behavior: the 503 sentinel
         // comes back as a message with HasNoResponders set instead of throwing.
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = NatsRequestReplyMode.Direct });
+        await nats.ConnectRetryAsync();
         var reply = await nats.RequestAsync<int, int>(Guid.NewGuid().ToString(), 0);
         Assert.True(reply.HasNoResponders);
     }
@@ -130,6 +136,7 @@ public class RequestReplyTest
     {
         // Per-call ThrowIfNoResponders=false returns the sentinel as a message in either mode.
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var reply = await nats.RequestAsync<int, int>(Guid.NewGuid().ToString(), 0, replyOpts: new NatsSubOpts { ThrowIfNoResponders = false });
         Assert.True(reply.HasNoResponders);
     }
@@ -139,6 +146,7 @@ public class RequestReplyTest
     {
         // Per-call ThrowIfNoResponders=true forces a throw even when Direct was selected explicitly.
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = NatsRequestReplyMode.Direct });
+        await nats.ConnectRetryAsync();
         await Assert.ThrowsAsync<NatsNoRespondersException>(async () =>
             await nats.RequestAsync<int, int>(Guid.NewGuid().ToString(), 0, replyOpts: new NatsSubOpts { ThrowIfNoResponders = true }));
     }
@@ -149,6 +157,7 @@ public class RequestReplyTest
         const int msgs = 10;
 
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var sub = await nats.SubscribeCoreAsync<int>("foo");
         var reg = sub.Register(async msg =>
@@ -180,6 +189,7 @@ public class RequestReplyTest
     public async Task Request_reply_many_test_overall_timeout()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var sub = await nats.SubscribeCoreAsync<int>("foo");
         var reg = sub.Register(async msg =>
@@ -210,6 +220,7 @@ public class RequestReplyTest
     public async Task Request_reply_many_test_idle_timeout()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var sub = await nats.SubscribeCoreAsync<int>("foo");
         var reg = sub.Register(async msg =>
@@ -243,6 +254,7 @@ public class RequestReplyTest
     public async Task Request_reply_many_test_start_up_timeout()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var sub = await nats.SubscribeCoreAsync<int>("foo");
         var reg = sub.Register(async msg =>
@@ -305,6 +317,7 @@ public class RequestReplyTest
     public async Task Request_reply_many_test_sentinel()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var sub = await nats.SubscribeCoreAsync<int>("foo");
         var reg = sub.Register(async msg =>
@@ -338,6 +351,7 @@ public class RequestReplyTest
         }
 
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
@@ -372,7 +386,7 @@ public class RequestReplyTest
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
 
         // connect to avoid race to subscribe and publish
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         const string subject = "foo";
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -436,6 +450,7 @@ public class RequestReplyTest
     public async Task Simple_empty_request_reply_test()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         const string subject = "foo";
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
@@ -461,6 +476,7 @@ public class RequestReplyTest
     public async Task Direct_request_reply_test()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = NatsRequestReplyMode.Direct });
+        await nats.ConnectRetryAsync();
         var reply = await nats.RequestAsync<string>("$JS.API.INFO", cancellationToken: default);
 
         // reply-to should be inbox with id
@@ -481,6 +497,7 @@ public class RequestReplyTest
         // Default RequestReplyMode is Direct, so the reply-to inbox carries a numeric id
         // e.g. _INBOX.Hu5HPpWesrJhvQq2NG3YJ6.1
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         Assert.Equal(NatsRequestReplyMode.Direct, nats.Opts.RequestReplyMode);
 
         var reply = await nats.RequestAsync<string>("$JS.API.INFO", cancellationToken: default);
@@ -499,6 +516,7 @@ public class RequestReplyTest
     public async Task SharedInbox_request_reply_test()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = NatsRequestReplyMode.SharedInbox });
+        await nats.ConnectRetryAsync();
         var reply = await nats.RequestAsync<string>("$JS.API.INFO", cancellationToken: default);
 
         // reply-to should be inbox
@@ -517,6 +535,7 @@ public class RequestReplyTest
     public async Task Request_reply_no_timeout_sentinels_do_not_throw(NatsRequestReplyMode mode)
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var subject = $"foo.{Guid.NewGuid():N}";
         await using var sub = await nats.SubscribeCoreAsync<int>(subject);
@@ -546,6 +565,7 @@ public class RequestReplyTest
     public async Task Request_reply_out_of_range_timeout_throws(NatsRequestReplyMode mode)
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var replyOpts = new NatsSubOpts { Timeout = TimeSpan.FromDays(50) };
 

--- a/tests/NATS.Client.Core2.Tests/RequestReplyTest.cs
+++ b/tests/NATS.Client.Core2.Tests/RequestReplyTest.cs
@@ -169,6 +169,7 @@ public class RequestReplyTest
 
             await msg.ReplyAsync<int?>(null); // stop iteration with a sentinel
         });
+        await nats.PingAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         const int data = 2;
@@ -197,6 +198,7 @@ public class RequestReplyTest
             await msg.ReplyAsync(msg.Data * 2);
             await msg.ReplyAsync(msg.Data * 3);
         });
+        await nats.PingAsync();
 
         var results = new[] { 8, 12 };
         var count = 0;
@@ -231,6 +233,7 @@ public class RequestReplyTest
             await Task.Delay(5_000);
             await msg.ReplyAsync(msg.Data * 4);
         });
+        await nats.PingAsync();
 
         var results = new[] { 6, 9 };
         var count = 0;
@@ -262,6 +265,7 @@ public class RequestReplyTest
             await Task.Delay(2_000);
             await msg.ReplyAsync(msg.Data * 2);
         });
+        await nats.PingAsync();
 
         var count = 0;
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -294,6 +298,7 @@ public class RequestReplyTest
             await msg.ReplyAsync(msg.Data * 4);
             await msg.ReplyAsync<int?>(null); // sentinel
         });
+        await nats.PingAsync();
 
         var results = new[] { 2, 3, 4 };
         var count = 0;
@@ -327,6 +332,7 @@ public class RequestReplyTest
             await msg.ReplyAsync(msg.Data * 4);
             await msg.ReplyAsync<int?>(null); // sentinel
         });
+        await nats.PingAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var results = new[] { 2, 3, 4 };

--- a/tests/NATS.Client.Core2.Tests/SerializerTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SerializerTest.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using NATS.Client.Core2.Tests;
 using NATS.Client.Serializers.Json;
+using NATS.Client.TestUtilities2;
 
 // ReSharper disable RedundantTypeArgumentsOfMethod
 // ReSharper disable ReturnTypeCanBeNotNullable
@@ -25,7 +26,7 @@ public class SerializerTest
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
 
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         await Assert.ThrowsAsync<TestSerializerException>(() =>
             nats.PublishAsync(
@@ -51,7 +52,7 @@ public class SerializerTest
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var cancellationToken = cts.Token;
 
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var sub = await nats.SubscribeCoreAsync<NatsMemoryOwner<byte>>("foo", cancellationToken: cancellationToken);
         await nats.PingAsync(cancellationToken);
@@ -242,7 +243,7 @@ public class SerializerTest
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var cancellationToken = cts.Token;
 
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var serializer = new TestSerializerWithEmpty<TestData>();
         var sub = await nats.SubscribeCoreAsync("foo", serializer: serializer, cancellationToken: cancellationToken);
@@ -271,7 +272,7 @@ public class SerializerTest
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var cancellationToken = cts.Token;
 
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var sub = await nats.SubscribeCoreAsync<TestData>("foo", cancellationToken: cancellationToken);
 
@@ -307,7 +308,7 @@ public class SerializerTest
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var cancellationToken = cts.Token;
 
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var sub1 = await nats.SubscribeCoreAsync<TestMessage1>($"{prefix}.1", cancellationToken: cancellationToken);
         var sub2 = await nats.SubscribeCoreAsync<TestMessage2>($"{prefix}.2", cancellationToken: cancellationToken);
@@ -336,7 +337,7 @@ public class SerializerTest
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var cancellationToken = cts.Token;
 
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var subject = _server.GetNextId();
         var sub = await nats.SubscribeCoreAsync<string>(subject, cancellationToken: cancellationToken);

--- a/tests/NATS.Client.Core2.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SlowConsumerTest.cs
@@ -1,4 +1,5 @@
 using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.Core.Tests;
 
@@ -22,6 +23,7 @@ public class SlowConsumerTest
             Url = _server.Url,
             SubPendingChannelCapacity = 3,
         });
+        await nats.ConnectRetryAsync();
 
         var lost = 0;
         nats.MessageDropped += (_, e) =>
@@ -108,6 +110,7 @@ public class SlowConsumerTest
             Url = _server.Url,
             SubPendingChannelCapacity = 3,
         });
+        await nats.ConnectRetryAsync();
 
         var droppedCount = 0;
         var slowConsumerCount = 0;
@@ -206,6 +209,7 @@ public class SlowConsumerTest
             Url = _server.Url,
             SubPendingChannelCapacity = 3,
         });
+        await nats.ConnectRetryAsync();
 
         var droppedCount = 0;
         var slowConsumerCount = 0;

--- a/tests/NATS.Client.Core2.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SlowConsumerTest.cs
@@ -321,7 +321,7 @@ public class SlowConsumerTest
         // Wait for more drops and the second slow consumer event
         await Retry.Until(
             "episode 2 drops",
-            () => Volatile.Read(ref droppedCount) > droppedAfterEpisode1 && Volatile.Read(ref slowConsumerCount) >= 2);
+            () => Volatile.Read(ref droppedCount) > droppedAfterEpisode1 && Volatile.Read(ref slowConsumerCount) > slowConsumerAfterEpisode1);
 
         var droppedAfterEpisode2 = Volatile.Read(ref droppedCount);
         var slowConsumerAfterEpisode2 = Volatile.Read(ref slowConsumerCount);

--- a/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SubscriptionDrainTest.cs
@@ -1,4 +1,5 @@
 using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.Core.Tests;
 
@@ -16,6 +17,7 @@ public class SubscriptionDrainTest
     public async Task Drain_preserves_buffered_messages_and_completes_channel()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var cancellationToken = cts.Token;
 
@@ -44,6 +46,7 @@ public class SubscriptionDrainTest
     public async Task Drain_delivers_messages_still_in_flight_after_unsub()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var cancellationToken = cts.Token;
 
@@ -76,6 +79,7 @@ public class SubscriptionDrainTest
     public async Task Drain_stops_new_messages_but_connection_stays_usable()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var cancellationToken = cts.Token;
 
@@ -109,6 +113,7 @@ public class SubscriptionDrainTest
     public async Task Drain_is_idempotent_and_dispose_after_drain_is_safe()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var cancellationToken = cts.Token;
 

--- a/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
+++ b/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Text;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.GoHarness;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
@@ -86,7 +87,7 @@ public class TlsPreferTest(ITestOutputHelper output)
             ConnectTimeout = TimeSpan.FromSeconds(10),
         });
 
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
         await serverTask;
         listener.Stop();
 
@@ -371,7 +372,7 @@ public class TlsPreferTest(ITestOutputHelper output)
             ConnectTimeout = TimeSpan.FromSeconds(10),
         });
 
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
         await serverTask;
         listener.Stop();
 
@@ -419,7 +420,7 @@ public class TlsPreferTest(ITestOutputHelper output)
             TlsOpts = new NatsTlsOpts { Mode = TlsMode.Disable },
         });
 
-        await natsDisable.ConnectAsync();
+        await natsDisable.ConnectRetryAsync();
         await natsDisable.PingAsync(cts.Token);
         output.WriteLine("Disable mode: connected in plaintext");
     }

--- a/tests/NATS.Client.Core2.Tests/Utf8SubjectTest.cs
+++ b/tests/NATS.Client.Core2.Tests/Utf8SubjectTest.cs
@@ -151,6 +151,7 @@ public class Utf8SubjectServerTest
     public async Task Utf8_subject_pub_sub_with_real_server()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var subject = "test.café.🔥";
         var sync = 0;
@@ -188,6 +189,7 @@ public class Utf8SubjectServerTest
     public async Task Utf8_subject_request_reply_with_real_server()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
 
         var subject = "svc.ñoño.日本語";
         var sync = 0;

--- a/tests/NATS.Client.JetStream.Tests/CancellationTokenTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/CancellationTokenTests.cs
@@ -12,6 +12,7 @@ public class CancellationTokenTests(NatsServerFixture server)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = server.GetNextId();
         var js = new NatsJSContext(nats);
         await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
@@ -43,6 +44,7 @@ public class CancellationTokenTests(NatsServerFixture server)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = server.GetNextId();
         var js = new NatsJSContext(nats);
         await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
@@ -74,6 +76,7 @@ public class CancellationTokenTests(NatsServerFixture server)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, ConnectTimeout = TimeSpan.FromSeconds(30) });
+        await nats.ConnectRetryAsync();
         var prefix = server.GetNextId();
         var js = new NatsJSContext(nats);
         await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);
@@ -100,6 +103,7 @@ public class CancellationTokenTests(NatsServerFixture server)
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = server.GetNextId();
         var js = new NatsJSContext(nats);
         await js.CreateStreamAsync($"{prefix}s1", [$"{prefix}s1.*"], cts.Token);

--- a/tests/NATS.Client.JetStream.Tests/ConsumeResponseTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumeResponseTest.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 using NATS.Net;
 
 namespace NATS.Client.JetStream.Tests;
@@ -38,6 +39,7 @@ public class ConsumeResponseTest
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = ms.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var js = nats.CreateJetStreamContext();
         var consumer = await js.GetConsumerAsync("x", "x", cts.Token);
 

--- a/tests/NATS.Client.JetStream.Tests/ConsumerConsumeTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerConsumeTest.cs
@@ -282,6 +282,7 @@ public class ConsumerConsumeTest
             Url = _server.Url,
             DrainSubscriptionsOnDispose = true,
         });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -380,6 +381,7 @@ public class ConsumerConsumeTest
 
         await using (var setup = new NatsConnection(new NatsOpts { Url = _server.Url }))
         {
+            await setup.ConnectRetryAsync();
             var setupJs = new NatsJSContext(setup);
             var stream = await setupJs.CreateStreamAsync(new StreamConfig(streamName, [subject]), cts.Token);
 
@@ -395,6 +397,7 @@ public class ConsumerConsumeTest
             DrainSubscriptionsOnDispose = true,
             ConsumerDrainOnDisposeTimeout = TimeSpan.FromSeconds(30),
         });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var consumer = await js.GetConsumerAsync(streamName, consumerName, cts.Token);
 
@@ -423,6 +426,7 @@ public class ConsumerConsumeTest
         var consumed = await consumeTask;
 
         await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await check.ConnectRetryAsync();
         var checkJs = new NatsJSContext(check);
         var info = (await checkJs.GetConsumerAsync(streamName, consumerName, cts.Token)).Info;
 
@@ -834,7 +838,7 @@ public class ConsumerConsumeTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
@@ -878,7 +882,7 @@ public class ConsumerConsumeTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
@@ -986,7 +990,7 @@ public class ConsumerConsumeTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 

--- a/tests/NATS.Client.JetStream.Tests/ConsumerFetchTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerFetchTest.cs
@@ -1,6 +1,7 @@
 using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
 
@@ -23,6 +24,7 @@ public class ConsumerFetchTest
     {
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
         await js.CreateStreamAsync($"{prefix}s1", new[] { $"{prefix}s1.*" }, cts.Token);
@@ -55,6 +57,7 @@ public class ConsumerFetchTest
     {
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
         await js.CreateStreamAsync($"{prefix}s1", new[] { $"{prefix}s1.*" }, cts.Token);
@@ -93,6 +96,7 @@ public class ConsumerFetchTest
             RequestReplyMode = mode,
             DrainSubscriptionsOnDispose = true,
         });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -190,6 +194,7 @@ public class ConsumerFetchTest
 
         await using (var setup = new NatsConnection(new NatsOpts { Url = _server.Url }))
         {
+            await setup.ConnectRetryAsync();
             var setupJs = new NatsJSContext(setup);
             var stream = await setupJs.CreateStreamAsync(new StreamConfig(streamName, [subject]), cts.Token);
 
@@ -205,6 +210,7 @@ public class ConsumerFetchTest
             DrainSubscriptionsOnDispose = true,
             ConsumerDrainOnDisposeTimeout = TimeSpan.FromSeconds(30),
         });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var consumer = await js.GetConsumerAsync(streamName, consumerName, cts.Token);
 
@@ -234,6 +240,7 @@ public class ConsumerFetchTest
         var consumed = await fetchTask;
 
         await using var check = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await check.ConnectRetryAsync();
         var checkJs = new NatsJSContext(check);
         var info = (await checkJs.GetConsumerAsync(streamName, consumerName, cts.Token)).Info;
 

--- a/tests/NATS.Client.JetStream.Tests/ConsumerNotificationTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerNotificationTest.cs
@@ -3,6 +3,7 @@ using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.JetStream.Tests;
@@ -24,6 +25,7 @@ public class ConsumerNotificationTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -97,6 +99,7 @@ public class ConsumerNotificationTest
     public async Task Exceeded_max_errors()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
 

--- a/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ConsumerSetupTest.cs
@@ -3,6 +3,7 @@ using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.JetStream.Tests;
@@ -25,6 +26,7 @@ public class ConsumerSetupTest
     public async Task Create_push_consumer(NatsRequestReplyMode mode)
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
 
@@ -57,6 +59,7 @@ public class ConsumerSetupTest
     public async Task Create_paused_consumer()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContextFactory().CreateContext(nats);
 
@@ -90,6 +93,7 @@ public class ConsumerSetupTest
     public async Task Consumer_config(NatsRequestReplyMode mode)
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContextFactory().CreateContext(nats);
 

--- a/tests/NATS.Client.JetStream.Tests/CounterTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/CounterTest.cs
@@ -1,6 +1,7 @@
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
 
@@ -20,6 +21,7 @@ public class CounterTest
     public async Task Counter_functionality_test()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
 
@@ -94,6 +96,7 @@ public class CounterTest
     public async Task Counter_without_AllowMsgCounter_should_return_error()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
 

--- a/tests/NATS.Client.JetStream.Tests/DirectGetTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/DirectGetTest.cs
@@ -1,6 +1,7 @@
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
 
@@ -22,6 +23,7 @@ public class DirectGetTest
         // https://github.com/nats-io/nats-server/commit/ce309b79d99552996e18dce47dc04bdc730c0d84
         // When we fail to deliver a message through a service import respond with no responders.
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
 
@@ -42,6 +44,7 @@ public class DirectGetTest
     public async Task Direct_get_returns_no_reply()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
 

--- a/tests/NATS.Client.JetStream.Tests/DoubleAckTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/DoubleAckTest.cs
@@ -1,4 +1,5 @@
 using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.JetStream.Tests;
@@ -20,6 +21,7 @@ public class DoubleAckTest
     {
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);

--- a/tests/NATS.Client.JetStream.Tests/ErrorHandlerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ErrorHandlerTest.cs
@@ -24,6 +24,7 @@ public class ErrorHandlerTest
     {
         var proxy = new NatsProxy(_server.Port);
         await using var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -97,6 +98,7 @@ public class ErrorHandlerTest
     {
         var proxy = new NatsProxy(_server.Port);
         await using var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -187,6 +189,7 @@ public class ErrorHandlerTest
     {
         var proxy = new NatsProxy(_server.Port);
         await using var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -357,6 +360,7 @@ public class ErrorHandlerTest
     {
         var proxy = new NatsProxy(_server.Port);
         await using var nats = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}", ConnectTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);

--- a/tests/NATS.Client.JetStream.Tests/JetStreamApiSerializerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/JetStreamApiSerializerTest.cs
@@ -4,6 +4,7 @@ using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Internal;
 using NATS.Client.JetStream.Models;
+using NATS.Client.TestUtilities2;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace NATS.Client.JetStream.Tests;
@@ -24,6 +25,7 @@ public class JetStreamApiSerializerTest
     public async Task Should_respect_buffers_lifecycle()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
         var apiSubject = $"{prefix}.js.fake.api";

--- a/tests/NATS.Client.JetStream.Tests/ListTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/ListTests.cs
@@ -1,6 +1,7 @@
 using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.JetStream.Tests;
@@ -21,6 +22,7 @@ public class ListTests
     public async Task List_streams()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(5) });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId() + "-";
         _output.WriteLine($"prefix: {prefix}");
 
@@ -95,6 +97,7 @@ public class ListTests
     public async Task List_consumers()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(5) });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId() + "-";
         _output.WriteLine($"prefix: {prefix}");
         var js = new NatsJSContext(nats);

--- a/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/NatsJsContextFactoryTest.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Channels;
 using NATS.Client.Core.Tests;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.JetStream.Tests;
@@ -18,6 +19,7 @@ public class NatsJSContextFactoryTest
         // Arrange
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
         var factory = new NatsJSContextFactory();
 
         // Act
@@ -33,6 +35,7 @@ public class NatsJSContextFactoryTest
         // Arrange
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
         var factory = new NatsJSContextFactory();
         var opts = new NatsJSOpts(nats.Opts);
 

--- a/tests/NATS.Client.JetStream.Tests/OrderedConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/OrderedConsumerTest.cs
@@ -510,6 +510,7 @@ public class OrderedConsumerTest
 
         await using (var setup = new NatsConnection(new NatsOpts { Url = _server.Url }))
         {
+            await setup.ConnectRetryAsync();
             var setupJs = new NatsJSContext(setup);
             await setupJs.CreateStreamAsync(new StreamConfig(streamName, [subject]), cts.Token);
 
@@ -523,6 +524,7 @@ public class OrderedConsumerTest
             DrainSubscriptionsOnDispose = true,
             ConsumerDrainOnDisposeTimeout = TimeSpan.FromSeconds(30),
         });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var stream = await js.GetStreamAsync(streamName, cancellationToken: cts.Token);
         var consumer = await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);

--- a/tests/NATS.Client.JetStream.Tests/PinnedClientTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PinnedClientTest.cs
@@ -27,6 +27,7 @@ public class PinnedClientTest
     public async Task Pinned_client_basic_flow_with_consume()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -95,6 +96,7 @@ public class PinnedClientTest
     public async Task Unpin_allows_other_consumer_to_receive()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -257,6 +259,7 @@ public class PinnedClientTest
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = ms.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var js = nats.CreateJetStreamContext();
         var consumer = (NatsJSConsumer)await js.GetConsumerAsync("x", "x", cts.Token);
 
@@ -376,6 +379,7 @@ public class PinnedClientTest
     public async Task Invalid_priority_group_returns_error()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -410,6 +414,7 @@ public class PinnedClientTest
     public async Task Context_unpin_consumer_async()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -474,6 +479,7 @@ public class PinnedClientTest
     public async Task Consumer_info_shows_priority_groups_state()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -538,6 +544,7 @@ public class PinnedClientMockServerTest
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = ms.Url, ConnectTimeout = TimeSpan.FromSeconds(30) });
+        await nats.ConnectRetryAsync();
         var js = nats.CreateJetStreamContext();
         var consumer = (NatsJSConsumer)await js.GetConsumerAsync("x", "x", cts.Token);
         var headers = new NatsHeaders
@@ -578,6 +585,7 @@ public class PinnedClientMockServerTest
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         await using var nats = new NatsConnection(new NatsOpts { Url = ms.Url });
+        await nats.ConnectRetryAsync();
         var js = nats.CreateJetStreamContext();
         var consumer = (NatsJSConsumer)await js.GetConsumerAsync("x", "x", cts.Token);
 

--- a/tests/NATS.Client.JetStream.Tests/PriorityGroupTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PriorityGroupTest.cs
@@ -2,6 +2,7 @@ using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
 
@@ -21,6 +22,7 @@ public class PriorityGroupTest
     public async Task Next_from_overflow_group()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -64,6 +66,7 @@ public class PriorityGroupTest
     public async Task Fetch_from_overflow_group()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -110,6 +113,7 @@ public class PriorityGroupTest
     public async Task Consume_from_overflow_group()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -156,6 +160,7 @@ public class PriorityGroupTest
     public async Task Fetch_from_prioritized_group_with_priority()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 
@@ -218,6 +223,7 @@ public class PriorityGroupTest
     public async Task Consumer_with_prioritized_policy_validation()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var prefix = _server.GetNextId();
 

--- a/tests/NATS.Client.JetStream.Tests/PublishConcurrentTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/PublishConcurrentTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.JetStream.Tests;
@@ -21,6 +22,7 @@ public class PublishConcurrentTests
     public async Task Publish_concurrently()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
 

--- a/tests/NATS.Client.JetStream.Tests/PublishRetryTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PublishRetryTest.cs
@@ -24,6 +24,7 @@ public class PublishRetryTest
     {
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         // Without telemetry

--- a/tests/NATS.Client.JetStream.Tests/PublishTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/PublishTest.cs
@@ -343,6 +343,7 @@ public class PublishTest
             LoggerFactory = logger,
             RequestReplyMode = mode,
         });
+        await nats.ConnectRetryAsync();
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var js = new NatsJSContext(nats);
@@ -379,6 +380,7 @@ public class PublishTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var js = nats.CreateJetStreamContext();
         var result = await js.TryPublishAsync("foo", 1);
         Assert.IsType<NatsJSPublishNoResponseException>(result.Error);

--- a/tests/NATS.Client.JetStream.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/SlowConsumerTest.cs
@@ -1,6 +1,7 @@
 using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
 using NATS.Client.JetStream.Models;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.JetStream.Tests;
 
@@ -28,7 +29,7 @@ public class SlowConsumerTest
             Url = _server.Url,
             SubPendingChannelCapacity = 10, // Small capacity to trigger drops quickly
         });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);
@@ -208,7 +209,7 @@ public class SlowConsumerTest
             Url = _server.Url,
             SubPendingChannelCapacity = 10,
         });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);

--- a/tests/NATS.Client.JetStream.Tests/StreamDomainAdjustmentTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/StreamDomainAdjustmentTest.cs
@@ -38,6 +38,7 @@ public class StreamDomainAdjustmentTest(NatsServerFixture server)
         });
 
         await using var nats = new NatsConnection(new NatsOpts { Url = ms.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
 
         // Configure a stream with Source that has Domain set

--- a/tests/NATS.Client.KeyValueStore.Tests/GetKeysTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/GetKeysTest.cs
@@ -1,5 +1,6 @@
 using NATS.Client.Core.Tests;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.KeyValueStore.Tests;
@@ -17,6 +18,7 @@ public class GetKeysTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats1 = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats1.ConnectRetryAsync();
         var js1 = new NatsJSContext(nats1);
         var kv1 = new NatsKVContext(js1);
         var store1 = await kv1.CreateStoreAsync(config, cancellationToken: cancellationToken);
@@ -59,6 +61,7 @@ public class GetKeysTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats1 = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats1.ConnectRetryAsync();
         var js1 = new NatsJSContext(nats1);
         var kv1 = new NatsKVContext(js1);
         var store1 = await kv1.CreateStoreAsync(config, cancellationToken: cancellationToken);
@@ -94,6 +97,7 @@ public class GetKeysTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats1 = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats1.ConnectRetryAsync();
         var js1 = new NatsJSContext(nats1);
         var kv1 = new NatsKVContext(js1);
         var store1 = await kv1.CreateStoreAsync(config, cancellationToken: cancellationToken);

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueContextTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueContextTest.cs
@@ -1,4 +1,5 @@
 using NATS.Client.Core.Tests;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.KeyValueStore.Tests;
@@ -14,6 +15,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -33,6 +35,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -58,6 +61,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -81,6 +85,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -106,6 +111,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -125,6 +131,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -148,6 +155,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -170,6 +178,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -199,6 +208,7 @@ public class KeyValueContextTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);

--- a/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/KeyValueStoreTest.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using NATS.Client.Core.Tests;
 using NATS.Client.JetStream.Models;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.KeyValueStore.Tests;
@@ -19,6 +20,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -40,6 +42,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -83,6 +86,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -122,6 +126,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -182,6 +187,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -310,6 +316,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -394,6 +401,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -434,6 +442,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -486,6 +495,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -505,6 +515,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -567,6 +578,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -586,6 +598,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -602,6 +615,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -656,6 +670,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -703,6 +718,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -749,6 +765,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -787,6 +804,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -818,6 +836,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -883,6 +902,7 @@ public class KeyValueStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
 
@@ -916,6 +936,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -965,6 +986,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -1001,6 +1023,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);
@@ -1028,6 +1051,7 @@ public class KeyValueStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestReplyMode = mode });
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var kv = new NatsKVContext(js);

--- a/tests/NATS.Client.KeyValueStore.Tests/NatsKVContextFactoryTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/NatsKVContextFactoryTest.cs
@@ -1,5 +1,6 @@
 using NATS.Client.Core.Tests;
 using NATS.Client.JetStream.Models;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.KeyValueStore.Tests;
@@ -16,6 +17,7 @@ public class NatsKVContextFactoryTest
         // Arrange
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, RequestTimeout = TimeSpan.FromSeconds(10) });
+        await nats.ConnectRetryAsync();
         var jsFactory = new NatsJSContextFactory();
         var jsContext = jsFactory.CreateContext(nats);
         var factory = new NatsKVContextFactory();

--- a/tests/NATS.Client.KeyValueStore.Tests/NatsKVWatcherTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/NatsKVWatcherTest.cs
@@ -40,6 +40,7 @@ public class NatsKVWatcherTest
 
         var proxy = new NatsProxy(_server.Port);
         await using var nats2 = new NatsConnection(new NatsOpts { Url = $"nats://127.0.0.1:{proxy.Port}" });
+        await nats2.ConnectRetryAsync();
         await nats1.ConnectRetryAsync();
         var js2 = new NatsJSContext(nats2);
         var kv2 = new NatsKVContext(js2);
@@ -118,6 +119,7 @@ public class NatsKVWatcherTest
         var cancellationToken = cts.Token;
 
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -162,6 +164,7 @@ public class NatsKVWatcherTest
         var cancellationToken = cts.Token;
 
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -328,6 +331,7 @@ public class NatsKVWatcherTest
     public async Task Watch_push_consumer_flow_control()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -368,6 +372,7 @@ public class NatsKVWatcherTest
         var cancellationToken = cts.Token;
 
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -409,6 +414,7 @@ public class NatsKVWatcherTest
     public async Task Serialization_errors()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -435,6 +441,7 @@ public class NatsKVWatcherTest
     public async Task Watch_with_empty_filter()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -456,6 +463,7 @@ public class NatsKVWatcherTest
     public async Task Watch_with_multiple_filter_on_old_server()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);
@@ -485,6 +493,7 @@ public class NatsKVWatcherTest
     public async Task Watch_resume_at_revision()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var bucket = $"{prefix}Watch_resume_at_revision";
@@ -568,6 +577,7 @@ public class NatsKVWatcherTest
     public async Task Validate_watch_options()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var bucket = prefix + nameof(Validate_watch_options);
@@ -643,6 +653,7 @@ public class NatsKVWatcherTest
     public async Task ReadAfterDelete()
     {
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId();
 
         var js = new NatsJSContext(nats);

--- a/tests/NATS.Client.KeyValueStore.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/SlowConsumerTest.cs
@@ -1,5 +1,6 @@
 using NATS.Client.Core.Tests;
 using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
 
 namespace NATS.Client.KeyValueStore.Tests;
 
@@ -27,7 +28,7 @@ public class SlowConsumerTest
             Url = _server.Url,
             SubPendingChannelCapacity = 10, // Small capacity to trigger drops quickly
         });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var prefix = _server.GetNextId();
         var js = new NatsJSContext(nats);

--- a/tests/NATS.Client.ObjectStore.Tests/CompatTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/CompatTest.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using NATS.Client.Core.Tests;
 using NATS.Client.ObjectStore.Models;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.ObjectStore.Tests;
@@ -13,6 +14,7 @@ public class CompatTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 

--- a/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
@@ -8,6 +8,7 @@ using NATS.Client.ObjectStore.Internal;
 using NATS.Client.ObjectStore.Models;
 using NATS.Client.Serializers.Json;
 using NATS.Client.TestUtilities;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.ObjectStore.Tests;
@@ -26,6 +27,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 
@@ -53,6 +55,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 
@@ -135,6 +138,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 
@@ -189,6 +193,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 
@@ -227,6 +232,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -258,6 +264,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -305,6 +312,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -344,6 +352,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -402,6 +411,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -441,6 +451,7 @@ public class ObjectStoreTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -473,6 +484,7 @@ public class ObjectStoreTest
             Url = server.Url,
             SerializerRegistry = NatsJsonSerializerRegistry.Default,
         });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 
@@ -508,6 +520,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -540,6 +553,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -564,6 +578,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 
@@ -632,6 +647,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var obj = new NatsObjContext(js);
 
@@ -673,6 +689,7 @@ public class ObjectStoreTest
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 

--- a/tests/NATS.Client.ObjectStore.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/SlowConsumerTest.cs
@@ -1,5 +1,6 @@
 using NATS.Client.Core.Tests;
 using NATS.Client.ObjectStore.Models;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.ObjectStore.Tests;
@@ -24,7 +25,7 @@ public class SlowConsumerTest
             Url = server.Url,
             SubPendingChannelCapacity = 10,
         });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);

--- a/tests/NATS.Client.ObjectStore.Tests/WatcherTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/WatcherTest.cs
@@ -1,4 +1,5 @@
 using NATS.Client.Core.Tests;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.ObjectStore.Tests;
@@ -10,6 +11,7 @@ public class WatcherTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var js = new NatsJSContext(nats);
         var ob = new NatsObjContext(js);
 

--- a/tests/NATS.Client.Services.Tests/ServicesSerializationTest.cs
+++ b/tests/NATS.Client.Services.Tests/ServicesSerializationTest.cs
@@ -5,6 +5,7 @@ using NATS.Client.Core.Tests;
 using NATS.Client.Serializers.Json;
 using NATS.Client.Services.Internal;
 using NATS.Client.Services.Models;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.Services.Tests;
@@ -22,6 +23,7 @@ public class ServicesSerializationTest
 
         // Set serializer registry to use anything but a raw bytes (NatsMemory in this case) serializer
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, SerializerRegistry = NatsJsonSerializerRegistry.Default });
+        await nats.ConnectRetryAsync();
 
         var svc = new NatsSvcContext(nats);
 
@@ -49,6 +51,7 @@ public class ServicesSerializationTest
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url, SerializerRegistry = NatsJsonSerializerRegistry.Default });
+        await nats.ConnectRetryAsync();
 
         var svc = new NatsSvcContext(nats);
 

--- a/tests/NATS.Client.Services.Tests/ServicesTests.cs
+++ b/tests/NATS.Client.Services.Tests/ServicesTests.cs
@@ -22,6 +22,7 @@ public class ServicesTests
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         await using var s1 = await svc.AddServiceAsync("s1", "1.0.0", cancellationToken: cancellationToken);
@@ -57,6 +58,7 @@ public class ServicesTests
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         await using var s1 = await svc.AddServiceAsync("s1", "1.0.0", cancellationToken: cancellationToken);
@@ -139,6 +141,7 @@ public class ServicesTests
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         await using var s1 = await svc.AddServiceAsync("s1", "1.0.0", cancellationToken: cancellationToken);
@@ -240,6 +243,7 @@ public class ServicesTests
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
@@ -276,6 +280,7 @@ public class ServicesTests
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         await using var s1 = await svc.AddServiceAsync("s1", "1.0.0", cancellationToken: cancellationToken);
@@ -334,6 +339,7 @@ public class ServicesTests
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         await using var s1 = await svc.AddServiceAsync("s1", "1.0.0", cancellationToken: cancellationToken);
@@ -358,6 +364,7 @@ public class ServicesTests
     {
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -392,6 +399,7 @@ public class ServicesTests
         await using var server = await NatsServerProcess.StartAsync();
         var proxy = new NatsProxy(server.Port);
         await using var nats = new NatsConnection(new NatsOpts { Url = $"127.0.0.1:{proxy.Port}" });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
@@ -532,6 +540,7 @@ public class ServicesTests
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         await using var s1 = await svc.AddServiceAsync("s1", "1.0.0", cancellationToken: cancellationToken);
@@ -557,6 +566,7 @@ public class ServicesTests
 
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
         var svc = new NatsSvcContext(nats);
 
         await using var s1 = await svc.AddServiceAsync(

--- a/tests/NATS.Client.Services.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.Services.Tests/SlowConsumerTest.cs
@@ -1,4 +1,5 @@
 using NATS.Client.Core.Tests;
+using NATS.Client.TestUtilities2;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.Services.Tests;
@@ -23,7 +24,7 @@ public class SlowConsumerTest
             Url = server.Url,
             SubPendingChannelCapacity = 10,
         });
-        await nats.ConnectAsync();
+        await nats.ConnectRetryAsync();
 
         var svc = new NatsSvcContext(nats);
 


### PR DESCRIPTION
Integration tests that construct a NatsConnection and use it without first gating on a successful connect can fail with a TimeoutException from the 2s connect/INFO-wait when CI runs TFMs in parallel under load. The failure surfaces as an unrelated test before any assertion runs. Gate positive-path connections with the existing ConnectRetryAsync helper (retries ConnectAsync for up to 60s) and convert plain ConnectAsync setup gates to it. Negative-path tests (expected connect failures/timeouts, reconnect/cancel/TLS/auth behaviour) are left as-is.

Also fixes two unrelated test flakes surfaced by CI: a request-reply race where the request could outrun the responder's subscription, and a slow-consumer test whose episode-2 wait used an absolute event-count threshold instead of a relative one.