### PR TITLE
Fix receive activity leak when tracing is enabled

### DIFF
--- a/src/NATS.Client.Core/Internal/ActivityEndingMsgReader.cs
+++ b/src/NATS.Client.Core/Internal/ActivityEndingMsgReader.cs
@@ -9,7 +9,11 @@ namespace NATS.Client.Core.Internal;
 // 2. Keep the NatsSubBase from being garbage collected as long as calls interacting
 //    with the _inner channel are being made
 // To achieve (1):
-// Calls that result in a read from the _inner channel should msg.Headers?.Activity?.Dispose()
+// Calls that result in a read from the _inner channel should Telemetry.EndActivity(msg.Headers?.Activity).
+// Ending it goes through Telemetry rather than Dispose() directly because Activity.Stop()
+// would otherwise clear the caller's Activity.Current: reads happen on the consumer's
+// execution context, and Stop() restores whatever was current when the activity started,
+// which for a receive activity is nothing.
 // To achieve (2):
 // Synchronous calls should call GC.KeepAlive(_sub); immediately before returning
 // Asynchronous calls should allocate a GCHandle.Alloc(_sub) at the start of the method,
@@ -70,7 +74,7 @@ internal sealed class ActivityEndingMsgReader<T> : ChannelReader<T>
         if (!_inner.TryRead(out item))
             return false;
 
-        item.Headers?.Activity?.Dispose();
+        Telemetry.EndActivity(item.Headers?.Activity);
 
         GC.KeepAlive(_sub);
         return true;
@@ -95,7 +99,7 @@ internal sealed class ActivityEndingMsgReader<T> : ChannelReader<T>
         try
         {
             var msg = await _inner.ReadAsync(cancellationToken).ConfigureAwait(false);
-            msg.Headers?.Activity?.Dispose();
+            Telemetry.EndActivity(msg.Headers?.Activity);
             return msg;
         }
         finally
@@ -123,7 +127,7 @@ internal sealed class ActivityEndingMsgReader<T> : ChannelReader<T>
             {
                 while (_inner.TryRead(out var msg))
                 {
-                    msg.Headers?.Activity?.Dispose();
+                    Telemetry.EndActivity(msg.Headers?.Activity);
                     yield return msg;
                 }
             }

--- a/src/NATS.Client.Core/Internal/ReplyTask.cs
+++ b/src/NATS.Client.Core/Internal/ReplyTask.cs
@@ -98,7 +98,7 @@ internal sealed class ReplyTask<T> : ReplyTaskBase, IDisposable
             // A server reply carries no trace context, so without the request's context
             // the receive activity would be a root span disconnected from the request it
             // belongs to.
-            _msg = NatsMsg<T>.Build(Subject, replyTo, headersBuffer, payload, _connection, _connection.HeaderParser, _deserializer, _requestContext);
+            _msg = NatsMsg<T>.BuildInternal(Subject, replyTo, headersBuffer, payload, _connection, _connection.HeaderParser, _deserializer, _requestContext);
             _isNoResponders = payload.Length == 0 && NatsSubBase.IsHeader503(headersBuffer);
             _replyBytes = payload.Length + (headersBuffer?.Length ?? 0);
         }

--- a/src/NATS.Client.Core/Internal/ReplyTask.cs
+++ b/src/NATS.Client.Core/Internal/ReplyTask.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Text;
 
 namespace NATS.Client.Core.Internal;
@@ -19,17 +20,19 @@ internal sealed class ReplyTask<T> : ReplyTaskBase, IDisposable
     private readonly TimeSpan _requestTimeout;
     private readonly bool _throwIfNoResponders;
     private readonly TaskCompletionSource _tcs;
+    private readonly ActivityContext _requestContext;
     private NatsMsg<T> _msg;
     private long _replyBytes;
     private bool _isNoResponders;
 
-    public ReplyTask(ReplyTaskFactory factory, long id, string subject, NatsConnection connection, INatsDeserialize<T> deserializer, TimeSpan requestTimeout, bool throwIfNoResponders)
+    public ReplyTask(ReplyTaskFactory factory, long id, string subject, NatsConnection connection, INatsDeserialize<T> deserializer, TimeSpan requestTimeout, bool throwIfNoResponders, ActivityContext requestContext)
     {
         _factory = factory;
         _id = id;
         Subject = subject;
         _connection = connection;
         _deserializer = deserializer;
+        _requestContext = requestContext;
         _requestTimeout = TimeoutValidation.Validate(requestTimeout, nameof(requestTimeout), Timeout.InfiniteTimeSpan);
         _throwIfNoResponders = throwIfNoResponders;
         _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -92,7 +95,10 @@ internal sealed class ReplyTask<T> : ReplyTaskBase, IDisposable
     {
         lock (_gate)
         {
-            _msg = NatsMsg<T>.Build(Subject, replyTo, headersBuffer, payload, _connection, _connection.HeaderParser, _deserializer);
+            // A server reply carries no trace context, so without the request's context
+            // the receive activity would be a root span disconnected from the request it
+            // belongs to.
+            _msg = NatsMsg<T>.Build(Subject, replyTo, headersBuffer, payload, _connection, _connection.HeaderParser, _deserializer, _requestContext);
             _isNoResponders = payload.Length == 0 && NatsSubBase.IsHeader503(headersBuffer);
             _replyBytes = payload.Length + (headersBuffer?.Length ?? 0);
         }
@@ -158,7 +164,12 @@ internal sealed class ReplyTaskFactory
             subject = _inboxPrefixString + id;
         }
 
-        var rt = new ReplyTask<TReply>(this, id, subject, _connection, deserializer, requestTimeout ?? _requestTimeout, throwIfNoResponders);
+        // Captured on the calling thread while the request activity is current, so it
+        // names the request this reply belongs to. Unlike the read loop's ambient
+        // context, this is a deterministic causal link rather than whatever ran last.
+        var requestContext = Activity.Current?.Context ?? default;
+
+        var rt = new ReplyTask<TReply>(this, id, subject, _connection, deserializer, requestTimeout ?? _requestTimeout, throwIfNoResponders, requestContext);
         _replies.TryAdd(id, rt);
         return rt;
     }

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -376,8 +376,7 @@ internal static class Telemetry
         }
         finally
         {
-            if (!ReferenceEquals(Activity.Current, ambient))
-                Activity.Current = ambient;
+            RestoreCurrentActivity(ambient);
         }
 
         if (activity is not null)
