### PR TITLE
Audit transitive dependencies

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,50 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: audit ${{ matrix.branch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Add a release branch here once its dependency closure is clean, otherwise
+        # this job is red from the first run and everyone learns to ignore it.
+        branch:
+          - main
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      NUGET_XMLDOC_MODE: skip
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            6.x
+            8.x
+            10.x
+
+      # Audit runs at restore, so a branch nobody builds is never checked. This picks up
+      # advisories published against dependencies that have not themselves changed.
+      # Passed on the command line rather than read from Directory.Build.props so that
+      # release branches predating that property are still audited.
+      - name: Audit dependencies
+        run: >
+          dotnet restore NATS.Net.slnx --force
+          -p:NuGetAudit=true
+          -p:NuGetAuditMode=all
+          -p:NuGetAuditLevel=low

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,10 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);CS1591;SA0001</NoWarn>
+
+        <!--  Audit the full dependency graph, not just direct references. The default 'direct' mode
+              cannot see a vulnerable package pulled in by a dependency, which is where they usually are.  -->
+        <NuGetAuditMode>all</NuGetAuditMode>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -16,6 +16,9 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
         <PackageReference Include="ZLogger" Version="2.5.10" />
         <PackageReference Include="ProcessX" Version="1.5.6" />
+
+        <!--  ConsoleAppFramework 4.x pulls Microsoft.Extensions.Hosting 6.0.0, which resolves a vulnerable System.Text.Json  -->
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/NATS.Client.Platform.Windows.Tests/NATS.Client.Platform.Windows.Tests.csproj
+++ b/tests/NATS.Client.Platform.Windows.Tests/NATS.Client.Platform.Windows.Tests.csproj
@@ -24,8 +24,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'net481'" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" Condition="'$(TargetFramework)' == 'net481'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
+++ b/tests/NATS.Client.TestUtilities/NATS.Client.TestUtilities.csproj
@@ -14,8 +14,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="SemanticVersioning" Version="3.0.0" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="1.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/tools/Schema.Generation/Schema.Generation.csproj
+++ b/tools/Schema.Generation/Schema.Generation.csproj
@@ -11,8 +11,6 @@
     <ItemGroup>
       <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="11.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="System.Net.Http" Version="4.3.4" />
-      <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet audit runs in `direct` mode by default, so vulnerable packages reached through a dependency are never reported. Enabling full-graph auditing surfaced two vulnerable packages, both in test, sandbox and tooling projects rather than anything shipped. The first commit clears them, the second turns the audit on. Dependabot has the same blind spot, since GitHub's NuGet dependency graph for this repo resolves direct references only without lock files.

Audit only runs at restore, so a branch nobody builds is never checked. The scheduled job covers that. It starts on `main` only; `release/3.0` needs the same dependency fixes backported before it can be added to the matrix.
