### PR TITLE
Fix silent completion when JetStream list enumeration is cancelled

### DIFF
--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -73,7 +73,11 @@ public partial class NatsJSContext : INatsJSContext
         var offset = 0;
         while (true)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (Opts.ThrowOnListCancellation)
+                cancellationToken.ThrowIfCancellationRequested();
+            else if (cancellationToken.IsCancellationRequested)
+                yield break;
+
             var response = await JSRequestResponseAsync<ConsumerListRequest, ConsumerListResponse>(
                 subject: $"{Opts.Prefix}.CONSUMER.LIST.{stream}",
                 new ConsumerListRequest { Offset = offset },
@@ -100,7 +104,11 @@ public partial class NatsJSContext : INatsJSContext
         var offset = 0;
         while (true)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (Opts.ThrowOnListCancellation)
+                cancellationToken.ThrowIfCancellationRequested();
+            else if (cancellationToken.IsCancellationRequested)
+                yield break;
+
             var response = await JSRequestResponseAsync<ConsumerNamesRequest, ConsumerNamesResponse>(
                 subject: $"{Opts.Prefix}.CONSUMER.NAMES.{stream}",
                 new ConsumerNamesRequest { Offset = offset },

--- a/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Consumers.cs
@@ -71,8 +71,9 @@ public partial class NatsJSContext : INatsJSContext
     {
         ThrowIfInvalidStreamName(stream);
         var offset = 0;
-        while (!cancellationToken.IsCancellationRequested)
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var response = await JSRequestResponseAsync<ConsumerListRequest, ConsumerListResponse>(
                 subject: $"{Opts.Prefix}.CONSUMER.LIST.{stream}",
                 new ConsumerListRequest { Offset = offset },
@@ -97,8 +98,9 @@ public partial class NatsJSContext : INatsJSContext
     {
         ThrowIfInvalidStreamName(stream);
         var offset = 0;
-        while (!cancellationToken.IsCancellationRequested)
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var response = await JSRequestResponseAsync<ConsumerNamesRequest, ConsumerNamesResponse>(
                 subject: $"{Opts.Prefix}.CONSUMER.NAMES.{stream}",
                 new ConsumerNamesRequest { Offset = offset },

--- a/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
@@ -186,7 +186,11 @@ public partial class NatsJSContext
         var offset = 0;
         while (true)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (Opts.ThrowOnListCancellation)
+                cancellationToken.ThrowIfCancellationRequested();
+            else if (cancellationToken.IsCancellationRequested)
+                yield break;
+
             var response = await JSRequestResponseAsync<StreamListRequest, StreamListResponse>(
                 subject: $"{Opts.Prefix}.STREAM.LIST",
                 request: new StreamListRequest
@@ -217,7 +221,11 @@ public partial class NatsJSContext
         var offset = 0;
         while (true)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (Opts.ThrowOnListCancellation)
+                cancellationToken.ThrowIfCancellationRequested();
+            else if (cancellationToken.IsCancellationRequested)
+                yield break;
+
             var response = await JSRequestResponseAsync<StreamNamesRequest, StreamNamesResponse>(
                 subject: $"{Opts.Prefix}.STREAM.NAMES",
                 request: new StreamNamesRequest

--- a/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.Streams.cs
@@ -184,8 +184,9 @@ public partial class NatsJSContext
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var offset = 0;
-        while (!cancellationToken.IsCancellationRequested)
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var response = await JSRequestResponseAsync<StreamListRequest, StreamListResponse>(
                 subject: $"{Opts.Prefix}.STREAM.LIST",
                 request: new StreamListRequest
@@ -214,8 +215,9 @@ public partial class NatsJSContext
     public async IAsyncEnumerable<string> ListStreamNamesAsync(string? subject = default, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var offset = 0;
-        while (!cancellationToken.IsCancellationRequested)
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var response = await JSRequestResponseAsync<StreamNamesRequest, StreamNamesResponse>(
                 subject: $"{Opts.Prefix}.STREAM.NAMES",
                 request: new StreamNamesRequest

--- a/src/NATS.Client.JetStream/NatsJSOpts.cs
+++ b/src/NATS.Client.JetStream/NatsJSOpts.cs
@@ -60,6 +60,17 @@ public record NatsJSOpts
     /// Default next options to be used in next calls in this context.
     /// </summary>
     public NatsJSNextOpts DefaultNextOpts { get; init; } = new();
+
+    /// <summary>
+    /// When <c>true</c>, cancelling a paginated list enumeration (streams, consumers, and their names)
+    /// throws <see cref="OperationCanceledException"/> instead of ending the enumeration silently.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c> for backwards compatibility, which ends the enumeration without throwing.
+    /// Setting this to <c>true</c> matches the conventional <see cref="IAsyncEnumerable{T}"/> cancellation
+    /// contract and lets callers distinguish a complete list from one truncated by cancellation.
+    /// </remarks>
+    public bool ThrowOnListCancellation { get; init; } = false;
 }
 
 public record NatsJSOrderedConsumerOpts

--- a/tests/NATS.Client.JetStream.Tests/ListTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/ListTests.cs
@@ -167,4 +167,99 @@ public class ListTests
             Assert.Equal(0, count);
         }
     }
+
+    [Fact]
+    public async Task List_streams_throws_when_cancelled()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(5) });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId() + "-";
+        var js = new NatsJSContext(nats);
+
+        using var setupCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        for (var i = 0; i < 3; i++)
+        {
+            await js.CreateStreamAsync(new StreamConfig($"{prefix}s{i}", [$"{prefix}s{i}.*"]), setupCts.Token);
+        }
+
+        // Cancelled before the first request: must throw instead of returning an empty list.
+        using (var cts = new CancellationTokenSource())
+        {
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var unused in js.ListStreamsAsync(cancellationToken: cts.Token))
+                {
+                }
+            });
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var unused in js.ListStreamNamesAsync(cancellationToken: cts.Token))
+                {
+                }
+            });
+        }
+
+        // Cancelled during enumeration: must throw instead of ending silently.
+        using (var cts = new CancellationTokenSource())
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var unused in js.ListStreamNamesAsync(cancellationToken: cts.Token))
+                {
+                    cts.Cancel();
+                }
+            });
+        }
+    }
+
+    [Fact]
+    public async Task List_consumers_throws_when_cancelled()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(5) });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId() + "-";
+        var js = new NatsJSContext(nats);
+
+        using var setupCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var stream = await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", [$"{prefix}s1.*"]), setupCts.Token);
+        for (var i = 0; i < 3; i++)
+        {
+            await js.CreateOrUpdateConsumerAsync($"{prefix}s1", new ConsumerConfig($"{prefix}c{i}"), setupCts.Token);
+        }
+
+        // Cancelled before the first request: must throw instead of returning an empty list.
+        using (var cts = new CancellationTokenSource())
+        {
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var unused in stream.ListConsumersAsync(cts.Token))
+                {
+                }
+            });
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var unused in stream.ListConsumerNamesAsync(cts.Token))
+                {
+                }
+            });
+        }
+
+        // Cancelled during enumeration: must throw instead of ending silently.
+        using (var cts = new CancellationTokenSource())
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            {
+                await foreach (var unused in stream.ListConsumerNamesAsync(cts.Token))
+                {
+                    cts.Cancel();
+                }
+            });
+        }
+    }
 }

