### PR TITLE
Optimize header handling with SearchValues

### DIFF
--- a/sandbox/MicroBenchmark/HeaderKeyValidationBench.cs
+++ b/sandbox/MicroBenchmark/HeaderKeyValidationBench.cs
@@ -1,0 +1,132 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace MicroBenchmark;
+
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class HeaderKeyValidationBench
+{
+    private const byte ByteColon = (byte)':';
+    private const byte ByteSpace = (byte)' ';
+    private const byte ByteDel = 127;
+
+    private static readonly SearchValues<byte> ValidKeyBytes = SearchValues.Create(CreateValidKeyBytes());
+    private static readonly SearchValues<byte> InvalidKeyBytes = SearchValues.Create(CreateInvalidKeyBytes());
+
+    private byte[] _key = null!;
+
+    public enum HeaderKeyCase
+    {
+        ShortValid,
+        MediumValid,
+        InvalidStart,
+        InvalidMiddle,
+        InvalidEnd,
+        InvalidNonAscii,
+    }
+
+    [Params(
+        HeaderKeyCase.ShortValid,
+        HeaderKeyCase.MediumValid,
+        HeaderKeyCase.InvalidStart,
+        HeaderKeyCase.InvalidMiddle,
+        HeaderKeyCase.InvalidEnd,
+        HeaderKeyCase.InvalidNonAscii)]
+    public HeaderKeyCase KeyCase { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var key = KeyCase switch
+        {
+            HeaderKeyCase.ShortValid => "Nats-Msg-Id",
+            HeaderKeyCase.MediumValid => "Nats-Expected-Last-Subject-Sequence",
+            HeaderKeyCase.InvalidStart => ":Nats-Msg-Id",
+            HeaderKeyCase.InvalidMiddle => "Nats Msg Id",
+            HeaderKeyCase.InvalidEnd => "Nats-Msg-Id\n",
+            HeaderKeyCase.InvalidNonAscii => "Nats-Msg-Id-é",
+            _ => throw new ArgumentOutOfRangeException(nameof(KeyCase), KeyCase, null),
+        };
+
+        _key = Encoding.UTF8.GetBytes(key);
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool ByteLoop() => ValidateKeyByteLoop(_key);
+
+    [Benchmark]
+    public bool SearchValuesInvalidBytes() => ValidateKeySearchValuesInvalidBytes(_key);
+
+    [Benchmark]
+    public bool SearchValuesValidBytes() => ValidateKeySearchValuesValidBytes(_key);
+
+    [Benchmark]
+    public bool RangeExceptAndColon() => ValidateKeyRangeExceptAndColon(_key);
+
+    private static bool ValidateKeyByteLoop(ReadOnlySpan<byte> span)
+    {
+        foreach (var b in span)
+        {
+            if (b <= ByteSpace || b == ByteColon || b >= ByteDel)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool ValidateKeySearchValuesInvalidBytes(ReadOnlySpan<byte> span)
+    {
+        return !span.ContainsAny(InvalidKeyBytes);
+    }
+
+    private static bool ValidateKeySearchValuesValidBytes(ReadOnlySpan<byte> span)
+    {
+        return !span.ContainsAnyExcept(ValidKeyBytes);
+    }
+
+    private static bool ValidateKeyRangeExceptAndColon(ReadOnlySpan<byte> span)
+    {
+        return !span.ContainsAnyExceptInRange((byte)33, (byte)126) && !span.Contains(ByteColon);
+    }
+
+    private static byte[] CreateValidKeyBytes()
+    {
+        var bytes = new byte[ByteDel - ByteSpace - 2];
+        var index = 0;
+
+        for (var b = ByteSpace + 1; b < ByteDel; b++)
+        {
+            if (b != ByteColon)
+            {
+                bytes[index++] = (byte)b;
+            }
+        }
+
+        return bytes;
+    }
+
+    private static byte[] CreateInvalidKeyBytes()
+    {
+        var bytes = new byte[(int)ByteSpace + 1 + 1 + byte.MaxValue - ByteDel + 1];
+        var index = 0;
+
+        for (var b = 0; b <= ByteSpace; b++)
+        {
+            bytes[index++] = (byte)b;
+        }
+
+        bytes[index++] = ByteColon;
+
+        for (var b = (int)ByteDel; b <= byte.MaxValue; b++)
+        {
+            bytes[index++] = (byte)b;
+        }
+
+        return bytes;
+    }
+}
+#endif

--- a/sandbox/MicroBenchmark/HeaderParserNameEndBench.cs
+++ b/sandbox/MicroBenchmark/HeaderParserNameEndBench.cs
@@ -1,0 +1,77 @@
+#if NET8_0_OR_GREATER
+using System.Buffers;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace MicroBenchmark;
+
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class HeaderParserNameEndBench
+{
+    private const byte ByteColon = (byte)':';
+    private const byte ByteSpace = (byte)' ';
+    private const byte ByteTab = (byte)'\t';
+
+    private static readonly SearchValues<byte> HeaderNameTerminators = SearchValues.Create([ByteColon, ByteSpace, ByteTab]);
+    private static readonly string LongHeader = "X-Nats-Metadata-" + new string('A', 112) + ": value";
+
+    private byte[] _headerLine = null!;
+
+    public enum HeaderLineCase
+    {
+        ShortValid,
+        MediumValid,
+        LongValid,
+        EmptyName,
+        SpaceBeforeColon,
+        TabBeforeColon,
+        MissingDelimiter,
+    }
+
+    [Params(
+        HeaderLineCase.ShortValid,
+        HeaderLineCase.MediumValid,
+        HeaderLineCase.LongValid,
+        HeaderLineCase.EmptyName,
+        HeaderLineCase.SpaceBeforeColon,
+        HeaderLineCase.TabBeforeColon,
+        HeaderLineCase.MissingDelimiter)]
+    public HeaderLineCase LineCase { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var headerLine = LineCase switch
+        {
+            HeaderLineCase.ShortValid => "Nats-Msg-Id: value",
+            HeaderLineCase.MediumValid => "Nats-Expected-Last-Subject-Sequence: 123",
+            HeaderLineCase.LongValid => LongHeader,
+            HeaderLineCase.EmptyName => ": value",
+            HeaderLineCase.SpaceBeforeColon => "Nats Msg Id: value",
+            HeaderLineCase.TabBeforeColon => "Nats\tMsg-Id: value",
+            HeaderLineCase.MissingDelimiter => "Nats-Msg-Id",
+            _ => throw new ArgumentOutOfRangeException(nameof(LineCase), LineCase, null),
+        };
+
+        _headerLine = Encoding.ASCII.GetBytes(headerLine);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int IndexOfAnyThreeValues() => FindNameEndIndexOfAnyThreeValues(_headerLine);
+
+    [Benchmark]
+    public int IndexOfAnySearchValues() => FindNameEndSearchValues(_headerLine);
+
+    private static int FindNameEndIndexOfAnyThreeValues(ReadOnlySpan<byte> headerLine)
+    {
+        return headerLine.IndexOfAny(ByteColon, ByteSpace, ByteTab);
+    }
+
+    private static int FindNameEndSearchValues(ReadOnlySpan<byte> headerLine)
+    {
+        return headerLine.IndexOfAny(HeaderNameTerminators);
+    }
+}
+#endif

--- a/sandbox/MicroBenchmark/HeaderValueValidationBench.cs
+++ b/sandbox/MicroBenchmark/HeaderValueValidationBench.cs
@@ -1,0 +1,77 @@
+#if NET8_0_OR_GREATER
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace MicroBenchmark;
+
+public class HeaderValueValidationBench
+{
+    private const byte ByteCr = (byte)'\r';
+    private const byte ByteLf = (byte)'\n';
+
+    private byte[] _value = null!;
+
+    public enum HeaderValueCase
+    {
+        ShortValid,
+        LongValid,
+        CrAtEnd,
+        CrWithoutLf,
+        CrLfAtStart,
+        CrLfAtEnd,
+    }
+
+    [Params(
+        HeaderValueCase.ShortValid,
+        HeaderValueCase.LongValid,
+        HeaderValueCase.CrAtEnd,
+        HeaderValueCase.CrWithoutLf,
+        HeaderValueCase.CrLfAtStart,
+        HeaderValueCase.CrLfAtEnd)]
+    public HeaderValueCase ValueCase { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var value = ValueCase switch
+        {
+            HeaderValueCase.ShortValid => "ok",
+            HeaderValueCase.LongValid => new string('A', 256),
+            HeaderValueCase.CrAtEnd => "value\r",
+            HeaderValueCase.CrWithoutLf => "value\rnext",
+            HeaderValueCase.CrLfAtStart => "\r\nvalue",
+            HeaderValueCase.CrLfAtEnd => "value\r\n",
+            _ => throw new ArgumentOutOfRangeException(nameof(ValueCase), ValueCase, null),
+        };
+
+        _value = Encoding.ASCII.GetBytes(value);
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool IndexOfCrLoop() => ValidateValueIndexOfCrLoop(_value);
+
+    [Benchmark]
+    public bool IndexOfCrLfSequence() => ValidateValueIndexOfCrLfSequence(_value);
+
+    private static bool ValidateValueIndexOfCrLoop(ReadOnlySpan<byte> span)
+    {
+        while (true)
+        {
+            var pos = span.IndexOf(ByteCr);
+            if (pos == -1 || pos == span.Length - 1)
+                return true;
+
+            pos += 1;
+            if (span[pos] == ByteLf)
+                return false;
+
+            span = span[pos..];
+        }
+    }
+
+    private static bool ValidateValueIndexOfCrLfSequence(ReadOnlySpan<byte> span)
+    {
+        return span.IndexOf("\r\n"u8) < 0;
+    }
+}
+#endif

--- a/src/NATS.Client.Core/Internal/HeaderWriter.cs
+++ b/src/NATS.Client.Core/Internal/HeaderWriter.cs
@@ -12,6 +12,10 @@ internal class HeaderWriter
     private const byte ByteSpace = (byte)' ';
     private const byte ByteDel = 127;
 
+#if NET8_0_OR_GREATER
+    private static readonly SearchValues<byte> ValidKeyBytes = SearchValues.Create(CreateValidKeyBytes());
+#endif
+
     private readonly Encoding _encoding;
 
     public HeaderWriter(Encoding encoding) => _encoding = encoding;
@@ -49,6 +53,22 @@ internal class HeaderWriter
         // CrLf length for empty headers
         len += CrLf.Length;
         return len;
+    }
+
+    // cannot contain ASCII Bytes <=32, 58, or >=127
+    internal static bool ValidateKey(ReadOnlySpan<byte> span)
+    {
+#if NET8_0_OR_GREATER
+        return !span.ContainsAnyExcept(ValidKeyBytes);
+#else
+        foreach (var b in span)
+        {
+            if (b <= ByteSpace || b == ByteColon || b >= ByteDel)
+                return false;
+        }
+
+        return true;
+#endif
     }
 
     internal long Write(IBufferWriter<byte> bufferWriter, NatsHeaders headers)
@@ -104,17 +124,23 @@ internal class HeaderWriter
         return len;
     }
 
-    // cannot contain ASCII Bytes <=32, 58, or 127
-    private static bool ValidateKey(ReadOnlySpan<byte> span)
+#if NET8_0_OR_GREATER
+    private static byte[] CreateValidKeyBytes()
     {
-        foreach (var b in span)
+        var bytes = new byte[ByteDel - ByteSpace - 2];
+        var index = 0;
+
+        for (var b = ByteSpace + 1; b < ByteDel; b++)
         {
-            if (b <= ByteSpace || b == ByteColon || b >= ByteDel)
-                return false;
+            if (b != ByteColon)
+            {
+                bytes[index++] = (byte)b;
+            }
         }
 
-        return true;
+        return bytes;
     }
+#endif
 
     // cannot contain CRLF
     private static bool ValidateValue(ReadOnlySpan<byte> span)

--- a/tests/NATS.Client.CoreUnit.Tests/NatsHeaderTest.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsHeaderTest.cs
@@ -53,6 +53,20 @@ public class NatsHeaderTest
     }
 
     [Fact]
+    public void WriterHeaderKeyValidationByteBoundaryTests()
+    {
+        var key = new byte[] { (byte)'a', 0, (byte)'z' };
+
+        for (var b = 0; b <= byte.MaxValue; b++)
+        {
+            key[1] = (byte)b;
+            var expected = b > ' ' && b != ':' && b < 127;
+
+            Assert.Equal(expected, HeaderWriter.ValidateKey(key));
+        }
+    }
+
+    [Fact]
     public void ParserTests()
     {
         var parser = new NatsHeaderParser(Encoding.UTF8);


### PR DESCRIPTION
Use SearchValues for header key validation on .NET 8+ while preserving fallback behavior for older targets.

Add microbenchmarks for the new SearchValues variants and a byte-boundary test for header key validation.
Contributes to #1139 

Using SearchValues on NatsHeaderParser.TryTakeSingleHeader and using span.IndexOf("\r\n"u8) in HeaderWriter.ValidateValue does not yield any improvement on my machine so they are not changes in this PR.

Benchmark results on Apple M2 Ultra:

### HeaderKeyValidationBench:

| Method                   | Job       | Runtime   | KeyCase         | Mean       | Error     | StdDev    | Median     | Ratio | RatioSD |
|------------------------- |---------- |---------- |---------------- |-----------:|----------:|----------:|-----------:|------:|--------:|
| ByteLoop                 | .NET 10.0 | .NET 10.0 | ShortValid      |  5.4218 ns | 0.0240 ns | 0.0213 ns |  5.4151 ns |  1.00 |    0.01 |
| SearchValuesInvalidBytes | .NET 10.0 | .NET 10.0 | ShortValid      |  1.5126 ns | 0.0430 ns | 0.0402 ns |  1.4929 ns |  0.28 |    0.01 |
| SearchValuesValidBytes   | .NET 10.0 | .NET 10.0 | ShortValid      |  1.3347 ns | 0.0300 ns | 0.0281 ns |  1.3185 ns |  0.25 |    0.01 |
| RangeExceptAndColon      | .NET 10.0 | .NET 10.0 | ShortValid      |  6.1402 ns | 0.0131 ns | 0.0116 ns |  6.1390 ns |  1.13 |    0.00 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 8.0  | .NET 8.0  | ShortValid      |  7.6582 ns | 0.0676 ns | 0.0633 ns |  7.6710 ns |  1.00 |    0.01 |
| SearchValuesInvalidBytes | .NET 8.0  | .NET 8.0  | ShortValid      |  3.5832 ns | 0.0405 ns | 0.0379 ns |  3.5784 ns |  0.47 |    0.01 |
| SearchValuesValidBytes   | .NET 8.0  | .NET 8.0  | ShortValid      |  2.9932 ns | 0.0055 ns | 0.0048 ns |  2.9949 ns |  0.39 |    0.00 |
| RangeExceptAndColon      | .NET 8.0  | .NET 8.0  | ShortValid      |  8.7890 ns | 0.0463 ns | 0.0411 ns |  8.7814 ns |  1.15 |    0.01 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 10.0 | .NET 10.0 | MediumValid     | 17.5347 ns | 0.2610 ns | 0.2441 ns | 17.4888 ns |  1.00 |    0.02 |
| SearchValuesInvalidBytes | .NET 10.0 | .NET 10.0 | MediumValid     |  2.6759 ns | 0.0026 ns | 0.0022 ns |  2.6761 ns |  0.15 |    0.00 |
| SearchValuesValidBytes   | .NET 10.0 | .NET 10.0 | MediumValid     |  2.1777 ns | 0.0428 ns | 0.0400 ns |  2.1742 ns |  0.12 |    0.00 |
| RangeExceptAndColon      | .NET 10.0 | .NET 10.0 | MediumValid     |  2.2172 ns | 0.0073 ns | 0.0064 ns |  2.2149 ns |  0.13 |    0.00 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 8.0  | .NET 8.0  | MediumValid     | 18.0503 ns | 0.3345 ns | 0.2965 ns | 18.0162 ns |  1.00 |    0.02 |
| SearchValuesInvalidBytes | .NET 8.0  | .NET 8.0  | MediumValid     |  3.5390 ns | 0.0424 ns | 0.0396 ns |  3.5163 ns |  0.20 |    0.00 |
| SearchValuesValidBytes   | .NET 8.0  | .NET 8.0  | MediumValid     |  2.7781 ns | 0.0616 ns | 0.0576 ns |  2.7555 ns |  0.15 |    0.00 |
| RangeExceptAndColon      | .NET 8.0  | .NET 8.0  | MediumValid     |  4.7864 ns | 0.0065 ns | 0.0054 ns |  4.7856 ns |  0.27 |    0.00 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 10.0 | .NET 10.0 | InvalidStart    |  0.1151 ns | 0.0111 ns | 0.0098 ns |  0.1111 ns |  1.01 |    0.11 |
| SearchValuesInvalidBytes | .NET 10.0 | .NET 10.0 | InvalidStart    |  1.4955 ns | 0.0112 ns | 0.0099 ns |  1.4912 ns | 13.07 |    0.97 |
| SearchValuesValidBytes   | .NET 10.0 | .NET 10.0 | InvalidStart    |  1.3136 ns | 0.0020 ns | 0.0018 ns |  1.3136 ns | 11.48 |    0.85 |
| RangeExceptAndColon      | .NET 10.0 | .NET 10.0 | InvalidStart    |  6.6630 ns | 0.1536 ns | 0.3560 ns |  6.7242 ns | 58.22 |    5.31 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 8.0  | .NET 8.0  | InvalidStart    |  0.8394 ns | 0.0009 ns | 0.0007 ns |  0.8394 ns |  1.00 |    0.00 |
| SearchValuesInvalidBytes | .NET 8.0  | .NET 8.0  | InvalidStart    |  6.7554 ns | 0.0448 ns | 0.0419 ns |  6.7374 ns |  8.05 |    0.05 |
| SearchValuesValidBytes   | .NET 8.0  | .NET 8.0  | InvalidStart    |  4.4537 ns | 0.0095 ns | 0.0080 ns |  4.4503 ns |  5.31 |    0.01 |
| RangeExceptAndColon      | .NET 8.0  | .NET 8.0  | InvalidStart    |  6.3315 ns | 0.0053 ns | 0.0044 ns |  6.3321 ns |  7.54 |    0.01 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 10.0 | .NET 10.0 | InvalidMiddle   |  3.3793 ns | 0.2439 ns | 0.7152 ns |  3.1781 ns |  1.04 |    0.30 |
| SearchValuesInvalidBytes | .NET 10.0 | .NET 10.0 | InvalidMiddle   |  1.4878 ns | 0.0030 ns | 0.0028 ns |  1.4862 ns |  0.46 |    0.09 |
| SearchValuesValidBytes   | .NET 10.0 | .NET 10.0 | InvalidMiddle   |  1.3574 ns | 0.0237 ns | 0.0222 ns |  1.3607 ns |  0.42 |    0.08 |
| RangeExceptAndColon      | .NET 10.0 | .NET 10.0 | InvalidMiddle   |  5.0478 ns | 0.3596 ns | 1.0603 ns |  5.2953 ns |  1.55 |    0.44 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 8.0  | .NET 8.0  | InvalidMiddle   |  2.9988 ns | 0.0774 ns | 0.1666 ns |  2.9756 ns |  1.00 |    0.08 |
| SearchValuesInvalidBytes | .NET 8.0  | .NET 8.0  | InvalidMiddle   |  6.7189 ns | 0.0064 ns | 0.0056 ns |  6.7180 ns |  2.25 |    0.12 |
| SearchValuesValidBytes   | .NET 8.0  | .NET 8.0  | InvalidMiddle   |  4.4751 ns | 0.0578 ns | 0.0482 ns |  4.4519 ns |  1.50 |    0.08 |
| RangeExceptAndColon      | .NET 8.0  | .NET 8.0  | InvalidMiddle   |  3.8090 ns | 0.0834 ns | 0.0780 ns |  3.8124 ns |  1.27 |    0.07 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 10.0 | .NET 10.0 | InvalidEnd      |  5.8088 ns | 0.0114 ns | 0.0101 ns |  5.8076 ns |  1.00 |    0.00 |
| SearchValuesInvalidBytes | .NET 10.0 | .NET 10.0 | InvalidEnd      |  1.4841 ns | 0.0074 ns | 0.0061 ns |  1.4814 ns |  0.26 |    0.00 |
| SearchValuesValidBytes   | .NET 10.0 | .NET 10.0 | InvalidEnd      |  1.3427 ns | 0.0205 ns | 0.0191 ns |  1.3420 ns |  0.23 |    0.00 |
| RangeExceptAndColon      | .NET 10.0 | .NET 10.0 | InvalidEnd      |  4.1561 ns | 0.0236 ns | 0.0221 ns |  4.1513 ns |  0.72 |    0.00 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 8.0  | .NET 8.0  | InvalidEnd      |  7.9609 ns | 0.2851 ns | 0.8362 ns |  7.7224 ns |  1.01 |    0.15 |
| SearchValuesInvalidBytes | .NET 8.0  | .NET 8.0  | InvalidEnd      |  6.7200 ns | 0.0255 ns | 0.0226 ns |  6.7131 ns |  0.85 |    0.08 |
| SearchValuesValidBytes   | .NET 8.0  | .NET 8.0  | InvalidEnd      |  4.4539 ns | 0.0045 ns | 0.0037 ns |  4.4534 ns |  0.57 |    0.06 |
| RangeExceptAndColon      | .NET 8.0  | .NET 8.0  | InvalidEnd      |  5.6949 ns | 0.0491 ns | 0.0460 ns |  5.6769 ns |  0.72 |    0.07 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 10.0 | .NET 10.0 | InvalidNonAscii |  6.3613 ns | 0.0320 ns | 0.0299 ns |  6.3616 ns |  1.00 |    0.01 |
| SearchValuesInvalidBytes | .NET 10.0 | .NET 10.0 | InvalidNonAscii |  1.5004 ns | 0.0296 ns | 0.0262 ns |  1.4916 ns |  0.24 |    0.00 |
| SearchValuesValidBytes   | .NET 10.0 | .NET 10.0 | InvalidNonAscii |  1.3378 ns | 0.0124 ns | 0.0116 ns |  1.3348 ns |  0.21 |    0.00 |
| RangeExceptAndColon      | .NET 10.0 | .NET 10.0 | InvalidNonAscii |  4.4635 ns | 0.0609 ns | 0.0570 ns |  4.4678 ns |  0.70 |    0.01 |
|                          |           |           |                 |            |           |           |            |       |         |
| ByteLoop                 | .NET 8.0  | .NET 8.0  | InvalidNonAscii |  6.9572 ns | 0.1100 ns | 0.1029 ns |  6.9334 ns |  1.00 |    0.02 |
| SearchValuesInvalidBytes | .NET 8.0  | .NET 8.0  | InvalidNonAscii |  6.7356 ns | 0.1187 ns | 0.1052 ns |  6.6774 ns |  0.97 |    0.02 |
| SearchValuesValidBytes   | .NET 8.0  | .NET 8.0  | InvalidNonAscii |  4.5178 ns | 0.0423 ns | 0.0396 ns |  4.5105 ns |  0.65 |    0.01 |
| RangeExceptAndColon      | .NET 8.0  | .NET 8.0  | InvalidNonAscii |  6.1911 ns | 0.1025 ns | 0.0909 ns |  6.1885 ns |  0.89 |    0.02 |


### HeaderValueValidationBench:

| Method              | ValueCase   | Mean      | Error     | StdDev    | Ratio | RatioSD |
|-------------------- |------------ |----------:|----------:|----------:|------:|--------:|
| IndexOfCrLoop       | ShortValid  |  3.197 ns | 0.0589 ns | 0.0551 ns |  1.00 |    0.02 |
| IndexOfCrLfSequence | ShortValid  |  3.624 ns | 0.0110 ns | 0.0103 ns |  1.13 |    0.02 |
|                     |             |           |           |           |       |         |
| IndexOfCrLoop       | LongValid   |  7.141 ns | 0.0286 ns | 0.0224 ns |  1.00 |    0.00 |
| IndexOfCrLfSequence | LongValid   | 11.514 ns | 0.1411 ns | 0.1320 ns |  1.61 |    0.02 |
|                     |             |           |           |           |       |         |
| IndexOfCrLoop       | CrAtEnd     |  2.856 ns | 0.0444 ns | 0.0415 ns |  1.00 |    0.02 |
| IndexOfCrLfSequence | CrAtEnd     |  4.231 ns | 0.0395 ns | 0.0330 ns |  1.48 |    0.02 |
|                     |             |           |           |           |       |         |
| IndexOfCrLoop       | CrWithoutLf |  5.168 ns | 0.0171 ns | 0.0160 ns |  1.00 |    0.00 |
| IndexOfCrLfSequence | CrWithoutLf |  7.840 ns | 0.0475 ns | 0.0444 ns |  1.52 |    0.01 |
|                     |             |           |           |           |       |         |
| IndexOfCrLoop       | CrLfAtStart |  2.032 ns | 0.0042 ns | 0.0033 ns |  1.00 |    0.00 |
| IndexOfCrLfSequence | CrLfAtStart |  4.339 ns | 0.0647 ns | 0.0605 ns |  2.13 |    0.03 |
|                     |             |           |           |           |       |         |
| IndexOfCrLoop       | CrLfAtEnd   |  3.080 ns | 0.0576 ns | 0.0511 ns |  1.00 |    0.02 |
| IndexOfCrLfSequence | CrLfAtEnd   |  5.427 ns | 0.0065 ns | 0.0061 ns |  1.76 |    0.03 |


### HeaderParserNameEndBench:

| Method                 | Job       | Runtime   | LineCase         | Mean      | Error     | StdDev    | Ratio | RatioSD |
|----------------------- |---------- |---------- |----------------- |----------:|----------:|----------:|------:|--------:|
| IndexOfAnyThreeValues  | .NET 10.0 | .NET 10.0 | ShortValid       | 1.5651 ns | 0.0016 ns | 0.0015 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 10.0 | .NET 10.0 | ShortValid       | 1.6584 ns | 0.0203 ns | 0.0190 ns |  1.06 |    0.01 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 8.0  | .NET 8.0  | ShortValid       | 1.7713 ns | 0.0017 ns | 0.0013 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 8.0  | .NET 8.0  | ShortValid       | 1.9608 ns | 0.0079 ns | 0.0070 ns |  1.11 |    0.00 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 10.0 | .NET 10.0 | MediumValid      | 2.6424 ns | 0.0284 ns | 0.0252 ns |  1.00 |    0.01 |
| IndexOfAnySearchValues | .NET 10.0 | .NET 10.0 | MediumValid      | 2.7321 ns | 0.0740 ns | 0.0792 ns |  1.03 |    0.03 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 8.0  | .NET 8.0  | MediumValid      | 2.8658 ns | 0.0731 ns | 0.0718 ns |  1.00 |    0.03 |
| IndexOfAnySearchValues | .NET 8.0  | .NET 8.0  | MediumValid      | 3.0436 ns | 0.0540 ns | 0.0505 ns |  1.06 |    0.03 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 10.0 | .NET 10.0 | LongValid        | 5.4432 ns | 0.0185 ns | 0.0155 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 10.0 | .NET 10.0 | LongValid        | 5.5058 ns | 0.0032 ns | 0.0030 ns |  1.01 |    0.00 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 8.0  | .NET 8.0  | LongValid        | 5.7234 ns | 0.0538 ns | 0.0503 ns |  1.00 |    0.01 |
| IndexOfAnySearchValues | .NET 8.0  | .NET 8.0  | LongValid        | 5.8702 ns | 0.0548 ns | 0.0512 ns |  1.03 |    0.01 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 10.0 | .NET 10.0 | EmptyName        | 0.6716 ns | 0.0069 ns | 0.0057 ns |  1.00 |    0.01 |
| IndexOfAnySearchValues | .NET 10.0 | .NET 10.0 | EmptyName        | 0.7424 ns | 0.0021 ns | 0.0019 ns |  1.11 |    0.01 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 8.0  | .NET 8.0  | EmptyName        | 1.2800 ns | 0.0024 ns | 0.0021 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 8.0  | .NET 8.0  | EmptyName        | 1.2894 ns | 0.0034 ns | 0.0032 ns |  1.01 |    0.00 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 10.0 | .NET 10.0 | SpaceBeforeColon | 1.5649 ns | 0.0028 ns | 0.0025 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 10.0 | .NET 10.0 | SpaceBeforeColon | 1.6361 ns | 0.0019 ns | 0.0017 ns |  1.05 |    0.00 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 8.0  | .NET 8.0  | SpaceBeforeColon | 1.7781 ns | 0.0025 ns | 0.0022 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 8.0  | .NET 8.0  | SpaceBeforeColon | 2.0230 ns | 0.0551 ns | 0.0515 ns |  1.14 |    0.03 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 10.0 | .NET 10.0 | TabBeforeColon   | 1.5663 ns | 0.0029 ns | 0.0028 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 10.0 | .NET 10.0 | TabBeforeColon   | 1.6359 ns | 0.0040 ns | 0.0034 ns |  1.04 |    0.00 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 8.0  | .NET 8.0  | TabBeforeColon   | 1.7771 ns | 0.0094 ns | 0.0083 ns |  1.00 |    0.01 |
| IndexOfAnySearchValues | .NET 8.0  | .NET 8.0  | TabBeforeColon   | 1.9536 ns | 0.0017 ns | 0.0015 ns |  1.10 |    0.00 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 10.0 | .NET 10.0 | MissingDelimiter | 5.4216 ns | 0.0068 ns | 0.0053 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 10.0 | .NET 10.0 | MissingDelimiter | 5.4698 ns | 0.0130 ns | 0.0115 ns |  1.01 |    0.00 |
|                        |           |           |                  |           |           |           |       |         |
| IndexOfAnyThreeValues  | .NET 8.0  | .NET 8.0  | MissingDelimiter | 7.4766 ns | 0.0104 ns | 0.0092 ns |  1.00 |    0.00 |
| IndexOfAnySearchValues | .NET 8.0  | .NET 8.0  | MissingDelimiter | 7.7365 ns | 0.0095 ns | 0.0084 ns |  1.03 |    0.00 |