### PR TITLE
Clarify AddNats vs AddNatsClient

### DIFF
--- a/src/NATS.Client.Hosting/NatsHostingExtensions.cs
+++ b/src/NATS.Client.Hosting/NatsHostingExtensions.cs
@@ -8,9 +8,15 @@ namespace NATS.Client.Hosting;
 public static class NatsHostingExtensions
 {
     /// <summary>
-    /// Add NatsConnection/Pool to ServiceCollection. When poolSize = 1, registered `NatsConnection` and `INatsConnection` as singleton.
-    /// Others, registered `NatsConnectionPool` as singleton, `NatsConnection` and `INatsConnection` as transient(get from pool).
+    /// Registers a NATS connection on the service collection with minimal dependencies and no JSON serializer.
     /// </summary>
+    /// <remarks>
+    /// When <c>poolSize</c> is 1, <c>NatsConnection</c> and <c>INatsConnection</c> are registered as singletons.
+    /// For a larger pool, <c>NatsConnectionPool</c> is registered as a singleton and <c>NatsConnection</c>/
+    /// <c>INatsConnection</c> as transient, resolved from the pool. This package suits AOT and tight dependency
+    /// footprints; it does not register <c>INatsClient</c> or enable ad hoc JSON serialization. For those, use
+    /// <c>NATS.Extensions.Microsoft.DependencyInjection</c> and its <c>AddNatsClient</c> method instead.
+    /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1001:Commas should not be preceded by whitespace", Justification = "Required for conditional build.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1009:Closing parenthesis should not be preceded by a space", Justification = "Required for conditional build.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1111:Closing parenthesis should be on the same line as the last parameter", Justification = "Required for conditional build.")]

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NatsBuilder.cs
@@ -10,13 +10,25 @@ using NATS.Net;
 
 namespace NATS.Extensions.Microsoft.DependencyInjection;
 
+/// <summary>
+/// Mutable holder for the <see cref="NatsOpts"/> and connection configuration built up by <see cref="NatsBuilder"/>.
+/// </summary>
 public class NatsOptsBuilder
 {
+    /// <summary>
+    /// Gets or sets the options used to create the connection.
+    /// </summary>
     public NatsOpts Opts { get; set; } = NatsOpts.Default;
 
+    /// <summary>
+    /// Gets or sets an optional callback invoked on each connection after it is created.
+    /// </summary>
     public Action<IServiceProvider, NatsConnection>? ConfigureConnection { get; set; }
 }
 
+/// <summary>
+/// Fluent builder for configuring the NATS client registered by <c>AddNatsClient</c>.
+/// </summary>
 public class NatsBuilder
 {
     private readonly IServiceCollection _services;
@@ -25,6 +37,10 @@ public class NatsBuilder
     private object? _diKey = null;
     private string _optionsName = Options.DefaultName;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NatsBuilder"/> class.
+    /// </summary>
+    /// <param name="services">The service collection the client is registered on.</param>
     public NatsBuilder(IServiceCollection services)
     {
         _services = services;
@@ -45,6 +61,11 @@ public class NatsBuilder
             }
         });
 
+    /// <summary>
+    /// Sets the connection pool size.
+    /// </summary>
+    /// <param name="size">Number of connections in the pool. Values below 1 are treated as 1.</param>
+    /// <returns>Builder to allow method chaining.</returns>
     public NatsBuilder WithPoolSize(int size)
     {
         _poolSizeConfigurer = _ => Math.Max(size, 1);
@@ -52,6 +73,11 @@ public class NatsBuilder
         return this;
     }
 
+    /// <summary>
+    /// Sets the connection pool size using a factory resolved from the service provider.
+    /// </summary>
+    /// <param name="sizeConfigurer">Callback returning the pool size. Values below 1 are treated as 1.</param>
+    /// <returns>Builder to allow method chaining.</returns>
     public NatsBuilder WithPoolSize(Func<IServiceProvider, int> sizeConfigurer)
     {
         _poolSizeConfigurer = sp => Math.Max(sizeConfigurer(sp), 1);
@@ -59,6 +85,11 @@ public class NatsBuilder
         return this;
     }
 
+    /// <summary>
+    /// Configures the underlying <see cref="NatsOptsBuilder"/> options.
+    /// </summary>
+    /// <param name="configure">Callback to configure the options builder.</param>
+    /// <returns>Builder to allow method chaining.</returns>
     public NatsBuilder ConfigureOptions(Action<OptionsBuilder<NatsOptsBuilder>> configure)
     {
         configure(Builder);
@@ -76,6 +107,11 @@ public class NatsBuilder
         ConfigureOptions(builder => builder.Configure<IServiceProvider>((opts, provider) =>
             opts.Opts = optsFactory(provider, opts.Opts)));
 
+    /// <summary>
+    /// Registers a callback invoked on each connection after it is created, with access to the service provider.
+    /// </summary>
+    /// <param name="configureConnection">Callback to configure the connection.</param>
+    /// <returns>Builder to allow method chaining.</returns>
     public NatsBuilder ConfigureConnection(Action<IServiceProvider, NatsConnection> configureConnection) =>
         ConfigureOptions(builder =>
             builder.Configure<IServiceProvider>((opts, provider) =>
@@ -89,6 +125,11 @@ public class NatsBuilder
                 };
             }));
 
