### PR TITLE
Fix inverted array check in object store put path

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -92,7 +92,8 @@ jobs:
           cd tests/NATS.Client.ObjectStore.Encoder.Tests
           dotnet test -c Release --no-build -p:TestTfmsInParallel=false
 
-      # net481 exercises the netstandard2.0 build of the client (e.g. the PutAsync read loop)
+      # net481 resolves the netstandard2.0 build of the client, the only TFM that compiles the
+      # PutAsync read loop; NetStandardPutPathTest is what actually asserts against it
       - name: Test Object Store
         run: |
           tasklist | grep -i nats-server && taskkill -F -IM nats-server.exe

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -92,6 +92,14 @@ jobs:
           cd tests/NATS.Client.ObjectStore.Encoder.Tests
           dotnet test -c Release --no-build -p:TestTfmsInParallel=false
 
+      # net481 exercises the netstandard2.0 build of the client (e.g. the PutAsync read loop)
+      - name: Test Object Store
+        run: |
+          tasklist | grep -i nats-server && taskkill -F -IM nats-server.exe
+          nats-server.exe -v
+          cd tests/NATS.Client.ObjectStore.Tests
+          dotnet test -c Release --no-build -p:TestTfmsInParallel=false
+
       - name: Test JetStream
         run: |
             tasklist | grep -i nats-server && taskkill -F -IM nats-server.exe

--- a/src/NATS.Client.ObjectStore/NatsObjStore.cs
+++ b/src/NATS.Client.ObjectStore/NatsObjStore.cs
@@ -211,7 +211,7 @@ public class NatsObjStore : INatsObjStore
                     {
 #if NETSTANDARD2_0
                         int read;
-                        if (MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment) == false)
+                        if (MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment))
                         {
                             read = await hashedStream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken);
                         }
