### PR TITLE
Add explicit permissions to CI workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,6 +3,9 @@
 on:
   pull_request: {}
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: check

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,6 +6,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -6,6 +6,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   linux_test:
     name: Linux

--- a/.github/workflows/test_linux_core.yml
+++ b/.github/workflows/test_linux_core.yml
@@ -6,6 +6,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
   linux_test:
     name: Linux

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -6,6 +6,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 jobs:
 
   windows_test:


### PR DESCRIPTION
Adds a `permissions: contents: read` block to the five workflows CodeQL flagged for missing explicit permissions (Test Windows, Test Linux, Test Linux Core, Perf, Format). None of them write to the repo, so this just scopes the default `GITHUB_TOKEN` down to read-only, matching the pattern already used in `apicompat.yml`, `release.yml`, and `signoffs.yml`.