@@ -394,6 +393,50 @@ internal static class Telemetry
         }
 
         return activity;
+    }
+
+    /// <summary>
+    /// Puts back an <see cref="Activity.Current"/> saved earlier, falling back to its nearest
+    /// ancestor that is still running if the saved activity has since stopped.
+    /// </summary>
+    /// <remarks>
+    /// Activity.Current's setter silently refuses a finished activity, so assigning back a saved
+    /// ambient that stopped in the meantime does nothing and leaves Current pointing at whatever
+    /// was set since. The read loop's execution context is a snapshot holding the activity that
+    /// was current when the connection was created, which the application is free to stop at any
+    /// point, so this is a normal case rather than an edge one. Walking up to the closest living
+    /// ancestor keeps as much of the caller's context as the platform allows, and matches what
+    /// the OpenTelemetry API does when it deactivates a span it started as a root.
+    /// </remarks>
+    public static void RestoreCurrentActivity(Activity? ambient)
+    {
+        if (ReferenceEquals(Activity.Current, ambient))
+            return;
+
+        while (ambient is { IsStopped: true })
+            ambient = ambient.Parent;
+
+        Activity.Current = ambient;
+    }
+
+    /// <summary>
+    /// Ends a receive activity without disturbing <see cref="Activity.Current"/>.
+    /// </summary>
+    /// <remarks>
+    /// Activity.Stop() sets Current to whichever activity was current when the activity being
+    /// stopped was started, and it does so whether or not that activity is current on this
+    /// execution context. Receive activities are started with Current deliberately cleared, so
+    /// stopping one sets Current to null: ending a message's activity as the application reads
+    /// it would detach the span the application had current.
+    /// </remarks>
+    public static void EndActivity(Activity? activity)
+    {
+        if (activity is null)
+            return;
+
+        var ambient = Activity.Current;
+        activity.Dispose();
+        RestoreCurrentActivity(ambient);
     }
 
     public static void SetException(Activity? activity, Exception exception)

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -259,13 +259,19 @@ internal static class Telemetry
         string? replyTo,
         long bodySize,
         long size,
-        NatsHeaders? headers)
+        NatsHeaders? headers,
+        ActivityContext fallbackParentContext = default)
     {
         if (!NatsActivities.HasListeners())
             return null;
 
+        // Trace context carried by the message always wins: it is the real causal link,
+        // possibly from another process. The fallback is for messages that carry none but
+        // whose cause is known locally, i.e. a reply to a request this client is waiting
+        // on. It is an ActivityContext (ids only) rather than an Activity, so parenting
+        // never creates an object reference between activities.
         if (headers is null || !TryParseTraceContext(headers, out var context))
-            context = default;
+            context = fallbackParentContext;
 
         var options = NatsInstrumentationOptions.Default;
         IReadOnlyList<KeyValuePair<string, string?>>? baggage = null;
@@ -346,7 +352,7 @@ internal static class Telemetry
         }
 
         // A receive activity's parent comes exclusively from the message's trace
-        // context. The ambient
+        // context, or from the request this is a reply to. The ambient
         // Activity.Current here is unrelated: receive activities are created on the
         // connection's read loop (or on contexts inheriting from it), where Current
         // is whatever ran last, typically a previous message's activity. Letting

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -365,14 +365,20 @@ internal static class Telemetry
         if (ambient is not null)
             Activity.Current = null;
 
-        var activity = NatsActivities.StartActivity(
-            name,
-            kind: ActivityKind.Consumer,
-            parentContext: context,
-            tags: tags);
-
-        if (!ReferenceEquals(Activity.Current, ambient))
-            Activity.Current = ambient;
+        Activity? activity;
+        try
+        {
+            activity = NatsActivities.StartActivity(
+                name,
+                kind: ActivityKind.Consumer,
+                parentContext: context,
+                tags: tags);
+        }
+        finally
+        {
+            if (!ReferenceEquals(Activity.Current, ambient))
+                Activity.Current = ambient;
+        }
 
         if (activity is not null)
         {

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -345,11 +345,28 @@ internal static class Telemetry
                 tags[9] = new KeyValuePair<string, object?>(Constants.ReplyTo, replyTo);
         }
 
+        // A receive activity's parent comes exclusively from the message's trace
+        // context. The ambient
+        // Activity.Current here is unrelated: receive activities are created on the
+        // connection's read loop (or on contexts inheriting from it), where Current
+        // is whatever ran last, typically a previous message's activity. Letting
+        // StartActivity fall back to it as parent chains unrelated messages together,
+        // and leaving the new activity in Current roots the whole chain through the
+        // read loop's AsyncLocal for the connection's lifetime. Clear Current around
+        // the start call and restore it so the caller's execution context is left
+        // exactly as it was.
+        var ambient = Activity.Current;
+        if (ambient is not null)
+            Activity.Current = null;
+
         var activity = NatsActivities.StartActivity(
             name,
             kind: ActivityKind.Consumer,
             parentContext: context,
             tags: tags);
+
+        if (!ReferenceEquals(Activity.Current, ambient))
+            Activity.Current = ambient;
 
         if (activity is not null)
         {

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -60,8 +60,9 @@ public partial class NatsConnection
                         await PublishAsync(subject, data, headers, rt.Subject, requestSerializer, requestOpts, cancellationToken).ConfigureAwait(false);
                         var msg = await rt.GetResultAsync(cancellationToken).ConfigureAwait(false);
 
-                        // Dispose activity from headers to avoid leaking it
-                        msg.Headers?.Activity?.Dispose();
+                        // End the activity from the headers to avoid leaking it. Direct mode
+                        // materializes the reply on the read loop, so nothing else ends it.
+                        Telemetry.EndActivity(msg.Headers?.Activity);
 
                         return msg;
                     }