@@ -220,9 +220,8 @@ public class NatsObjStore : INatsObjStore
                             var bytes = ArrayPool<byte>.Shared.Rent(memory.Length);
                             try
                             {
-                                segment = new ArraySegment<byte>(bytes, 0, memory.Length);
-                                read = await hashedStream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken);
-                                segment.Array.AsMemory(0, read).CopyTo(memory);
+                                read = await hashedStream.ReadAsync(bytes, 0, memory.Length, cancellationToken);
+                                bytes.AsMemory(0, read).CopyTo(memory);
                             }
                             finally
                             {

--- a/tests/NATS.Client.ObjectStore.Tests/CompatTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/CompatTest.cs
@@ -32,7 +32,7 @@ public class CompatTest
 
         // Verify PUT
         {
-            await using var stream = new MemoryStream("Hello, World!"u8.ToArray());
+            using var stream = new MemoryStream("Hello, World!"u8.ToArray());
             await store.PutAsync(objMeta, stream, cancellationToken: cancellationToken);
 
             // nats obj info b1 o1

--- a/tests/NATS.Client.ObjectStore.Tests/NATS.Client.ObjectStore.Tests.csproj
+++ b/tests/NATS.Client.ObjectStore.Tests/NATS.Client.ObjectStore.Tests.csproj
@@ -1,12 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <!-- net481 resolves the netstandard2.0 build of the client, the only TFM that compiles
+             the netstandard2.0-specific code paths (e.g. the PutAsync read loop). -->
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
+        <RuntimeIdentifiers>any;win-x86</RuntimeIdentifiers>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <NoWarn>$(NoWarn);CS8002</NoWarn>
         <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\xunit.runsettings</RunSettingsFilePath>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -20,6 +26,8 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
+      <PackageReference Include="System.Net.Http" Version="4.3.4" Condition="'$(TargetFramework)' == 'net481'" />
+      <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" Condition="'$(TargetFramework)' == 'net481'" />
       <Using Include="Xunit" />
       <Using Include="FluentAssertions" />
       <Using Include="NATS.Client.Core" />

--- a/tests/NATS.Client.ObjectStore.Tests/NATS.Client.ObjectStore.Tests.csproj
+++ b/tests/NATS.Client.ObjectStore.Tests/NATS.Client.ObjectStore.Tests.csproj
@@ -5,7 +5,7 @@
              the netstandard2.0-specific code paths (e.g. the PutAsync read loop). -->
         <TargetFrameworks>net8.0</TargetFrameworks>
         <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net481</TargetFrameworks>
-        <RuntimeIdentifiers>any;win-x86</RuntimeIdentifiers>
+        <RuntimeIdentifiers Condition="'$(OS)' == 'Windows_NT'">any;win-x86</RuntimeIdentifiers>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);CS8002</NoWarn>

--- a/tests/NATS.Client.ObjectStore.Tests/NetFrameworkCompat.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/NetFrameworkCompat.cs
@@ -1,44 +1,69 @@
-#if NETFRAMEWORK
-// Minimal stand-ins for BCL APIs missing on .NET Framework. The global using aliases below make
-// the shims take the place of the real types on net481 only, so the test sources stay identical
-// across target frameworks. The aliases apply file-wide, hence the fully qualified names inside
-// the shim bodies.
-global using File = NATS.Client.ObjectStore.Tests.FileCompat;
-global using Random = NATS.Client.ObjectStore.Tests.RandomCompat;
-global using SHA256 = NATS.Client.ObjectStore.Tests.Sha256Compat;
+using System.Security.Cryptography;
 
 namespace NATS.Client.ObjectStore.Tests;
 
+// Stand-ins for BCL APIs the test sources use that do not exist on .NET Framework. These are
+// deliberately named so they do not shadow the types they stand in for: an earlier version
+// aliased File/Random/SHA256 assembly-wide, which meant a call to any member the shim did not
+// cover still compiled on Linux (net8.0 only there) and broke on Windows CI alone. They compile
+// on every target framework and forward to the real API where there is one, so a call site reads
+// the same everywhere and the net481 leg is the only thing switching underneath.
 internal static class Sha256Compat
 {
     public static byte[] HashData(byte[] source)
     {
-        using var sha = System.Security.Cryptography.SHA256.Create();
+#if NETFRAMEWORK
+        using var sha = SHA256.Create();
         return sha.ComputeHash(source);
+#else
+        return SHA256.HashData(source);
+#endif
     }
 }
 
 internal static class RandomCompat
 {
+#if NETFRAMEWORK
+    // Random.Shared does not exist on .NET Framework, and the parameterless Random seeds from
+    // Environment.TickCount (~15ms resolution), so two xunit worker threads first touching this
+    // within the same tick would otherwise produce identical byte sequences for their payloads.
     [ThreadStatic]
-    private static System.Random? _shared;
+    private static Random? _shared;
 
-    public static System.Random Shared => _shared ??= new System.Random();
+    public static Random Shared => _shared ??= new Random(Guid.NewGuid().GetHashCode());
+#else
+    public static Random Shared => Random.Shared;
+#endif
 }
 
 internal static class FileCompat
 {
-    public static FileStream OpenRead(string path) => System.IO.File.OpenRead(path);
+    public static FileStream OpenRead(string path) => File.OpenRead(path);
 
-    public static FileStream OpenWrite(string path) => System.IO.File.OpenWrite(path);
+    public static FileStream OpenWrite(string path) => File.OpenWrite(path);
 
+#if NETFRAMEWORK
+    // File.ReadAllBytesAsync/WriteAllBytesAsync are net-core only. Going through an async
+    // FileStream rather than wrapping the blocking call keeps the CancellationToken meaningful:
+    // callers here run under a test deadline and would otherwise never observe it expiring.
+    public static async Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
+    {
+        using var source = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 81920, useAsync: true);
+        using var buffer = new MemoryStream();
+        await source.CopyToAsync(buffer, 81920, cancellationToken).ConfigureAwait(false);
+        return buffer.ToArray();
+    }
+
+    public static async Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default)
+    {
+        using var target = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 81920, useAsync: true);
+        await target.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+    }
+#else
     public static Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
-        => Task.FromResult(System.IO.File.ReadAllBytes(path));
+        => File.ReadAllBytesAsync(path, cancellationToken);
 
     public static Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default)
-    {
-        System.IO.File.WriteAllBytes(path, bytes);
-        return Task.CompletedTask;
-    }
-}
+        => File.WriteAllBytesAsync(path, bytes, cancellationToken);
 #endif
+}