+    /// <summary>
+    /// Registers a callback invoked on each connection after it is created.
+    /// </summary>
+    /// <param name="configureConnection">Callback to configure the connection.</param>
+    /// <returns>Builder to allow method chaining.</returns>
     public NatsBuilder ConfigureConnection(Action<NatsConnection> configureConnection) =>
         ConfigureConnection((_, connection) => configureConnection(connection));
 
@@ -108,6 +149,12 @@ public class NatsBuilder
             }));
 
 #if NET8_0_OR_GREATER
+    /// <summary>
+    /// Registers the client as a keyed service so multiple connections can be resolved by key (.NET 8+).
+    /// </summary>
+    /// <param name="key">The service key.</param>
+    /// <returns>Builder to allow method chaining.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when called after options have already been configured.</exception>
     public NatsBuilder WithKey(object key)
     {
         if (_builder != null)

--- a/src/NATS.Extensions.Microsoft.DependencyInjection/NatsHostingExtensions.cs
+++ b/src/NATS.Extensions.Microsoft.DependencyInjection/NatsHostingExtensions.cs
@@ -4,6 +4,17 @@ namespace NATS.Extensions.Microsoft.DependencyInjection;
 
 public static class NatsHostingExtensions
 {
+    /// <summary>
+    /// Registers a NATS client on the service collection with ad hoc JSON serialization enabled by default.
+    /// </summary>
+    /// <param name="services">The service collection to add NATS to.</param>
+    /// <param name="buildAction">Optional callback to configure the client through <see cref="NatsBuilder"/>.</param>
+    /// <returns>The same service collection so calls can be chained.</returns>
+    /// <remarks>
+    /// Registers <c>INatsClient</c>, <c>INatsConnection</c>, <c>NatsConnection</c> and the connection pool.
+    /// This is the option to use for most applications. For AOT deployments or a minimal dependency footprint
+    /// without the JSON serializer, use <c>NATS.Client.Hosting</c> and its <c>AddNats</c> method instead.
+    /// </remarks>
     public static IServiceCollection AddNatsClient(this IServiceCollection services, Action<NatsBuilder>? buildAction = null)
     {
         var builder = new NatsBuilder(services);

--- a/tools/site_src/documentation/advanced/platform-compatibility.md
+++ b/tools/site_src/documentation/advanced/platform-compatibility.md
@@ -39,8 +39,9 @@ If you need the full `SslClientAuthenticationOptions` functionality, consider ta
 
 ### Keyed Services
 
-The [`AddNats`](xref:NATS.Client.Hosting.NatsHostingExtensions.AddNats*) extension method has different
-signatures depending on the target framework:
+[Keyed dependency injection services](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#keyed-services)
+were introduced in .NET 8, so the [`AddNats`](xref:NATS.Client.Hosting.NatsHostingExtensions.AddNats*)
+extension method gains a `key` parameter on newer target frameworks:
 
 **netstandard2.0, netstandard2.1:**
 ```csharp
@@ -61,18 +62,8 @@ public static IServiceCollection AddNats(
     object? key = null)  // Additional parameter for keyed services
 ```
 
-[Keyed dependency injection services](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#keyed-services)
-were introduced in .NET 8. The `key` parameter allows you to register multiple NATS connections
-with different keys:
-
-```csharp
-// .NET 8+ only
-services.AddNats(key: "primary", configureOpts: opts => opts with { Url = "nats://primary:4222" });
-services.AddNats(key: "secondary", configureOpts: opts => opts with { Url = "nats://secondary:4222" });
-
-// Inject with [FromKeyedServices("primary")]
-public class MyService([FromKeyedServices("primary")] INatsConnection primaryNats) { }
-```
+See [Dependency Injection](dependency-injection.md) for how to register and inject keyed connections
+with both DI packages.
 
 ## API Compatibility Checking
 


### PR DESCRIPTION
Documents the two DI entry points that are easy to confuse: AddNatsClient (ad hoc JSON, registers INatsClient) and AddNats (minimal, AOT-friendly, no JSON serializer). Adds inline docs to the previously undocumented builder API, and removes the keyed-services usage example from the platform compatibility page that duplicated the dependency injection page.

Addresses questions raised in discussion #1209.