--- a/src/NATS.Client.Core/NatsConnection.RequestSub.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestSub.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using NATS.Client.Core.Internal;
 
 namespace NATS.Client.Core;
@@ -25,7 +26,12 @@ public partial class NatsConnection
         var replyTo = NewInbox();
 
         replySerializer ??= Opts.SerializerRegistry.GetDeserializer<TReply>();
-        var sub = new NatsSub<TReply>(this, _subscriptionManager.InboxSubBuilder, replyTo, queueGroup: default, replyOpts, replySerializer);
+        var sub = new NatsSub<TReply>(this, _subscriptionManager.InboxSubBuilder, replyTo, queueGroup: default, replyOpts, replySerializer)
+        {
+            // Captured on the calling thread while the request activity is current, so
+            // replies arriving without trace context are traced under their request.
+            ReplyParentContext = Activity.Current?.Context ?? default,
+        };
         await AddSubAsync(sub, cancellationToken).ConfigureAwait(false);
 
         requestSerializer ??= Opts.SerializerRegistry.GetSerializer<TRequest>();

--- a/src/NATS.Client.Core/NatsConnection.RequestSub.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestSub.cs
@@ -28,8 +28,12 @@ public partial class NatsConnection
         replySerializer ??= Opts.SerializerRegistry.GetDeserializer<TReply>();
         var sub = new NatsSub<TReply>(this, _subscriptionManager.InboxSubBuilder, replyTo, queueGroup: default, replyOpts, replySerializer)
         {
-            // Captured on the calling thread while the request activity is current, so
-            // replies arriving without trace context are traced under their request.
+            // Set from the caller's current activity. On the request path that starts a NATS
+            // request activity this is that activity, so replies arriving without trace
+            // context are traced under their request. Paths that start no request activity,
+            // RequestMany and the JetStream shared-inbox publish and API calls, supply their
+            // caller's ambient span instead: a weaker link, but still the work that caused
+            // the request. Only ids are captured, so this never keeps an activity alive.
             ReplyParentContext = Activity.Current?.Context ?? default,
         };
         await AddSubAsync(sub, cancellationToken).ConfigureAwait(false);

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -294,6 +294,11 @@ public partial class NatsConnection : INatsConnection
         if (Telemetry.DroppedMessages.Enabled)
             Telemetry.DroppedMessages.Add(1, Telemetry.BuildMetricTags(this, Telemetry.Constants.OpRec));
 
+        // A dropped message never reaches a consumer, and it is the read from the subscription
+        // channel that ends a receive activity. This is the only place the dropped message is
+        // still in hand, so it is the last chance to end its activity.
+        Telemetry.EndActivity(msg.Headers?.Activity);
+
         var subject = msg.Subject;
         PushEvent(NatsEvent.MessageDropped, new NatsMessageDroppedEventArgs(natsSub, pending, subject, msg.ReplyTo, msg.Headers, msg.Data));
 

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using NATS.Client.Core.Commands;
@@ -333,6 +334,38 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
         INatsConnection? connection,
         NatsHeaderParser headerParser,
         INatsDeserialize<T> serializer)
+        => Build(subject, replyTo, headersBuffer, payloadBuffer, connection, headerParser, serializer, default);
+
+    /// <summary>
+    /// Builds a new instance of a <see cref="NatsMsg{T}"/> with the specified parameters.
+    /// </summary>
+    /// <remarks>
+    /// (INTERNAL API) This method is intended for internal use only. it doesn't have the same
+    /// guarantees as the public API. it may change in future versions with no notice.
+    /// </remarks>
+    /// <param name="subject">The subject string associated with the message.</param>
+    /// <param name="replyTo">The optional reply-to subject string.</param>
+    /// <param name="headersBuffer">The optional buffer containing the message headers.</param>
+    /// <param name="payloadBuffer">The buffer containing the message payload.</param>
+    /// <param name="connection">The connection associated with the message.</param>
+    /// <param name="headerParser">The parser for processing message headers.</param>
+    /// <param name="serializer">The deserializer for the message payload.</param>
+    /// <param name="replyParentContext">
+    /// Parent for the receive activity when the message carries no trace context of its own.
+    /// Set by the request/reply paths so a reply is traced under the request that caused it.
+    /// Pass <c>default</c> for messages that are not replies.
+    /// </param>
+    /// <returns>A new <see cref="NatsMsg{T}"/> instance containing the provided data.</returns>
+    /// <exception cref="NatsException">Thrown if there is an error during the processing of the message.</exception>
+    public static NatsMsg<T> Build(
+        string subject,
+        string? replyTo,
+        in ReadOnlySequence<byte>? headersBuffer,
+        in ReadOnlySequence<byte> payloadBuffer,
+        INatsConnection? connection,
+        NatsHeaderParser headerParser,
+        INatsDeserialize<T> serializer,
+        ActivityContext replyParentContext)
     {
         NatsHeaders? headers = null;
         var flags = NatsMsgFlags.None;
@@ -386,7 +419,8 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
                 replyTo: replyTo,
                 bodySize: payloadBuffer.Length,
                 size: size,
-                headers: headers);
+                headers: headers,
+                fallbackParentContext: replyParentContext);
 
             if (activity is not null)
             {

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -334,7 +334,7 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
         INatsConnection? connection,
         NatsHeaderParser headerParser,
         INatsDeserialize<T> serializer)
-        => Build(subject, replyTo, headersBuffer, payloadBuffer, connection, headerParser, serializer, default);
+        => BuildInternal(subject, replyTo, headersBuffer, payloadBuffer, connection, headerParser, serializer, default);
 
     /// <summary>
     /// Builds a new instance of a <see cref="NatsMsg{T}"/> with the specified parameters.
@@ -357,7 +357,7 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
     /// </param>
     /// <returns>A new <see cref="NatsMsg{T}"/> instance containing the provided data.</returns>
     /// <exception cref="NatsException">Thrown if there is an error during the processing of the message.</exception>