--- a/tests/NATS.Client.ObjectStore.Tests/NetFrameworkCompat.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/NetFrameworkCompat.cs
@@ -1,0 +1,44 @@
+#if NETFRAMEWORK
+// Minimal stand-ins for BCL APIs missing on .NET Framework. The global using aliases below make
+// the shims take the place of the real types on net481 only, so the test sources stay identical
+// across target frameworks. The aliases apply file-wide, hence the fully qualified names inside
+// the shim bodies.
+global using File = NATS.Client.ObjectStore.Tests.FileCompat;
+global using Random = NATS.Client.ObjectStore.Tests.RandomCompat;
+global using SHA256 = NATS.Client.ObjectStore.Tests.Sha256Compat;
+
+namespace NATS.Client.ObjectStore.Tests;
+
+internal static class Sha256Compat
+{
+    public static byte[] HashData(byte[] source)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        return sha.ComputeHash(source);
+    }
+}
+
+internal static class RandomCompat
+{
+    [ThreadStatic]
+    private static System.Random? _shared;
+
+    public static System.Random Shared => _shared ??= new System.Random();
+}
+
+internal static class FileCompat
+{
+    public static FileStream OpenRead(string path) => System.IO.File.OpenRead(path);
+
+    public static FileStream OpenWrite(string path) => System.IO.File.OpenWrite(path);
+
+    public static Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
+        => Task.FromResult(System.IO.File.ReadAllBytes(path));
+
+    public static Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default)
+    {
+        System.IO.File.WriteAllBytes(path, bytes);
+        return Task.CompletedTask;
+    }
+}
+#endif

