### PR TITLE
Make shared OpenTelemetry instrumentation options thread-visible

### DIFF
--- a/src/NATS.Client.Core/NatsInstrumentationOptions.cs
+++ b/src/NATS.Client.Core/NatsInstrumentationOptions.cs
@@ -7,6 +7,13 @@ namespace NATS.Client.Core;
 /// </summary>
 public sealed class NatsInstrumentationOptions
 {
+    // The shared Default instance is configured at startup but its callbacks are read on the
+    // publish/subscribe path from other threads. Backing fields are volatile so a configuration
+    // change made after traffic has started is observed by those readers.
+    private volatile Func<NatsInstrumentationContext, bool>? _filter;
+    private volatile Action<Activity, NatsInstrumentationContext>? _enrich;
+    private volatile Func<string, string>? _spanDestinationNameFormatter;
+
     public static NatsInstrumentationOptions Default { get; } = new();
 
     /// <summary>
@@ -17,12 +24,20 @@ public sealed class NatsInstrumentationOptions
     /// - If filter returns `true`, the request is collected.
     /// - If filter returns `false` or throws an exception the request is NOT collected.
     /// </remarks>
-    public Func<NatsInstrumentationContext, bool>? Filter { get; set; }
+    public Func<NatsInstrumentationContext, bool>? Filter
+    {
+        get => _filter;
+        set => _filter = value;
+    }
 
     /// <summary>
     /// Gets or sets an action to enrich an Activity.
     /// </summary>
-    public Action<Activity, NatsInstrumentationContext>? Enrich { get; set; }
+    public Action<Activity, NatsInstrumentationContext>? Enrich
+    {
+        get => _enrich;
+        set => _enrich = value;
+    }
 
     /// <summary>
     /// Gets or sets a function that formats the destination name used in span names.
@@ -30,5 +45,9 @@ public sealed class NatsInstrumentationOptions
     /// <remarks>
     /// The input is the raw NATS subject. This only changes activity names, not telemetry tags.
     /// </remarks>
-    public Func<string, string>? SpanDestinationNameFormatter { get; set; }
+    public Func<string, string>? SpanDestinationNameFormatter
+    {
+        get => _spanDestinationNameFormatter;
+        set => _spanDestinationNameFormatter = value;
+    }
 }


### PR DESCRIPTION
The shared NatsInstrumentationOptions.Default is configured once at startup, but its Filter, Enrich, and SpanDestinationNameFormatter callbacks are read on the publish/subscribe path from other threads. Back the properties with volatile fields so a configuration change applied after traffic has started is visible to those readers rather than depending on incidental memory barriers. No new test: this is a visibility guarantee and the existing configure round-trip test already covers get/set behavior.