-    public static NatsMsg<T> Build(
+    internal static NatsMsg<T> BuildInternal(
         string subject,
         string? replyTo,
         in ReadOnlySequence<byte>? headersBuffer,

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -42,7 +42,7 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
 
     protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
     {
-        var natsMsg = NatsMsg<T>.Build(
+        var natsMsg = NatsMsg<T>.BuildInternal(
             subject,
             replyTo,
             headersBuffer,

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading.Channels;
 using NATS.Client.Core.Internal;
@@ -30,6 +31,13 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
 
     public ChannelReader<NatsMsg<T>> Msgs { get; }
 
+    /// <summary>
+    /// Parent for receive activities when a message carries no trace context. Set only on
+    /// the reply subscription of a request so replies are traced under their request;
+    /// stays default for ordinary subscriptions, which have no such causal link.
+    /// </summary>
+    internal ActivityContext ReplyParentContext { get; set; }
+
     private INatsDeserialize<T> Serializer { get; }
 
     protected override async ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
@@ -41,7 +49,8 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
             payloadBuffer,
             Connection,
             Connection.HeaderParser,
-            Serializer);
+            Serializer,
+            ReplyParentContext);
 
         await _msgs.Writer.WriteAsync(natsMsg).ConfigureAwait(false);
 

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -52,6 +52,8 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
             Serializer,
             ReplyParentContext);
 
+        ReceiveActivity = natsMsg.Headers?.Activity;
+
         await _msgs.Writer.WriteAsync(natsMsg).ConfigureAwait(false);
 
         ResetSlowConsumer(_msgs.Reader.Count);

--- a/src/NATS.Client.Core/NatsSubBase.cs
+++ b/src/NATS.Client.Core/NatsSubBase.cs
@@ -200,6 +200,18 @@ public abstract class NatsSubBase
     internal NatsSubOpts? Opts { get; private set; }
 
     /// <summary>
+    /// Receive activity of the message currently being handed off, so that a failure part way
+    /// through can be recorded against the right span. Set by <see cref="ReceiveInternalAsync"/>
+    /// implementations once they have built the message; <see cref="ReceiveAsync"/> clears it.
+    /// </summary>
+    /// <remarks>
+    /// Receive activities are deliberately kept out of <see cref="Activity.Current"/>, so the
+    /// failing message's activity has to be passed along explicitly. A plain property is enough
+    /// because the read loop delivers to a given subscription one message at a time.
+    /// </remarks>
+    internal Activity? ReceiveActivity { get; set; }
+
+    /// <summary>
     /// Represents a connection to the NATS server.
     /// </summary>
     protected INatsConnection Connection { get; }
@@ -364,10 +376,12 @@ public abstract class NatsSubBase
             }
         }
 
+        var handedOff = false;
         try
         {
             // Need to await to handle any exceptions
             await ReceiveInternalAsync(subject, replyTo, headersBuffer, payloadBuffer).ConfigureAwait(false);
+            handedOff = true;
 
             // Per OTel messaging semconv, consumed.messages counts messages "delivered to
             // the application", so we only record after ReceiveInternalAsync has completed
@@ -422,7 +436,21 @@ public abstract class NatsSubBase
 
             SetException(new NatsSubException($"Message error: {e.Message}", ExceptionDispatchInfo.Capture(e), payload, headers));
 
-            Telemetry.SetException(Activity.Current, e);
+            // The failing message's receive activity, not Activity.Current: receive activities
+            // are kept off the ambient context, which here holds whatever the read loop's
+            // execution context was created with.
+            Telemetry.SetException(ReceiveActivity, e);
+        }
+        finally
+        {
+            var activity = ReceiveActivity;
+            ReceiveActivity = null;
+
+            // A message that was never handed off has no consumer to read it, and it is the
+            // read from the subscription channel that ends a receive activity. Nothing else
+            // would ever end this one.
+            if (!handedOff)
+                Telemetry.EndActivity(activity);
         }
     }
 

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -484,6 +484,8 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
                     _serializer),
                 _context);
 
+            ReceiveActivity = msg.Headers?.Activity;
+
             NatsJSExtensionsInternal.TrySetPinIdFromHeaders(msg.Headers, _jsConsumer);
 
             // We can't pass cancellation token here because we need to hand

--- a/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
@@ -288,6 +288,8 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
                     _serializer),
                 _context);
 
+            ReceiveActivity = msg.Headers?.Activity;
+
             NatsJSExtensionsInternal.TrySetPinIdFromHeaders(msg.Headers, _jsConsumer);
 
             _pendingMsgs--;

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
@@ -291,6 +291,8 @@ internal class NatsJSOrderedConsume<TMsg> : NatsSubBase
                     _serializer),
                 _context);
 
+            ReceiveActivity = msg.Headers?.Activity;
+
             lock (_pendingGate)
             {
                 if (_pendingMsgs > 0)

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
@@ -57,6 +57,44 @@ public class NatsConnectionTelemetryTests
     }
 
     [Fact]
+    public async Task StartReceiveActivity_leaves_ambient_current_untouched_and_does_not_parent_to_it()
+    {
+        // Receive activities are started on the connection's read loop, where
+        // Activity.Current is whatever ran last on that execution context. Parenting to
+        // it would chain unrelated messages together and keep the chain reachable
+        // through the read loop's AsyncLocal, and leaving the new activity in Current
+        // would root it there for the connection's lifetime.
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource || source.Name == "test-ambient",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var ambientSource = new ActivitySource("test-ambient");
+        using var ambient = ambientSource.StartActivity("ambient");
+        ambient.Should().NotBeNull();
+        Activity.Current.Should().BeSameAs(ambient);
+
+        await using var nats = new NatsConnection();
+
+        using var activity = Telemetry.StartReceiveActivity(
+            nats,
+            name: "receive",
+            subscriptionSubject: "foo.bar",
+            queueGroup: null,
+            subject: "foo.bar",
+            replyTo: null,
+            bodySize: 0,
+            size: 0,
+            headers: null);
+
+        activity.Should().NotBeNull();
+        activity!.Parent.Should().BeNull();
+        Activity.Current.Should().BeSameAs(ambient);
+    }
+
+    [Fact]
     public async Task SpanDestinationName_uses_configured_formatter()
     {
         var previous = NatsInstrumentationOptions.Default.SpanDestinationNameFormatter;

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
@@ -1,4 +1,6 @@
+using System.Buffers;
 using System.Diagnostics;
+using System.Text;
 using NATS.Client.Core.Internal;
 
 namespace NATS.Client.CoreUnit.Tests;
@@ -95,6 +97,140 @@ public class NatsConnectionTelemetryTests
     }
 
     [Fact]