--- a/tests/NATS.Client.ObjectStore.Tests/NetStandardPutPathTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/NetStandardPutPathTest.cs
@@ -1,0 +1,233 @@
+#if NETFRAMEWORK
+using System.Buffers;
+using System.Diagnostics.Tracing;
+using System.Reflection;
+using System.Runtime.Versioning;
+#endif
+using System.Runtime.InteropServices;
+using NATS.Client.ObjectStore.Internal;
+using NATS.Client.ObjectStore.Models;
+using NATS.Client.TestUtilities2;
+using Synadia.Orbit.Testing.NatsServerProcessManager;
+
+namespace NATS.Client.ObjectStore.Tests;
+
+// Covers the netstandard2.0-specific read loop in NatsObjStore.PutAsync. On net481 the resolved
+// NATS.Client.ObjectStore is the netstandard2.0 build, which is the only one that compiles it;
+// the net8.0 leg runs whatever is framework-agnostic here as a cross-check.
+public class NetStandardPutPathTest
+{
+    private const int ChunkSize = 8 * 1024;
+
+    private readonly ITestOutputHelper _output;
+
+    public NetStandardPutPathTest(ITestOutputHelper output) => _output = output;
+
+    // PutAsync reads into NatsMemoryOwner<byte>.Memory, which is always array-backed, so the
+    // TryGetArray==true branch is the one that runs and the pooled-copy fallback is dead code.
+    // If this ever fails the fallback has come alive and needs testing in its own right.
+    [Fact]
+    public void Chunk_buffer_is_array_backed()
+    {
+        using var owner = NatsMemoryOwner<byte>.Allocate(ChunkSize);
+
+        Assert.True(MemoryMarshal.TryGetArray<byte>(owner.Memory, out var segment));
+        Assert.NotNull(segment.Array);
+        Assert.Equal(ChunkSize, segment.Count);
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(0, true)]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    [InlineData(ChunkSize - 1, false)]
+    [InlineData(ChunkSize - 1, true)]
+    [InlineData(ChunkSize, false)]
+    [InlineData(ChunkSize, true)]
+    [InlineData(ChunkSize + 1, false)]
+    [InlineData(ChunkSize + 1, true)]
+    [InlineData((ChunkSize * 5) / 2, false)]
+    [InlineData((ChunkSize * 5) / 2, true)]
+    [InlineData(ChunkSize * 4, false)]
+    [InlineData(ChunkSize * 4, true)]
+    public async Task Put_and_get_round_trip_across_chunk_boundaries(int size, bool trickle)
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
+        var js = new NatsJSContext(nats);
+        var ob = new NatsObjContext(js);
+        var store = await ob.CreateObjectStoreAsync(new NatsObjConfig("b1"), cancellationToken);
+
+        var data = new byte[size];
+        RandomCompat.Shared.NextBytes(data);
+
+        // The trickling stream returns a few bytes per read, which drives the inner chunk-fill
+        // loop where the direct-read path has to respect the advancing segment offset.
+        using var stream = trickle ? (Stream)new TrickleStream(data) : new MemoryStream(data);
+        var meta = new ObjectMetadata
+        {
+            Name = "obj",
+            Options = new MetaDataOptions { MaxChunkSize = ChunkSize },
+        };
+
+        var put = await store.PutAsync(meta, stream, cancellationToken: cancellationToken);
+
+        Assert.Equal((ulong)size, put.Size);
+        Assert.Equal((uint)((size + ChunkSize - 1) / ChunkSize), put.Chunks);
+        Assert.Equal("SHA-256=" + Base64UrlEncoder.Encode(Sha256Compat.HashData(data)), put.Digest);
+
+        var got = await store.GetBytesAsync("obj", cancellationToken);
+        Assert.Equal(data, got);
+    }
+
+#if NETFRAMEWORK
+    // Everything below rests on net481 resolving the netstandard2.0 build of the client, since
+    // that is the only one compiling the path under test. If the client ever gains a .NET
+    // Framework target this leg would quietly stop covering it, so assert it outright.
+    [Fact]
+    public void Object_store_assembly_is_the_netstandard_build()
+    {
+        var tfm = typeof(NatsObjStore).Assembly.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
+
+        _output.WriteLine($"NATS.Client.ObjectStore TFM: {tfm}");
+        Assert.Equal(".NETStandard,Version=v2.0", tfm);
+    }
+
+    // Regression test for the inverted TryGetArray check: the broken code rented an
+    // ArrayPool<byte>.Shared transfer buffer and copied it into the chunk buffer for every chunk
+    // read, while the fixed code reads straight into the chunk buffer and never rents in the read
+    // loop. Both variants produce identical objects, so renting is the only observable difference
+    // and it is counted here through the pool's own ArrayPoolEventSource.
+    //
+    // The publish path rents about one chunk-sized buffer per published message either way, a
+    // fixed background cost, so the two regimes are ~2 rents per chunk broken (measured 203 for
+    // 100 chunks) versus ~1 per chunk fixed (measured 102); the threshold sits between them.
+    [Fact]
+    public async Task Put_does_not_rent_a_transfer_buffer_per_chunk()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        using var listener = new ArrayPoolRentListener(ChunkSize);
+
+        // Without this the assertion below could pass vacuously by observing no events at all.
+        var probe = ArrayPool<byte>.Shared.Rent(ChunkSize);
+        ArrayPool<byte>.Shared.Return(probe);
+        Assert.True(listener.Count > 0, "ArrayPoolEventSource is not observable in this process");
+
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
+        var js = new NatsJSContext(nats);
+        var ob = new NatsObjContext(js);
+        var store = await ob.CreateObjectStoreAsync(new NatsObjConfig("b1"), cancellationToken);
+
+        const int chunks = 100;
+        var data = new byte[ChunkSize * chunks];
+        RandomCompat.Shared.NextBytes(data);
+
+        var meta = new ObjectMetadata
+        {
+            Name = "obj",
+            Options = new MetaDataOptions { MaxChunkSize = ChunkSize },
+        };
+
+        var before = listener.Count;
+        using var stream = new MemoryStream(data);
+        var put = await store.PutAsync(meta, stream, cancellationToken: cancellationToken);
+        var rented = listener.Count - before;
+
+        Assert.Equal((uint)chunks, put.Chunks);
+        _output.WriteLine($"chunk-sized buffers rented during {chunks}-chunk put: {rented}");
+
+        Assert.True(
+            rented < chunks * 3 / 2,
+            $"PutAsync rented {rented} chunk-sized buffers for {chunks} chunks; expected about one per chunk from the publish path alone. The netstandard2.0 read path is renting an extra transfer buffer per chunk.");
+    }
+
+    private sealed class ArrayPoolRentListener : EventListener
+    {
+        private const int BufferRentedEventId = 1;
+
+        private readonly int _watchedSize;
+        private long _count;
+
+        public ArrayPoolRentListener(int watchedSize) => _watchedSize = watchedSize;
+
+        public long Count => Interlocked.Read(ref _count);
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == "System.Buffers.ArrayPoolEventSource")
+            {
+                EnableEvents(eventSource, EventLevel.Verbose);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            // BufferRented payload: bufferId, bufferSize, poolId, bucketId
+            if (eventData.EventId == BufferRentedEventId
+                && eventData.Payload is { Count: >= 2 }
+                && eventData.Payload[1] is int size
+                && size == _watchedSize)
+            {
+                Interlocked.Increment(ref _count);
+            }
+        }
+    }
+#endif
+
+    // Returns at most a handful of bytes per read so a chunk takes many reads to fill.
+    private sealed class TrickleStream : Stream
+    {
+        private readonly byte[] _data;
+        private readonly Random _random = new(1234);
+        private int _position;
+
+        public TrickleStream(byte[] data) => _data = data;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _data.Length;
+
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var remaining = _data.Length - _position;
+            if (remaining == 0 || count == 0)
+            {
+                return 0;
+            }
+
+            var n = Math.Min(Math.Min(count, remaining), _random.Next(1, 17));
+            Buffer.BlockCopy(_data, _position, buffer, offset, n);
+            _position += n;
+            return n;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/ObjectStoreTest.cs
@@ -80,7 +80,7 @@ public class ObjectStoreTest
 
             var data = await store.GetInfoAsync("k1", cancellationToken: cancellationToken);
 
-            var sha = Base64UrlEncoder.Encode(SHA256.HashData(buffer));
+            var sha = Base64UrlEncoder.Encode(Sha256Compat.HashData(buffer));
             var size = buffer.Length;
             var chunks = Math.Ceiling(size / 10.0);
 
@@ -100,7 +100,7 @@ public class ObjectStoreTest
 
             var data = await store.GetInfoAsync("k2", cancellationToken: cancellationToken);
 
-            var sha = Base64UrlEncoder.Encode(SHA256.HashData(buffer));
+            var sha = Base64UrlEncoder.Encode(Sha256Compat.HashData(buffer));
             var size = buffer.Length;
             var chunks = Math.Ceiling(size / 10.0);
 
@@ -239,19 +239,19 @@ public class ObjectStoreTest
         var store = await obj.CreateObjectStoreAsync(new NatsObjConfig("b1"), cancellationToken);
 
         var data = new byte[1024 * 1024 * 10];
-        Random.Shared.NextBytes(data);
+        RandomCompat.Shared.NextBytes(data);
 
         const string filename = $"_tmp_test_file_{nameof(Put_and_get_large_file)}.bin";
         var filename1 = $"{filename}.1";
 
-        await File.WriteAllBytesAsync(filename, data, cancellationToken);
+        await FileCompat.WriteAllBytesAsync(filename, data, cancellationToken);
 
-        await store.PutAsync("my/random/data.bin", File.OpenRead(filename), cancellationToken: cancellationToken);
+        await store.PutAsync("my/random/data.bin", FileCompat.OpenRead(filename), cancellationToken: cancellationToken);
 
-        await store.GetAsync("my/random/data.bin", File.OpenWrite(filename1), cancellationToken: cancellationToken);
+        await store.GetAsync("my/random/data.bin", FileCompat.OpenWrite(filename1), cancellationToken: cancellationToken);
 
-        var hash = Convert.ToBase64String(SHA256.HashData(await File.ReadAllBytesAsync(filename, cancellationToken)));
-        var hash1 = Convert.ToBase64String(SHA256.HashData(await File.ReadAllBytesAsync(filename1, cancellationToken)));
+        var hash = Convert.ToBase64String(Sha256Compat.HashData(await FileCompat.ReadAllBytesAsync(filename, cancellationToken)));
+        var hash1 = Convert.ToBase64String(Sha256Compat.HashData(await FileCompat.ReadAllBytesAsync(filename1, cancellationToken)));
 
         Assert.Equal(hash, hash1);
     }
