### PR TITLE
Add custom span destination name formatter

### DIFF
--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -384,6 +384,9 @@ public partial class NatsConnection : INatsConnection
         if (subject.StartsWith(Opts.InboxPrefix, StringComparison.Ordinal))
             return "inbox";
 
+        if (NatsInstrumentationOptions.Default.SpanDestinationNameFormatter is { } formatter)
+            return formatter(subject);
+
         // to avoid long span names and low cardinality, only take the first two tokens
         var subjectSpan = subject.AsSpan();
         var firstSeparator = subjectSpan.IndexOf('.');

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -385,8 +385,12 @@ public partial class NatsConnection : INatsConnection
             return "inbox";
 
         // to avoid long span names and low cardinality, only take the first two tokens
-        var tokens = subject.Split('.');
-        return tokens.Length < 2 ? subject : $"{tokens[0]}.{tokens[1]}";
+        var subjectSpan = subject.AsSpan();
+        var firstSeparator = subjectSpan.IndexOf('.');
+        var secondSeparator = firstSeparator < 0 ? -1 : subjectSpan[(firstSeparator + 1)..].IndexOf('.');
+        return secondSeparator < 0
+            ? subject
+            : subjectSpan[..(firstSeparator + 1 + secondSeparator)].ToString();
     }
 
     internal NatsStats GetStats() => Counter.ToStats();

--- a/src/NATS.Client.Core/NatsInstrumentationOptions.cs
+++ b/src/NATS.Client.Core/NatsInstrumentationOptions.cs
@@ -23,4 +23,12 @@ public sealed class NatsInstrumentationOptions
     /// Gets or sets an action to enrich an Activity.
     /// </summary>
     public Action<Activity, NatsInstrumentationContext>? Enrich { get; set; }
+
+    /// <summary>
+    /// Gets or sets a function that formats the destination name used in span names.
+    /// </summary>
+    /// <remarks>
+    /// The input is the raw NATS subject. This only changes activity names, not telemetry tags.
+    /// </remarks>
+    public Func<string, string>? SpanDestinationNameFormatter { get; set; }
 }

--- a/src/NATS.Client.OpenTelemetry/NatsInstrumentationExtensions.cs
+++ b/src/NATS.Client.OpenTelemetry/NatsInstrumentationExtensions.cs
@@ -18,7 +18,7 @@ public static class NatsInstrumentationExtensions
 
     /// <summary>
     /// Adds the NATS .NET client <see cref="System.Diagnostics.ActivitySource"/> to the tracer provider and
-    /// configures the shared <see cref="NatsInstrumentationOptions"/> (filter and enrich callbacks).
+    /// configures the shared <see cref="NatsInstrumentationOptions"/>.
     /// </summary>
     /// <param name="builder">The <see cref="TracerProviderBuilder"/> to add the source to.</param>
     /// <param name="configure">Action that mutates the process-wide <see cref="NatsInstrumentationOptions.Default"/>.</param>

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
@@ -17,4 +17,40 @@ public class NatsConnectionTelemetryTests
 
         nats.SpanDestinationName(subject).Should().Be(expected);
     }
+
+    [Fact]
+    public async Task SpanDestinationName_uses_configured_formatter()
+    {
+        var previous = NatsInstrumentationOptions.Default.SpanDestinationNameFormatter;
+        try
+        {
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = subject => $"custom:{subject}";
+
+            await using var nats = new NatsConnection();
+
+            nats.SpanDestinationName("foo.bar.baz").Should().Be("custom:foo.bar.baz");
+        }
+        finally
+        {
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = previous;
+        }
+    }
+
+    [Fact]
+    public async Task SpanDestinationName_collapses_inbox_before_configured_formatter()
+    {
+        var previous = NatsInstrumentationOptions.Default.SpanDestinationNameFormatter;
+        try
+        {
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = subject => $"custom:{subject}";
+
+            await using var nats = new NatsConnection();
+
+            nats.SpanDestinationName("_INBOX.abc.def").Should().Be("inbox");
+        }
+        finally
+        {
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = previous;
+        }
+    }
 }

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
@@ -1,0 +1,20 @@
+namespace NATS.Client.CoreUnit.Tests;
+
+public class NatsConnectionTelemetryTests
+{
+    [Theory]
+    [InlineData("foo", "foo")]
+    [InlineData("foo.bar", "foo.bar")]
+    [InlineData("foo.bar.baz", "foo.bar")]
+    [InlineData("foo.bar.baz.qux", "foo.bar")]
+    [InlineData("foo.", "foo.")]
+    [InlineData("foo..bar", "foo.")]
+    [InlineData(".foo.bar", ".foo")]
+    [InlineData("..", ".")]
+    public async Task SpanDestinationName_collapses_to_first_two_subject_tokens(string subject, string expected)
+    {
+        await using var nats = new NatsConnection();
+
+        nats.SpanDestinationName(subject).Should().Be(expected);
+    }
+}

--- a/tests/NATS.Net.OpenTelemetry.Tests/NatsInstrumentationExtensionsTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/NatsInstrumentationExtensionsTest.cs
@@ -39,17 +39,20 @@ public class NatsInstrumentationExtensionsTest
                     configured = true;
                     options.Filter = _ => true;
                     options.Enrich = (_, _) => { };
+                    options.SpanDestinationNameFormatter = subject => subject;
                 })
                 .Build();
 
             configured.Should().BeTrue();
             NatsInstrumentationOptions.Default.Filter.Should().NotBeNull();
             NatsInstrumentationOptions.Default.Enrich.Should().NotBeNull();
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter.Should().NotBeNull();
         }
         finally
         {
             NatsInstrumentationOptions.Default.Filter = null;
             NatsInstrumentationOptions.Default.Enrich = null;
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = null;
         }
     }
 


### PR DESCRIPTION
  - Add `NatsInstrumentationOptions.SpanDestinationNameFormatter` to let users customize the destination portion of NATS activity names.
  - Keep inbox span names collapsed to `inbox` before applying the custom formatter to avoid high-cardinality `_INBOX...` names.
  - Optimize the default `SpanDestinationName` path to use span-based token scanning instead of `string.Split`.