+    public async Task StartReceiveActivity_clears_current_when_the_ambient_activity_has_stopped()
+    {
+        // The read loop captures Activity.Current when it starts, so it can hold an activity
+        // the application later stops. Activity.Current's setter silently refuses to make a
+        // finished activity current again, which makes restoring the saved ambient a no-op
+        // and leaves the receive activity in Current on the read loop for good.
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource || source.Name == "test-ambient",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var nats = new NatsConnection();
+
+        using var ambientSource = new ActivitySource("test-ambient");
+        using var ambient = ambientSource.StartActivity("ambient");
+        ambient.Should().NotBeNull();
+
+        // Capture the execution context while the ambient activity is still running, the way
+        // the read loop does, then stop the activity from outside that context.
+        var gate = new SemaphoreSlim(0);
+        var probe = Task.Run(async () =>
+        {
+            await gate.WaitAsync().ConfigureAwait(false);
+
+            Activity.Current.Should().BeSameAs(ambient, "the captured context still holds the activity after it stops");
+
+            using var activity = Telemetry.StartReceiveActivity(
+                nats,
+                name: "receive",
+                subscriptionSubject: "foo.bar",
+                queueGroup: null,
+                subject: "foo.bar",
+                replyTo: null,
+                bodySize: 0,
+                size: 0,
+                headers: null);
+
+            activity.Should().NotBeNull();
+
+            return Activity.Current;
+        });
+
+        ambient!.Stop();
+        gate.Release();
+
+        var current = await probe;
+
+        current.Should().BeNull("a stopped ambient cannot be restored, so Current must be cleared instead of left holding the receive activity");
+    }
+
+    [Fact]
+    public async Task StartReceiveActivity_restores_the_nearest_running_ancestor_of_a_stopped_ambient()
+    {
+        // Clearing Current outright is only necessary as far up as the stopped activities go.
+        // If the saved ambient stopped but its parent is still running, that parent is the
+        // closest thing to the context the caller had.
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource || source.Name == "test-ambient",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var nats = new NatsConnection();
+
+        using var ambientSource = new ActivitySource("test-ambient");
+        using var outer = ambientSource.StartActivity("outer");
+        using var inner = ambientSource.StartActivity("inner");
+        inner!.Parent.Should().BeSameAs(outer);
+
+        var gate = new SemaphoreSlim(0);
+        var probe = Task.Run(async () =>
+        {
+            await gate.WaitAsync().ConfigureAwait(false);
+
+            using var activity = Telemetry.StartReceiveActivity(
+                nats,
+                name: "receive",
+                subscriptionSubject: "foo.bar",
+                queueGroup: null,
+                subject: "foo.bar",
+                replyTo: null,
+                bodySize: 0,
+                size: 0,
+                headers: null);
+
+            activity.Should().NotBeNull();
+
+            return Activity.Current;
+        });
+
+        // Only the inner activity stops; the outer one is still running.
+        inner.Stop();
+        gate.Release();
+
+        var current = await probe;
+
+        current.Should().BeSameAs(outer);
+    }
+
+    [Fact]
+    public async Task Reading_a_message_leaves_the_consumer_current_activity_untouched()
+    {
+        // Activity.Stop() sets Current to the activity's Parent whether or not the activity
+        // is current on this context. Receive activities are parented by context and so have
+        // no Parent, which means ending one as the consumer reads its message would clear
+        // whatever span the application had current.
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource || source.Name == "test-app",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var nats = new NatsConnection();
+        var sub = new NatsSub<string>(nats, new NoopSubscriptionManager(), "foo.bar", queueGroup: null, opts: null, NatsDefaultSerializer<string>.Default);
+
+        // Hand a message off the way the read loop does: no ambient activity current.
+        await sub.ReceiveAsync("foo.bar", replyTo: null, headersBuffer: null, payloadBuffer: new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("hi")));
+
+        using var appSource = new ActivitySource("test-app");
+        using var app = appSource.StartActivity("app");
+        Activity.Current.Should().BeSameAs(app);
+
+        sub.Msgs.TryRead(out var msg).Should().BeTrue();
+
+        msg.Headers?.Activity.Should().NotBeNull();
+        msg.Headers!.Activity!.IsStopped.Should().BeTrue("reading the message ends its receive activity");
+        Activity.Current.Should().BeSameAs(app);
+    }
+
+    [Fact]
     public async Task SpanDestinationName_uses_configured_formatter()
     {
         var previous = NatsInstrumentationOptions.Default.SpanDestinationNameFormatter;
@@ -128,5 +264,10 @@ public class NatsConnectionTelemetryTests
         {
             NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = previous;
         }
+    }
+
+    private sealed class NoopSubscriptionManager : INatsSubscriptionManager
+    {
+        public ValueTask RemoveAsync(NatsSubBase sub) => default;
     }
 }

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using System.Text;
+using System.Threading.Channels;
 using NATS.Client.Core.Internal;
 
 namespace NATS.Client.CoreUnit.Tests;
@@ -231,6 +232,80 @@ public class NatsConnectionTelemetryTests
     }
 
     [Fact]
