### PR TITLE
Fix null-key tag in OpenTelemetry receive fallback

### DIFF
--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -283,7 +283,11 @@ internal static class Telemetry
         }
         else
         {
-            tags = new KeyValuePair<string, object?>[10];
+            var len = 9;
+            if (replyTo is not null)
+                len++;
+
+            tags = new KeyValuePair<string, object?>[len];
             tags[0] = new KeyValuePair<string, object?>(Constants.SystemKey, Constants.SystemVal);
             tags[1] = new KeyValuePair<string, object?>(Constants.OpKey, Constants.OpRec);
             tags[2] = new KeyValuePair<string, object?>(Constants.DestTemplate, subscriptionSubject);

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
@@ -1,7 +1,45 @@
+using System.Diagnostics;
+using NATS.Client.Core.Internal;
+
 namespace NATS.Client.CoreUnit.Tests;
 
 public class NatsConnectionTelemetryTests
 {
+    [Theory]
+    [InlineData(null)]
+    [InlineData("_INBOX.reply")]
+    public async Task StartReceiveActivity_fallback_emits_no_null_key_tag(string? replyTo)
+    {
+        // A freshly constructed connection has no ServerInfo, so StartReceiveActivity
+        // takes the fallback branch. That branch must size its tag array to the tags it
+        // actually sets, or a trailing default {null, null} entry leaks into the activity.
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var nats = new NatsConnection();
+
+        using var activity = Telemetry.StartReceiveActivity(
+            nats,
+            name: "receive",
+            subscriptionSubject: "foo.bar",
+            queueGroup: null,
+            subject: "foo.bar",
+            replyTo: replyTo,
+            bodySize: 0,
+            size: 0,
+            headers: null);
+
+        activity.Should().NotBeNull();
+        activity!.TagObjects.Should().OnlyContain(tag => tag.Key != null);
+
+        var hasReplyToTag = activity.TagObjects.Any(tag => tag.Key == Telemetry.Constants.ReplyTo);
+        hasReplyToTag.Should().Be(replyTo is not null);
+    }
+
     [Theory]
     [InlineData("foo", "foo")]
     [InlineData("foo.bar", "foo.bar")]


### PR DESCRIPTION
The receive-path telemetry fallback (used when the connection is not a fully connected NatsConnection) allocated a fixed-size tag array but only populated the reply-to slot conditionally, leaving a default null-keyed entry that was passed to StartActivity when there was no reply-to. Size the array to the tags actually set, matching the send path, and add a regression test over the fallback branch.
