### PR TITLE
Add subscription events with OnSubscribed callback

### DIFF
--- a/src/NATS.Client.Core/INatsClient.cs
+++ b/src/NATS.Client.Core/INatsClient.cs
@@ -59,9 +59,18 @@ public interface INatsClient : IAsyncDisposable
     /// <typeparam name="T">Specifies the type of data that may be received from the NATS Server.</typeparam>
     /// <returns>An asynchronous enumerable of <see cref="NatsMsg{T}"/> objects</returns>
     /// <remarks>
+    /// <para>
     /// Subscribers with the same queue group name, become a queue group,
     /// and only one randomly chosen subscriber of the queue group will
     /// consume a message each time a message is received by the queue group.
+    /// </para>
+    /// <para>
+    /// The subscription is not established until the returned enumerable is iterated.
+    /// To find out when the subscription has been established, set
+    /// <see cref="NatsSubEvents.OnSubscribed"/> using <see cref="NatsSubOpts.Events"/>,
+    /// or use <see cref="INatsConnection.SubscribeCoreAsync{T}"/> which completes
+    /// once the subscription has been established.
+    /// </para>
     /// </remarks>
     IAsyncEnumerable<NatsMsg<T>> SubscribeAsync<T>(string subject, string? queueGroup = default, INatsDeserialize<T>? serializer = default, NatsSubOpts? opts = default, CancellationToken cancellationToken = default);
 

--- a/src/NATS.Client.Core/NatsConnection.LowLevelApi.cs
+++ b/src/NATS.Client.Core/NatsConnection.LowLevelApi.cs
@@ -23,7 +23,16 @@ public partial class NatsConnection
             }
             catch
             {
-                await sub.DisposeAsync().ConfigureAwait(false);
+                try
+                {
+                    await sub.DisposeAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Best-effort cleanup: DisposeAsync rethrows the subscription's own
+                    // exception if one was recorded; prefer surfacing the callback's.
+                }
+
                 throw;
             }
         }