+    public async Task Dropping_a_message_ends_its_receive_activity()
+    {
+        // A message evicted from a full subscription channel never reaches a consumer, so the
+        // read that would have ended its receive activity never happens.
+        var subject = $"drop.{Guid.NewGuid():N}";
+        var started = new List<Activity>();
+
+        // The listener is process-global, so only count activities for this test's subject.
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a =>
+            {
+                if (a.GetTagItem(Telemetry.Constants.DestName) is string name && name == subject)
+                {
+                    lock (started)
+                        started.Add(a);
+                }
+            },
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var nats = new NatsConnection();
+        var opts = new NatsSubOpts { ChannelOpts = new NatsSubChannelOpts { Capacity = 1, FullMode = BoundedChannelFullMode.DropOldest } };
+        var sub = new NatsSub<string>(nats, new NoopSubscriptionManager(), subject, queueGroup: null, opts, NatsDefaultSerializer<string>.Default);
+
+        await sub.ReceiveAsync(subject, replyTo: null, headersBuffer: null, payloadBuffer: new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("first")));
+        await sub.ReceiveAsync(subject, replyTo: null, headersBuffer: null, payloadBuffer: new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("second")));
+
+        // Only the second message is still in the channel; the first one was evicted.
+        sub.Msgs.TryRead(out var kept).Should().BeTrue();
+        kept.Data.Should().Be("second");
+        sub.Msgs.TryRead(out _).Should().BeFalse();
+
+        started.Should().HaveCount(2);
+        started.Should().AllSatisfy(a => a.IsStopped.Should().BeTrue(
+            "the kept message is ended by the read and the dropped one when it is evicted"));
+    }
+
+    [Fact]
+    public async Task Receive_failure_is_recorded_on_the_receive_activity_of_the_failing_message()
+    {
+        // Before receive activities were kept off the ambient context, the failing message's
+        // activity happened to be Activity.Current in the handler below. It no longer is, so
+        // the exception has to be recorded against the activity the message actually carries,
+        // and that activity has to be ended: it never reaches a consumer to be ended there.
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource || source.Name == "test-app",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var nats = new NatsConnection();
+        var sub = new ThrowingSub(nats);
+
+        using var appSource = new ActivitySource("test-app");
+        using var app = appSource.StartActivity("app");
+
+        await sub.ReceiveAsync("foo.bar", replyTo: null, headersBuffer: null, payloadBuffer: new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("hi")));
+
+        var activity = sub.BuiltActivity;
+        activity.Should().NotBeNull();
+        activity!.Status.Should().Be(ActivityStatusCode.Error);
+        activity.Events.Should().Contain(e => e.Name == "exception");
+        activity.IsStopped.Should().BeTrue("a message that never reaches a consumer has nowhere else to be ended");
+
+        app.Should().NotBeNull();
+        app!.Status.Should().Be(ActivityStatusCode.Unset, "the application's span did not fail");
+        Activity.Current.Should().BeSameAs(app);
+    }
+
+    [Fact]
     public async Task SpanDestinationName_uses_configured_formatter()
     {
         var previous = NatsInstrumentationOptions.Default.SpanDestinationNameFormatter;
@@ -269,5 +344,31 @@ public class NatsConnectionTelemetryTests
     private sealed class NoopSubscriptionManager : INatsSubscriptionManager
     {
         public ValueTask RemoveAsync(NatsSubBase sub) => default;
+    }
+
+    // Stands in for the receive paths that can fail after building the message, such as the
+    // JetStream subscriptions parsing consumer metadata off the reply subject.
+    private sealed class ThrowingSub : NatsSubBase
+    {
+        public ThrowingSub(INatsConnection connection)
+            : base(connection, new NoopSubscriptionManager(), "foo.bar", queueGroup: null, opts: null)
+        {
+        }
+
+        public Activity? BuiltActivity { get; private set; }
+
+        protected override ValueTask ReceiveInternalAsync(string subject, string? replyTo, ReadOnlySequence<byte>? headersBuffer, ReadOnlySequence<byte> payloadBuffer)
+        {
+            var msg = NatsMsg<string>.Build(subject, replyTo, headersBuffer, payloadBuffer, Connection, Connection.HeaderParser, NatsDefaultSerializer<string>.Default);
+            BuiltActivity = msg.Headers?.Activity;
+            ReceiveActivity = BuiltActivity;
+
+            // Not a SystemException: those are deliberately left to propagate out of ReceiveAsync.
+            throw new NatsException("receive failed");
+        }
+
+        protected override void TryComplete()
+        {
+        }
     }
 }

--- a/tests/NATS.Net.OpenTelemetry.Tests/ActivityTracker.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/ActivityTracker.cs
@@ -11,6 +11,7 @@ internal sealed class ActivityTracker : IDisposable
     private readonly List<Activity> _started = new();
     private readonly List<Activity> _stopped = new();
     private readonly ActivityListener _listener;
+    private readonly object _sync = new();
 
     public ActivityTracker()
     {
@@ -19,23 +20,47 @@ internal sealed class ActivityTracker : IDisposable
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
             ShouldListenTo = source => source.Name.StartsWith("NATS.Net"),
-            ActivityStarted = _started.Add,
-            ActivityStopped = _stopped.Add,
+
+            // Activities start and stop on the connection's read loop and on consumer
+            // loops, so these callbacks run concurrently with the test thread. Plain
+            // List.Add from several threads loses entries and makes the counts lie.
+            ActivityStarted = a =>
+            {
+                lock (_sync)
+                    _started.Add(a);
+            },
+            ActivityStopped = a =>
+            {
+                lock (_sync)
+                    _stopped.Add(a);
+            },
         };
         ActivitySource.AddActivityListener(_listener);
     }
 
-    public IReadOnlyList<Activity> Started => _started;
+    public IReadOnlyList<Activity> Started
+    {
+        get
+        {
+            lock (_sync)
+                return _started.ToArray();
+        }
+    }
 
