### PR TITLE
Document OpenTelemetry subject redaction

### DIFF
--- a/src/NATS.Client.Core/NatsInstrumentationOptions.cs
+++ b/src/NATS.Client.Core/NatsInstrumentationOptions.cs
@@ -25,7 +25,9 @@ public sealed class NatsInstrumentationOptions
     /// <remarks>
     /// The return value for the filter function is interpreted as follows:
     /// - If filter returns `true`, the request is collected.
-    /// - If filter returns `false` or throws an exception the request is NOT collected.
+    /// - If filter returns `false`, the request is NOT collected.
+    /// The filter must not throw. Exceptions are not caught: they propagate out of the
+    /// publish call, and out of message construction on the receive path.
     /// </remarks>
     public Func<NatsInstrumentationContext, bool>? Filter
     {
@@ -36,6 +38,11 @@ public sealed class NatsInstrumentationOptions
     /// <summary>
     /// Gets or sets an action to enrich an Activity.
     /// </summary>
+    /// <remarks>
+    /// Runs after the activity is created and its tags are set, so it can also overwrite
+    /// tags the client set (for example to redact a subject). The action must not throw:
+    /// exceptions are not caught and propagate to the caller.
+    /// </remarks>
     public Action<Activity, NatsInstrumentationContext>? Enrich
     {
         get => _enrich;
@@ -47,6 +54,10 @@ public sealed class NatsInstrumentationOptions
     /// </summary>
     /// <remarks>
     /// The input is the raw NATS subject. This only changes activity names, not telemetry tags.
+    /// The returned value is used as-is, replacing the default first-two-tokens truncation.
+    /// Inbox subjects are collapsed to <c>inbox</c> before this runs, so the formatter is
+    /// never called for them. The formatter must not throw: exceptions are not caught and
+    /// propagate to the caller.
     /// </remarks>
     public Func<string, string>? SpanDestinationNameFormatter
     {

--- a/tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs
+++ b/tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs
@@ -143,6 +143,37 @@ public class OpenTelemetryPage
         }
 
         {
+            #region redaction
+            // Span names contain the first two subject tokens by default. Use
+            // SpanDestinationNameFormatter to control that, for example to keep only
+            // the leading token so no identifier reaches the span name.
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = subject =>
+            {
+                int firstDot = subject.IndexOf('.');
+                return firstDot < 0 ? subject : subject.Substring(0, firstDot);
+            };
+
+            // The formatter does not touch tags. Subject-bearing tags are redacted with
+            // Enrich, which runs after the client has set them, so SetTag overwrites.
+            NatsInstrumentationOptions.Default.Enrich = (activity, context) =>
+            {
+                foreach (string tag in new[]
+                         {
+                             "messaging.destination.name",
+                             "messaging.destination_publish.name",
+                             "messaging.destination.template",
+                             "messaging.nats.message.subject",
+                             "messaging.nats.message.reply_to",
+                         })
+                {
+                    if (activity.GetTagItem(tag) is not null)
+                        activity.SetTag(tag, "redacted");
+                }
+            };
+            #endregion
+        }
+
+        {
             #region baggage
             // Baggage propagation is off by default because baggage can carry
             // sensitive or high-cardinality data. Opt in explicitly:

--- a/tools/site_src/documentation/advanced/opentelemetry.md
+++ b/tools/site_src/documentation/advanced/opentelemetry.md
@@ -67,6 +67,47 @@ custom tags to every activity:
 
 [!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs#enrich)]
 
+`Enrich` runs after the activity is created and its tags are set, so `SetTag` overwrites tags the
+client set as well as adding new ones. That makes it the only way to change tag values; see
+[Span Names and Subject Redaction](#span-names-and-subject-redaction).
+
+## Span Names and Subject Redaction
+
+Activity names are `<destination> <operation>`, for example `orders.new publish`. The destination is
+derived from the subject: by default only the first two tokens are used, to keep span names short and
+their cardinality low, so `orders.new.eu.12345` becomes `orders.new`. Inbox subjects
+(`_INBOX.<nuid>...`) are collapsed to the constant `inbox`.
+
+Use [`NatsInstrumentationOptions.Default.SpanDestinationNameFormatter`](xref:NATS.Client.Core.NatsInstrumentationOptions)
+to control that yourself, for example when a subject carries an identifier in one of the first two
+tokens. The input is the raw subject and the return value is used as-is, replacing the two-token
+truncation rather than being truncated afterwards. Inbox collapsing happens first, so the formatter is
+never called for an inbox subject. It applies to publish, request, subscribe and receive spans:
+
+[!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs#redaction)]
+
+The formatter changes span names only, never tags. These tags carry subject values and can only be
+changed through `Enrich`:
+
+| Tag | Spans | Inbox collapsed |
+|---|---|---|
+| `messaging.destination.name` | publish, request, subscribe, receive | yes |
+| `messaging.destination_publish.name` | receive | yes |
+| `messaging.nats.message.subject` | receive | yes |
+| `messaging.nats.message.reply_to` | publish, receive, both only when the message has a reply-to | yes |
+| `messaging.destination.template` | receive | no |
+
+"Inbox collapsed" means a subject under the inbox prefix is reported as `inbox` instead of the unique
+value. `messaging.destination.template` is the exception: it carries the raw subject, so a request/reply
+reply span reports the full `_INBOX.<nuid>.<nuid>`. Redact or drop it if that matters to you.
+
+Metrics carry no subject on any instrument, so nothing needs redacting there.
+
+> [!IMPORTANT]
+> `Filter`, `Enrich` and `SpanDestinationNameFormatter` must not throw. Exceptions from them are not
+> caught: they propagate out of the publish call, and out of message construction on the receive path.
+> Wrap anything that can fail (a regex, a dictionary lookup, a parse) in your own try/catch.
+
 ## Baggage Propagation
 
 [W3C Baggage](https://www.w3.org/TR/baggage/) lets you attach arbitrary key/value context (a tenant ID,
@@ -117,7 +158,8 @@ The following attributes are set on activities:
 |---|---|---|
 | `messaging.system` | `nats` | Always `nats` |
 | `messaging.operation` | `publish` / `receive` | Operation type |
-| `messaging.destination.name` | `orders.new` | Subject name |
+| `messaging.destination.name` | `orders.new` | Subject name, inbox subjects reported as `inbox` |
+| `messaging.nats.message.reply_to` | `orders.reply` | Reply-to subject, on publish and receive spans only and only when the message has one, inbox subjects reported as `inbox` |
 | `messaging.client_id` | `42` | NATS client ID |
 | `server.address` | `localhost` | Server host |
 | `server.port` | `4222` | Server port |
@@ -131,10 +173,12 @@ Receive activities include additional attributes:
 
 | Attribute | Example | Description |
 |---|---|---|
-| `messaging.destination.template` | `orders.*` | Subscription subject pattern |
+| `messaging.nats.message.subject` | `orders.new` | Subject the message was delivered on, inbox subjects reported as `inbox` |
+| `messaging.destination_publish.name` | `orders.new` | Subject the message was published to, inbox subjects reported as `inbox` |
+| `messaging.destination.template` | `orders.new` | Delivered subject, raw and never collapsed, so a reply span carries the full inbox subject |
+| `messaging.destination.temporary` | `false` | `true` when the subject is under this connection's inbox prefix |
 | `messaging.message.body.size` | `1024` | Message body size in bytes |
 | `messaging.message.envelope.size` | `1280` | Total message size in bytes |
-| `messaging.consumer.group.name` | `workers` | Queue group (if used) |
 
 ## Metrics
 


### PR DESCRIPTION
> Waiting for #1236 to land first

Documents `SpanDestinationNameFormatter`, which tags carry subjects and which of them collapse inbox subjects, and that `Enrich` is the only way to change a tag value. Fills four missing rows in the semantic conventions tables, corrects `messaging.destination.template` (it is the delivered subject, not the subscription pattern) and drops `messaging.consumer.group.name`, which is never emitted. Also corrects `Filter`'s doc comment, which promised that a throwing filter means the request is not collected; none of the three callbacks are guarded.

Fixes #1221