--- a/src/NATS.Client.Core/NatsConnection.LowLevelApi.cs
+++ b/src/NATS.Client.Core/NatsConnection.LowLevelApi.cs
@@ -4,13 +4,28 @@ public partial class NatsConnection
 {
     /// <inheritdoc />
     public ValueTask AddSubAsync(NatsSubBase sub, CancellationToken cancellationToken = default) =>
-        ConnectionState != NatsConnectionState.Open
-            ? ConnectAndSubAsync(sub, cancellationToken)
+        ConnectionState != NatsConnectionState.Open || sub.Opts?.Events?.OnSubscribed is not null
+            ? AddSubInternalAsync(sub, cancellationToken)
             : _subscriptionManager.SubscribeAsync(sub, cancellationToken);
 
-    private async ValueTask ConnectAndSubAsync(NatsSubBase sub, CancellationToken cancellationToken = default)
+    private async ValueTask AddSubInternalAsync(NatsSubBase sub, CancellationToken cancellationToken = default)
     {
-        await ConnectAsync().AsTask().WaitAsync(cancellationToken).ConfigureAwait(false);
+        if (ConnectionState != NatsConnectionState.Open)
+            await ConnectAsync().AsTask().WaitAsync(cancellationToken).ConfigureAwait(false);
+
         await _subscriptionManager.SubscribeAsync(sub, cancellationToken).ConfigureAwait(false);
+
+        if (sub.Opts?.Events?.OnSubscribed is { } onSubscribed)
+        {
+            try
+            {
+                await onSubscribed(sub).ConfigureAwait(false);
+            }
+            catch
+            {
+                await sub.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
     }
 }

--- a/src/NATS.Client.Core/NatsSubEvents.cs
+++ b/src/NATS.Client.Core/NatsSubEvents.cs
@@ -1,0 +1,32 @@
+namespace NATS.Client.Core;
+
+/// <summary>
+/// Callbacks invoked at points in a subscription's lifecycle.
+/// Set using <see cref="NatsSubOpts.Events"/>.
+/// </summary>
+public record NatsSubEvents
+{
+    /// <summary>
+    /// Invoked when the subscription has been established, that is, once the SUB protocol
+    /// message has been queued for sending to the server. This is the same guarantee
+    /// <see cref="INatsConnection.SubscribeCoreAsync{T}"/> provides when it completes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The async enumerable returned by <see cref="INatsClient.SubscribeAsync{T}"/> does not
+    /// establish the subscription until it is iterated. When the enumerable is handed off to
+    /// another task, use this callback (for example, to complete a
+    /// <see cref="TaskCompletionSource{TResult}"/>) to find out when it is safe to trigger
+    /// messages the subscription must observe. Publishers using other connections may still
+    /// race with the server processing the subscription; a <see cref="INatsClient.PingAsync"/>
+    /// round-trip on the subscribing connection after this callback removes that race.
+    /// </para>
+    /// <para>
+    /// The callback receives the subscription and is invoked once when the subscription is
+    /// first established; it is not invoked again when subscriptions are re-established
+    /// after a reconnect. If the callback throws, the subscription is disposed and the
+    /// exception propagates to the subscribe call.
+    /// </para>
+    /// </remarks>
+    public Func<NatsSubBase, ValueTask>? OnSubscribed { get; init; }
+}

--- a/src/NATS.Client.Core/NatsSubOpts.cs
+++ b/src/NATS.Client.Core/NatsSubOpts.cs
@@ -82,4 +82,11 @@ public record NatsSubOpts
     /// Allows Configuration of <see cref="Channel"/> options for a subscription.
     /// </summary>
     public NatsSubChannelOpts? ChannelOpts { get; init; }
+
+    /// <summary>
+    /// Callbacks invoked at points in the subscription's lifecycle,
+    /// for example <see cref="NatsSubEvents.OnSubscribed"/> when the
+    /// subscription has been established.
+    /// </summary>
+    public NatsSubEvents? Events { get; init; }
 }

--- a/tests/NATS.Client.Core2.Tests/SubscriptionEventsTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SubscriptionEventsTest.cs
@@ -1,0 +1,159 @@
+using NATS.Client.Core2.Tests;
+using NATS.Client.TestUtilities2;
+
+namespace NATS.Client.Core.Tests;
+
+[Collection("nats-server")]
+public class SubscriptionEventsTest
+{
+    private readonly NatsServerFixture _server;
+
+    public SubscriptionEventsTest(NatsServerFixture server)
+    {
+        _server = server;
+    }
+
+    [Fact]
+    public async Task OnSubscribed_fires_when_async_enumerable_subscription_is_established()
+    {
+        await using var nats1 = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await using var nats2 = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats1.ConnectRetryAsync();
+        await nats2.ConnectRetryAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+        var subject = $"foo.{Guid.NewGuid():N}";
+
+        var subscribed = new TaskCompletionSource<NatsSubBase>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var reg = cancellationToken.Register(() => subscribed.TrySetCanceled(cancellationToken));
+
+        var opts = new NatsSubOpts
+        {
+            Events = new NatsSubEvents
+            {
+                OnSubscribed = sub =>
+                {
+                    subscribed.TrySetResult(sub);
+                    return default;
+                },
+            },
+        };
+
+        var received = Task.Run(async () =>
+        {
+            await foreach (var msg in nats1.SubscribeAsync<int>(subject, opts: opts, cancellationToken: cancellationToken))
+                return msg.Data;
+            return -1;
+        });
+
+        var subscription = await subscribed.Task;
+        Assert.Equal(subject, subscription.Subject);
+
+        // A round-trip on the subscribing connection guarantees the server has
+        // processed the SUB before the other connection publishes.
+        await nats1.PingAsync(cancellationToken);
+        await nats2.PublishAsync(subject, 42, cancellationToken: cancellationToken);
+
+        Assert.Equal(42, await received);
+    }
+
+    [Fact]
+    public async Task OnSubscribed_fires_for_subscribe_core()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+        var subject = $"foo.{Guid.NewGuid():N}";
+
+        NatsSubBase? subscribed = null;
+        var opts = new NatsSubOpts
+        {
+            Events = new NatsSubEvents
+            {
+                OnSubscribed = sub =>
+                {
+                    subscribed = sub;
+                    return default;
+                },
+            },
+        };
+
+        await using var sub = await nats.SubscribeCoreAsync<int>(subject, opts: opts, cancellationToken: cancellationToken);
+
+        Assert.Same(sub, subscribed);
+    }
+
+    [Fact]
+    public async Task OnSubscribed_allows_request_reply_handoff_without_no_responders()
+    {
+        await using var nats1 = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await using var nats2 = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats1.ConnectRetryAsync();
+        await nats2.ConnectRetryAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+        var subject = $"foo.{Guid.NewGuid():N}";
+
+        var subscribed = new TaskCompletionSource<NatsSubBase>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var reg = cancellationToken.Register(() => subscribed.TrySetCanceled(cancellationToken));
+
+        var opts = new NatsSubOpts
+        {
+            Events = new NatsSubEvents
+            {
+                OnSubscribed = sub =>
+                {
+                    subscribed.TrySetResult(sub);
+                    return default;
+                },
+            },
+        };
+
+        // Hand off consuming the subscription to a task, as in the reported
+        // scenario, replying to the first request received.
+        var responder = Task.Run(async () =>
+        {
+            await foreach (var msg in nats1.SubscribeAsync<int>(subject, opts: opts, cancellationToken: cancellationToken))
+            {
+                await msg.ReplyAsync(msg.Data + 1, cancellationToken: cancellationToken);
+                break;
+            }
+        });
+
+        await subscribed.Task;
+        await nats1.PingAsync(cancellationToken);
+
+        var reply = await nats2.RequestAsync<int, int>(subject, 1, cancellationToken: cancellationToken);
+        Assert.Equal(2, reply.Data);
+
+        await responder;
+    }
+
+    [Fact]
+    public async Task OnSubscribed_exception_propagates_and_disposes_subscription()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+        var subject = $"foo.{Guid.NewGuid():N}";
+
+        var opts = new NatsSubOpts
+        {
+            Events = new NatsSubEvents
+            {
+                OnSubscribed = _ => throw new InvalidOperationException("callback failed"),
+            },
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await nats.SubscribeCoreAsync<int>(subject, opts: opts, cancellationToken: cancellationToken));
+
+        Assert.Equal("callback failed", exception.Message);
+    }
+}