-    public IReadOnlyList<Activity> Stopped => _stopped;
+    public IReadOnlyList<Activity> Stopped
+    {
+        get
+        {
+            lock (_sync)
+                return _stopped.ToArray();
+        }
+    }
 
     public void AssertAllStopped()
     {
-        Assert.NotEmpty(_started);
+        Assert.NotEmpty(Started);
 
-        var leaked = _started
-            .Where(started => !_stopped.Any(stopped => stopped.Id == started.Id))
-            .ToList();
+        var leaked = Leaked();
 
         if (leaked.Count > 0)
         {
@@ -45,4 +70,13 @@ internal sealed class ActivityTracker : IDisposable
     }
 
     public void Dispose() => _listener.Dispose();
+
+    private List<Activity> Leaked()
+    {
+        lock (_sync)
+        {
+            var stopped = new HashSet<string>(_stopped.Select(a => a.Id!));
+            return _started.Where(a => !stopped.Contains(a.Id!)).ToList();
+        }
+    }
 }

--- a/tests/NATS.Net.OpenTelemetry.Tests/ActivityTracker.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/ActivityTracker.cs
@@ -6,8 +6,18 @@ namespace NATS.Client.Core.Tests;
 /// Listens to all "NATS.Net" activity sources and records started/stopped activities
 /// so tests can inspect and assert on the telemetry the client emits.
 /// </summary>
+/// <remarks>
+/// ActivityListener is process-global and xUnit runs test classes concurrently, so a tracker
+/// also sees activities belonging to other test classes: receive activities in particular are
+/// started on connection read loops, which are ordinary background threads outside xUnit's
+/// concurrency control. Anything asserting on counts or on the absence of activities must
+/// therefore scope itself to its own connection, which the ServerPort overloads do since each
+/// test starts its own nats-server on its own port.
+/// </remarks>
 internal sealed class ActivityTracker : IDisposable
 {
+    private const string ServerPortTag = "server.port";
+
     private readonly List<Activity> _started = new();
     private readonly List<Activity> _stopped = new();
     private readonly ActivityListener _listener;
@@ -56,11 +66,22 @@ internal sealed class ActivityTracker : IDisposable
         }
     }
 
-    public void AssertAllStopped()
-    {
-        Assert.NotEmpty(Started);
+    /// <summary>
+    /// Activities started by a connection to the given server port.
+    /// </summary>
+    public IReadOnlyList<Activity> StartedFor(int serverPort) => Started.Where(a => IsForServer(a, serverPort)).ToList();
 
-        var leaked = Leaked();
+    public void AssertAllStopped(int serverPort)
+    {
+        var started = StartedFor(serverPort);
+        Assert.NotEmpty(started);
+
+        List<Activity> leaked;
+        lock (_sync)
+        {
+            var stopped = new HashSet<string>(_stopped.Select(a => a.Id!));
+            leaked = started.Where(a => !stopped.Contains(a.Id!)).ToList();
+        }
 
         if (leaked.Count > 0)
         {
@@ -71,12 +92,5 @@ internal sealed class ActivityTracker : IDisposable
 
     public void Dispose() => _listener.Dispose();
 
-    private List<Activity> Leaked()
-    {
-        lock (_sync)
-        {
-            var stopped = new HashSet<string>(_stopped.Select(a => a.Id!));
-            return _started.Where(a => !stopped.Contains(a.Id!)).ToList();
-        }
-    }
+    private static bool IsForServer(Activity activity, int serverPort) => activity.GetTagItem(ServerPortTag) is int port && port == serverPort;
 }

--- a/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
@@ -30,7 +30,7 @@ public class OpenTelemetryTest
         var expectedHost = new Uri(server.Url).Host;
         var expectedClientId = nats.ServerInfo!.ClientId.ToString();
         AssertActivityData("foo", tracker.Started, expectedHost, expectedClientId);
-        tracker.AssertAllStopped();
+        tracker.AssertAllStopped(server.Port);
     }
 
     [Fact]
@@ -74,7 +74,7 @@ public class OpenTelemetryTest
         // Verify the parent relationship (consume activity should have publish as parent via trace context)
         Assert.Equal(publishActivity.TraceId, consumeActivity.TraceId);
 
-        tracker.AssertAllStopped();
+        tracker.AssertAllStopped(server.Port);
     }
 
     [Fact]
@@ -436,7 +436,7 @@ public class OpenTelemetryTest
         var reply = await nats.RequestAsync<int, int>("foo.direct", 21, cancellationToken: cts.Token);
         Assert.Equal(42, reply.Data);
 
-        tracker.AssertAllStopped();
+        tracker.AssertAllStopped(server.Port);
 
         await sub.DisposeAsync();
         await reg;

--- a/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
@@ -41,6 +41,38 @@ public class ReceiveActivityLifecycleTest
     }
 
     [Fact]
+    public async Task Reply_receive_activity_is_traced_under_its_request()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            RequestReplyMode = NatsRequestReplyMode.Direct,
+        });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        // Connect outside any activity so the read loop cannot capture one, leaving the
+        // request context as the only thing that can parent the reply.
+        await nats.ConnectAsync();
+
+        var js = new NatsJSContext(nats);
+        await js.GetAccountInfoAsync(cts.Token);
+
+        var request = tracker.Started.Single(a => a.OperationName.EndsWith(" request", StringComparison.Ordinal));
+        var receive = tracker.Started.Single(a => a.Kind == ActivityKind.Consumer);
+
+        // The reply carries no trace context of its own, so it takes the request as
+        // parent: one trace covering the request, its publish and the reply.
+        receive.TraceId.Should().Be(request.TraceId);
+        receive.ParentSpanId.Should().Be(request.SpanId);
+
+        // Parented by context, not by reference; a reference is what leaked.
+        receive.Parent.Should().BeNull();
+    }
+
+    [Fact]
     public async Task Receive_activities_do_not_join_the_trace_ambient_at_connect_time()
     {
         using var tracker = new ActivityTracker();

--- a/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
@@ -30,7 +30,7 @@ public class ReceiveActivityLifecycleTest
             await js.GetAccountInfoAsync(cts.Token);
         }
 