@@ -527,12 +527,12 @@ public class ObjectStoreTest
         var store = await obj.CreateObjectStoreAsync(new NatsObjConfig("b1"), cancellationToken);
 
         var data = new byte[1024];
-        Random.Shared.NextBytes(data);
+        RandomCompat.Shared.NextBytes(data);
 
         const string filename = $"_tmp_test_file_{nameof(Put_with_activity)}.bin";
-        await File.WriteAllBytesAsync(filename, data, cancellationToken);
+        await FileCompat.WriteAllBytesAsync(filename, data, cancellationToken);
 
-        await store.PutAsync("my/random/data_1.bin", File.OpenRead(filename), cancellationToken: cancellationToken);
+        await store.PutAsync("my/random/data_1.bin", FileCompat.OpenRead(filename), cancellationToken: cancellationToken);
     }
 
     [Fact]
@@ -560,14 +560,14 @@ public class ObjectStoreTest
         var store = await obj.CreateObjectStoreAsync(new NatsObjConfig("b1"), cancellationToken);
 
         var data = new byte[1024];
-        Random.Shared.NextBytes(data);
+        RandomCompat.Shared.NextBytes(data);
 
         const string filename = $"_tmp_test_file_{nameof(Put_multiple_times_with_activity)}.bin";
-        await File.WriteAllBytesAsync(filename, data, cancellationToken);
+        await FileCompat.WriteAllBytesAsync(filename, data, cancellationToken);
 