--- a/tests/NATS.Client.Core2.Tests/SubscriptionEventsTest.cs
+++ b/tests/NATS.Client.Core2.Tests/SubscriptionEventsTest.cs
@@ -156,4 +156,34 @@ public class SubscriptionEventsTest
 
         Assert.Equal("callback failed", exception.Message);
     }
+
+    [Fact]
+    public async Task OnSubscribed_exception_propagates_for_async_enumerable()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+        var subject = $"foo.{Guid.NewGuid():N}";
+
+        var opts = new NatsSubOpts
+        {
+            Events = new NatsSubEvents
+            {
+                OnSubscribed = _ => throw new InvalidOperationException("callback failed"),
+            },
+        };
+
+        // The subscription is only established when enumeration begins, so the
+        // callback exception surfaces on the first MoveNextAsync call.
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var unused in nats.SubscribeAsync<int>(subject, opts: opts, cancellationToken: cancellationToken))
+            {
+            }
+        });
+
+        Assert.Equal("callback failed", exception.Message);
+    }
 }


### PR DESCRIPTION
Adds an `Events` object to `NatsSubOpts` with an `OnSubscribed` callback, invoked once the subscription has been established, with the same guarantee `SubscribeCoreAsync` gives on completion. This lets callers that hand the `SubscribeAsync` enumerable off to another task find out when it is safe to trigger messages the subscription must see, following the ASP.NET Core events-object pattern discussed in the issue.

Fixes #1178