-        var consumers = tracker.Started.Where(a => a.Kind == ActivityKind.Consumer).ToList();
+        var consumers = tracker.StartedFor(server.Port).Where(a => a.Kind == ActivityKind.Consumer).ToList();
         consumers.Should().HaveCount(5);
         consumers.Should().AllSatisfy(a => a.Parent.Should().BeNull(
             "receive activities must parent only by context, never by holding the ambient Activity"));
@@ -38,6 +38,8 @@ public class ReceiveActivityLifecycleTest
         // Each reply belongs to its own request, so they must land in five distinct
         // traces. Chaining would collapse them into one.
         consumers.Select(a => a.TraceId).Distinct().Should().HaveCount(5);
+
+        tracker.AssertAllStopped(server.Port);
     }
 
     [Fact]
@@ -60,8 +62,9 @@ public class ReceiveActivityLifecycleTest
         var js = new NatsJSContext(nats);
         await js.GetAccountInfoAsync(cts.Token);
 
-        var request = tracker.Started.Single(a => a.OperationName.EndsWith(" request", StringComparison.Ordinal));
-        var receive = tracker.Started.Single(a => a.Kind == ActivityKind.Consumer);
+        var activities = tracker.StartedFor(server.Port);
+        var request = activities.Single(a => a.OperationName.EndsWith(" request", StringComparison.Ordinal));
+        var receive = activities.Single(a => a.Kind == ActivityKind.Consumer);
 
         // The reply carries no trace context of its own, so it takes the request as
         // parent: one trace covering the request, its publish and the reply.
@@ -70,6 +73,8 @@ public class ReceiveActivityLifecycleTest
 
         // Parented by context, not by reference; a reference is what leaked.
         receive.Parent.Should().BeNull();
+
+        tracker.AssertAllStopped(server.Port);
     }
 
     [Fact]
@@ -109,10 +114,12 @@ public class ReceiveActivityLifecycleTest
             await js.GetAccountInfoAsync(cts.Token);
         }
 
-        var receives = tracker.Started.Where(a => a.Kind == ActivityKind.Consumer).ToList();
+        var receives = tracker.StartedFor(server.Port).Where(a => a.Kind == ActivityKind.Consumer).ToList();
         receives.Should().NotBeEmpty();
         receives.Should().AllSatisfy(a => a.TraceId.Should().NotBe(
             ambient.TraceId,
             "receive activities must not inherit the trace that happened to be current when the connection was established"));
+
+        tracker.AssertAllStopped(server.Port);
     }
 }

--- a/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
@@ -1,0 +1,86 @@
+using System.Diagnostics;
+using NATS.Client.JetStream;
+using Synadia.Orbit.Testing.NatsServerProcessManager;
+
+namespace NATS.Client.Core.Tests;
+
+public class ReceiveActivityLifecycleTest
+{
+    [Fact]
+    public async Task Receive_activities_do_not_chain_in_direct_request_reply()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            RequestReplyMode = NatsRequestReplyMode.Direct,
+        });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        // JS API replies come from the server without trace context headers. In direct
+        // mode the reply message is materialized synchronously on the connection's read
+        // loop, so if starting its receive activity leaks into the read loop's
+        // Activity.Current, each reply activity parents the previous one and the whole
+        // chain stays reachable through the reader's execution context.
+        var js = new NatsJSContext(nats);
+        for (var i = 0; i < 5; i++)
+        {
+            await js.GetAccountInfoAsync(cts.Token);
+        }
+
+        var consumers = tracker.Started.Where(a => a.Kind == ActivityKind.Consumer).ToList();
+        consumers.Should().HaveCount(5);
+        consumers.Should().AllSatisfy(a => a.Parent.Should().BeNull(
+            "receive activities must parent only by context, never by holding the ambient Activity"));
+
+        // Each reply belongs to its own request, so they must land in five distinct
+        // traces. Chaining would collapse them into one.
+        consumers.Select(a => a.TraceId).Distinct().Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task Receive_activities_do_not_join_the_trace_ambient_at_connect_time()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            RequestReplyMode = NatsRequestReplyMode.Direct,
+        });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        using var appListener = new ActivityListener();
+        appListener.ShouldListenTo = source => source.Name == "test-app-connect";
+        appListener.Sample = (ref _) => ActivitySamplingResult.AllDataAndRecorded;
+        ActivitySource.AddActivityListener(appListener);
+        using var appSource = new ActivitySource("test-app-connect");
+
+        // The read loop is started by ConnectAsync and captures the caller's execution
+        // context, Activity.Current included. Applications commonly connect lazily inside
+        // a request span; every later receive activity must not be attributed to that
+        // request's trace, which would also keep the request's activity alive for as long
+        // as the connection lives.
+        var ambient = appSource.StartActivity("user-request");
+        ambient.Should().NotBeNull();
+
+        await nats.ConnectAsync();
+
+        ambient!.Stop();
+
+        var js = new NatsJSContext(nats);
+        for (var i = 0; i < 3; i++)
+        {
+            await js.GetAccountInfoAsync(cts.Token);
+        }
+
+        var receives = tracker.Started.Where(a => a.Kind == ActivityKind.Consumer).ToList();
+        receives.Should().NotBeEmpty();
+        receives.Should().AllSatisfy(a => a.TraceId.Should().NotBe(
+            ambient.TraceId,
+            "receive activities must not inherit the trace that happened to be current when the connection was established"));
+    }
+}


### PR DESCRIPTION
Receive activities were created on the connection's read loop and left in `Activity.Current`, so a message with no trace context of its own took the previous message's activity as its parent. Unrelated messages chained together and the whole chain stayed reachable through the reader's execution context for the life of the connection. Receive activities are now parented only by trace context carried in the message; because a server reply carries none, the request waiting on it supplies the parent so a request-reply remains a single trace.

Keeping receive activities off the ambient context also meant ending them without disturbing whatever activity the application had current, and ending the ones that were never ended at all: messages evicted from a full subscription channel, and messages that never reach a consumer. That last part partially addresses #1227.

Adjacent problems in the same receive path are left out of this change: the remainder of #1227, and #1228, #1230, #1232 and #1233.

Fixes #1225