-        await store.PutAsync("my/random/data_1.bin", File.OpenRead(filename), cancellationToken: cancellationToken);
-        await store.PutAsync("my/random/data_2.bin", File.OpenRead(filename), cancellationToken: cancellationToken);
-        await store.PutAsync("my/random/data_3.bin", File.OpenRead(filename), cancellationToken: cancellationToken);
+        await store.PutAsync("my/random/data_1.bin", FileCompat.OpenRead(filename), cancellationToken: cancellationToken);
+        await store.PutAsync("my/random/data_2.bin", FileCompat.OpenRead(filename), cancellationToken: cancellationToken);
+        await store.PutAsync("my/random/data_3.bin", FileCompat.OpenRead(filename), cancellationToken: cancellationToken);
     }
 
     [Fact]

--- a/tests/NATS.Client.ObjectStore.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/SlowConsumerTest.cs
@@ -245,9 +245,11 @@ public class SlowConsumerTest
             }
         }
 
+#if !NETFRAMEWORK
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             return new ValueTask(WriteAsync(buffer.ToArray(), 0, buffer.Length, cancellationToken));
         }
+#endif
     }
 }

--- a/tests/NATS.Client.ObjectStore.Tests/SlowConsumerTest.cs
+++ b/tests/NATS.Client.ObjectStore.Tests/SlowConsumerTest.cs
@@ -46,7 +46,7 @@ public class SlowConsumerTest
         const int chunkSize = 1024;
         const int objectSize = 128 * 1024; // 128KB = 128 chunks
         var largeData = new byte[objectSize];
-        Random.Shared.NextBytes(largeData);
+        RandomCompat.Shared.NextBytes(largeData);
 
         var meta = new ObjectMetadata
         {


### PR DESCRIPTION
Noticed this while reading the put path for #941.

The netstandard2.0 branch in `PutAsync` has the `TryGetArray` check inverted:

```csharp
if (MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)memory, out var segment) == false)
{
    // segment is default here so segment.Array is null
    read = await hashedStream.ReadAsync(segment.Array!, segment.Offset, segment.Count, cancellationToken);
}
else
{
    // taken when memory IS array backed, which is always
    var bytes = ArrayPool<byte>.Shared.Rent(memory.Length);
    ...
}
```

`NatsMemoryOwner<byte>.Memory` is always array backed so `TryGetArray` always succeeds. That means netstandard2.0 rents an extra chunk sized buffer and copies the whole chunk on every iteration. The other branch is unreachable and would NRE if it ever ran. Came in with #513.

This just flips the condition so the array backed case reads straight into the chunk buffer and keeps the pooled buffer as the fallback.

No test added since the branch only compiles under `#if NETSTANDARD2_0` and the object store tests target net8.0Builds clean on all four TFMs.
