### PR TITLE
Add subject-dispatch serialization example

### DIFF
--- a/src/NATS.Client.Abstractions/INatsSerialize.cs
+++ b/src/NATS.Client.Abstractions/INatsSerialize.cs
@@ -20,6 +20,7 @@ public interface INatsSerializer<T> : INatsSerialize<T>, INatsDeserialize<T>
 /// Serializer interface for NATS messages.
 /// </summary>
 /// <typeparam name="T">Serialized object type</typeparam>
+/// <seealso cref="INatsSerializeWithContext{T}"/>
 public interface INatsSerialize<in T>
 {
     /// <summary>
@@ -34,6 +35,7 @@ public interface INatsSerialize<in T>
 /// Deserializer interface for NATS messages.
 /// </summary>
 /// <typeparam name="T">Deserialized object type</typeparam>
+/// <seealso cref="INatsDeserializeWithContext{T}"/>
 public interface INatsDeserialize<out T>
 {
     /// <summary>
@@ -47,7 +49,13 @@ public interface INatsDeserialize<out T>
 /// <summary>
 /// Extended serializer interface with access to message context during serialization.
 /// </summary>
+/// <remarks>
+/// The context carries the message <see cref="NatsMsgContext.Subject"/>, <see cref="NatsMsgContext.ReplyTo"/>
+/// and <see cref="NatsMsgContext.Headers"/>. To mutate headers during serialization the caller must pass a
+/// non-null headers instance to the publish call; see <see cref="NatsSerializationExtensions"/>.
+/// </remarks>
 /// <typeparam name="T">Serialized object type</typeparam>
+/// <seealso cref="NatsMsgContext"/>
 public interface INatsSerializeWithContext<in T> : INatsSerialize<T>
 {
     /// <summary>
@@ -62,7 +70,13 @@ public interface INatsSerializeWithContext<in T> : INatsSerialize<T>
 /// <summary>
 /// Extended deserializer interface with access to message context during deserialization.
 /// </summary>
+/// <remarks>
+/// The context carries the message <see cref="NatsMsgContext.Subject"/>, which can be used as a type
+/// discriminator when the schema is fixed per family of subjects rather than per stream (for example
+/// dispatching <c>orders.created.*</c> and <c>orders.cancelled.*</c> to different types).
+/// </remarks>
 /// <typeparam name="T">Deserialized object type</typeparam>
+/// <seealso cref="NatsMsgContext"/>
 public interface INatsDeserializeWithContext<out T> : INatsDeserialize<T>
 {
     /// <summary>

--- a/tests/NATS.Net.DocsExamples/Advanced/SerializationPage.cs
+++ b/tests/NATS.Net.DocsExamples/Advanced/SerializationPage.cs
@@ -321,6 +321,52 @@ public class MyHeaderAwareSerializer<T> : INatsSerializer<T>, INatsSerializerWit
 }
 #endregion
 
+#region subject-aware-deserializer
+public record OrderCreated
+{
+    public int OrderId { get; set; }
+}
+
+public record OrderCancelled
+{
+    public int OrderId { get; set; }
+
+    public string? Reason { get; set; }
+}
+
+[JsonSerializable(typeof(OrderCreated))]
+[JsonSerializable(typeof(OrderCancelled))]
+internal partial class OrderEventJsonContext : JsonSerializerContext
+{
+}
+
+// Picks the type to deserialize based on the message subject, for streams
+// where the schema is fixed per family of subjects rather than per stream,
+// e.g. orders.created.123 -> OrderCreated, orders.cancelled.123 -> OrderCancelled
+public class OrderEventDeserializer : INatsDeserializeWithContext<object>
+{
+    private readonly NatsJsonContextSerializer<OrderCreated> _created = new(OrderEventJsonContext.Default);
+    private readonly NatsJsonContextSerializer<OrderCancelled> _cancelled = new(OrderEventJsonContext.Default);
+
+    public object? Deserialize(in ReadOnlySequence<byte> buffer) =>
+        throw new NatsException("Subject is required to determine the event type");
+
+    public object? Deserialize(in ReadOnlySequence<byte> buffer, in NatsMsgContext context)
+    {
+        string[] tokens = context.Subject.Split('.');
+
+        return tokens.Length > 1
+            ? tokens[1] switch
+            {
+                "created" => _created.Deserialize(buffer),
+                "cancelled" => _cancelled.Deserialize(buffer),
+                _ => throw new NatsException($"Unknown event type in subject: {context.Subject}"),
+            }
+            : throw new NatsException($"Unexpected subject: {context.Subject}");
+    }
+}
+#endregion
+
 // Fake protobuf message.
 // Normally, this would be generated using protobuf compiler.
 public class Greeting : IBufferMessage

--- a/tools/site_src/documentation/advanced/serialization.md
+++ b/tools/site_src/documentation/advanced/serialization.md
@@ -99,6 +99,14 @@ Here is an example of a serializer that writes a content-type header during seri
 
 [!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/SerializationPage.cs#header-aware-serializer)]
 
+Note that the library does not create a headers instance on your behalf when publishing:
+a context-aware serializer can only add headers if the caller passed a headers instance to the publish call.
+
+The context also carries the message subject, which can be used as a type discriminator
+when the schema is fixed per family of subjects rather than per stream:
+
+[!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/SerializationPage.cs#subject-aware-deserializer)]
+
 ## Using Multiple Serializers (chaining)
 
 You can also chain multiple serializers together to support multiple serialization formats. The first serializer in the


### PR DESCRIPTION
Expands the message context section of the serialization docs with a subject-dispatch deserializer example, the use case raised in the linked issue, and notes that the library does not allocate a headers instance during publish, so context-aware serializers can only add headers when the caller passes an instance in.

Fixes #732