--- a/tests/NATS.Client.JetStream.Tests/ListTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/ListTests.cs
@@ -174,7 +174,7 @@ public class ListTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(5) });
         await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId() + "-";
-        var js = new NatsJSContext(nats);
+        var js = new NatsJSContext(nats, new NatsJSOpts(nats.Opts) { ThrowOnListCancellation = true });
 
         using var setupCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         for (var i = 0; i < 3; i++)
@@ -221,7 +221,7 @@ public class ListTests
         await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(5) });
         await nats.ConnectRetryAsync();
         var prefix = _server.GetNextId() + "-";
-        var js = new NatsJSContext(nats);
+        var js = new NatsJSContext(nats, new NatsJSOpts(nats.Opts) { ThrowOnListCancellation = true });
 
         using var setupCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         var stream = await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", [$"{prefix}s1.*"]), setupCts.Token);
@@ -260,6 +260,46 @@ public class ListTests
                     cts.Cancel();
                 }
             });
+        }
+    }
+
+    [Fact]
+    public async Task List_ends_silently_when_cancelled_by_default()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url, RequestTimeout = TimeSpan.FromSeconds(5) });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId() + "-";
+
+        // Default context: ThrowOnListCancellation is false, preserving the pre-3.0.x silent behavior.
+        var js = new NatsJSContext(nats);
+
+        using var setupCts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        var stream = await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", [$"{prefix}s1.*"]), setupCts.Token);
+        for (var i = 0; i < 3; i++)
+        {
+            await js.CreateOrUpdateConsumerAsync($"{prefix}s1", new ConsumerConfig($"{prefix}c{i}"), setupCts.Token);
+        }
+
+        // Cancelled before the first request: ends silently, yielding nothing.
+        using (var cts = new CancellationTokenSource())
+        {
+            cts.Cancel();
+
+            var count = 0;
+            await foreach (var unused in js.ListStreamNamesAsync(cancellationToken: cts.Token))
+            {
+                count++;
+            }
+
+            Assert.Equal(0, count);
+
+            count = 0;
+            await foreach (var unused in stream.ListConsumerNamesAsync(cts.Token))
+            {
+                count++;
+            }
+
+            Assert.Equal(0, count);
         }
     }
 }


### PR DESCRIPTION
JetStream paginated list operations (streams, stream names, consumers, consumer names) used the cancellation token only as a loop guard, so cancelling before the first request or between pages ended the enumeration silently instead of throwing. Callers could not distinguish a complete list from one truncated by cancellation. These now throw OperationCanceledException, matching the conventional IAsyncEnumerable contract and the watcher-based reads which already throw on cancel by default. The KV bucket and status listings inherit this via their delegation to the stream-name listing. Long-running consume/fetch loops are unchanged, since cancellation there is the normal stop signal.

Fixes #1193