### PR TITLE
Fix OpenTelemetry receive span lifecycle, parenting and tags

### DIFF
--- a/src/NATS.Client.Core/Internal/ReplyTask.cs
+++ b/src/NATS.Client.Core/Internal/ReplyTask.cs
@@ -24,6 +24,8 @@ internal sealed class ReplyTask<T> : ReplyTaskBase, IDisposable
     private NatsMsg<T> _msg;
     private long _replyBytes;
     private bool _isNoResponders;
+    private Activity? _activity;
+    private bool _disposed;
 
     public ReplyTask(ReplyTaskFactory factory, long id, string subject, NatsConnection connection, INatsDeserialize<T> deserializer, TimeSpan requestTimeout, bool throwIfNoResponders, ActivityContext requestContext)
     {
@@ -49,50 +51,61 @@ internal sealed class ReplyTask<T> : ReplyTaskBase, IDisposable
     {
         try
         {
-            await _tcs.Task
-                .WaitAsync(_requestTimeout, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        catch (TimeoutException)
-        {
-            NatsNoReplyException.Throw();
-        }
+            try
+            {
+                await _tcs.Task
+                    .WaitAsync(_requestTimeout, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                NatsNoReplyException.Throw();
+            }
 
-        NatsMsg<T> msg;
-        long bytes;
-        bool isNoResponders;
-        lock (_gate)
-        {
-            msg = _msg;
-            bytes = _replyBytes;
-            isNoResponders = _isNoResponders;
-        }
+            NatsMsg<T> msg;
+            long bytes;
+            bool isNoResponders;
+            lock (_gate)
+            {
+                msg = _msg;
+                bytes = _replyBytes;
+                isNoResponders = _isNoResponders;
+            }
 
-        // Match the SharedInbox path: when ThrowIfNoResponders is set, a 503 sentinel
-        // surfaces as NatsNoRespondersException rather than an empty message.
-        if (isNoResponders && _throwIfNoResponders)
-        {
-            throw new NatsNoRespondersException();
-        }
+            // Match the SharedInbox path: when ThrowIfNoResponders is set, a 503 sentinel
+            // surfaces as NatsNoRespondersException rather than an empty message.
+            if (isNoResponders && _throwIfNoResponders)
+            {
+                throw new NatsNoRespondersException();
+            }
 
-        // Count only messages actually delivered to the caller. Late replies that arrive
-        // after a timeout still hit SetResult, but the user never sees them, so the
-        // counters belong here on the success path, not in SetResult. 503 NoResponders
-        // sentinels are also excluded for parity with the SharedInbox path.
-        if (!isNoResponders && (Telemetry.ConsumedMessages.Enabled || Telemetry.ReceivedBytes.Enabled))
-        {
-            var tags = Telemetry.BuildMetricTags(_connection, Telemetry.Constants.OpRec);
-            if (Telemetry.ConsumedMessages.Enabled)
-                Telemetry.ConsumedMessages.Add(1, tags);
-            if (Telemetry.ReceivedBytes.Enabled)
-                Telemetry.ReceivedBytes.Add(bytes, tags);
-        }
+            // Count only messages actually delivered to the caller. Late replies that arrive
+            // after a timeout still hit SetResult, but the user never sees them, so the
+            // counters belong here on the success path, not in SetResult. 503 NoResponders
+            // sentinels are also excluded for parity with the SharedInbox path.
+            if (!isNoResponders && (Telemetry.ConsumedMessages.Enabled || Telemetry.ReceivedBytes.Enabled))
+            {
+                var tags = Telemetry.BuildMetricTags(_connection, Telemetry.Constants.OpRec);
+                if (Telemetry.ConsumedMessages.Enabled)
+                    Telemetry.ConsumedMessages.Add(1, tags);
+                if (Telemetry.ReceivedBytes.Enabled)
+                    Telemetry.ReceivedBytes.Add(bytes, tags);
+            }
 
-        return msg;
+            return msg;
+        }
+        finally
+        {
+            // Every exit ends the activity, not just the one that returns a message. The
+            // 503 sentinel and a reply that lands after the request timed out both leave
+            // here by throwing, and a span that is never stopped is never exported.
+            EndReceiveActivity();
+        }
     }
 
     public override void SetResult(string? replyTo, ReadOnlySequence<byte> payload, ReadOnlySequence<byte>? headersBuffer)
     {
+        Activity? orphaned = null;
         lock (_gate)
         {
             // A server reply carries no trace context, so without the request's context
@@ -101,12 +114,50 @@ internal sealed class ReplyTask<T> : ReplyTaskBase, IDisposable
             _msg = NatsMsg<T>.BuildInternal(Subject, replyTo, headersBuffer, payload, _connection, _connection.HeaderParser, _deserializer, _requestContext);
             _isNoResponders = payload.Length == 0 && NatsSubBase.IsHeader503(headersBuffer);
             _replyBytes = payload.Length + (headersBuffer?.Length ?? 0);
+
+            // Direct mode builds the reply on the read loop, so there is no
+            // ActivityEndingMsgReader behind it. The reply task owns the activity from here.
+            _activity = _msg.Headers?.Activity;
+
+            // Nothing will come back for it if the caller has already gone: a reply
+            // dispatched just as the request was disposed still reaches this far.
+            if (_disposed)
+            {
+                orphaned = _activity;
+                _activity = null;
+            }
         }
+
+        Telemetry.EndActivity(orphaned);
 
         _tcs.TrySetResult();
     }
 
-    public void Dispose() => _factory.Return(_id);
+    public void Dispose()
+    {
+        // Return first so no further reply can be dispatched to this task, then close the
+        // window on one that got in just before.
+        _factory.Return(_id);
+
+        lock (_gate)
+        {
+            _disposed = true;
+        }
+
+        EndReceiveActivity();
+    }
+
+    private void EndReceiveActivity()
+    {
+        Activity? activity;
+        lock (_gate)
+        {
+            activity = _activity;
+            _activity = null;
+        }
+
+        Telemetry.EndActivity(activity);
+    }
 }
 
 internal abstract class ReplyTaskBase

--- a/src/NATS.Client.Core/Internal/SubscriptionManager.cs
+++ b/src/NATS.Client.Core/Internal/SubscriptionManager.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core.Commands;
@@ -57,7 +58,13 @@ internal sealed class SubscriptionManager : INatsSubscriptionManager, IAsyncDisp
     {
         if (Telemetry.HasListeners())
         {
-            using var activity = Telemetry.StartSendActivity($"{_connection.SpanDestinationName(sub.Subject)} {Telemetry.Constants.SubscribeActivityName}", _connection, sub.Subject, null);
+            using var activity = Telemetry.StartSendActivity(
+                $"{_connection.SpanDestinationName(sub.Subject)} {Telemetry.Constants.SubscribeActivityName}",
+                _connection,
+                sub.Subject,
+                replyTo: null,
+                operation: Telemetry.Constants.OpSub,
+                kind: ActivityKind.Client);
             try
             {
                 if (IsInboxSubject(sub.Subject))

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -599,6 +599,15 @@ internal static class Telemetry
         if (options.Enrich is not { } enrich)
             return;
 
+        // Send and receive agree on what the callback sees. StartActivity leaves a send activity
+        // in Activity.Current, but receive activities are deliberately kept off the ambient
+        // context, so the receive path has to put it there for the call and take it back out.
+        // On the send path the activity is already current and this costs nothing.
+        var ambient = Activity.Current;
+        var restore = !ReferenceEquals(ambient, activity);
+        if (restore)
+            Activity.Current = activity;
+
         try
         {
             enrich(activity, context);
@@ -606,6 +615,11 @@ internal static class Telemetry
         catch
         {
             // Deliberately ignored, see above.
+        }
+        finally
+        {
+            if (restore)
+                RestoreCurrentActivity(ambient);
         }
     }
 

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -148,6 +148,29 @@ internal static class Telemetry
         return tags;
     }
 
+    /// <summary>
+    /// Starts the activity representing a request, under which the reply subscription, the
+    /// publish and the reply's receive activity all nest.
+    /// </summary>
+    /// <remarks>
+    /// RequestAsync is not the only entry point into request/reply. RequestManyAsync and the
+    /// JetStream shared-inbox paths drive CreateRequestSubAsync directly, and without a request
+    /// activity current each of the spans they produce becomes a root of its own trace, with the
+    /// reply's receive activity having nothing to parent under. They call this instead of
+    /// reproducing the naming.
+    /// </remarks>
+    public static Activity? StartRequestActivity(INatsConnection? connection, string subject)
+    {
+        if (!NatsActivities.HasListeners())
+            return null;
+
+        var name = connection is NatsConnection nats
+            ? $"{nats.SpanDestinationName(subject)} {Constants.RequestReplyActivityName}"
+            : Constants.RequestReplyActivityName;
+
+        return StartSendActivity(name, connection, subject, replyTo: null);
+    }
+
     public static Activity? StartSendActivity(
         string name,
         INatsConnection? connection,

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -288,13 +288,36 @@ internal static class Telemetry
         if (!NatsActivities.HasListeners())
             return null;
 
-        // Trace context carried by the message always wins: it is the real causal link,
+        // Trace context carried by the message normally wins: it is the real causal link,
         // possibly from another process. The fallback is for messages that carry none but
         // whose cause is known locally, i.e. a reply to a request this client is waiting
         // on. It is an ActivityContext (ids only) rather than an Activity, so parenting
         // never creates an object reference between activities.
+        ActivityLink[]? links = null;
         if (headers is null || !TryParseTraceContext(headers, out var context))
+        {
             context = fallbackParentContext;
+        }
+        else if (fallbackParentContext != default && context.TraceId != fallbackParentContext.TraceId)
+        {
+            // A reply carrying trace context from a different trace than the request waiting
+            // on it is not a responder continuing the caller's trace: it is a stored message
+            // replayed verbatim, headers and all, by something like a JetStream direct get.
+            // Its traceparent belongs to whatever wrote the value, possibly long ago.
+            //
+            // Parenting under it would take the receive span out of the reader's trace and
+            // attach it to the writer's, once per read for the life of the value. Backends
+            // treat a trace as complete after a period of inactivity, so a span arriving
+            // minutes later is dropped or rendered as an orphan: the read's trace loses a
+            // span and the write's trace gains nothing usable. Parent from the request and
+            // record the message's context as a link, which is the mechanism for pointing at
+            // a different and possibly stale trace without claiming the two are one.
+            //
+            // A responder that continues the caller's trace shares its trace id and so is
+            // unaffected.
+            links = new[] { new ActivityLink(context) };
+            context = fallbackParentContext;
+        }
 
         var options = NatsInstrumentationOptions.Default;
         IReadOnlyList<KeyValuePair<string, string?>>? baggage = null;
@@ -395,7 +418,8 @@ internal static class Telemetry
                 name,
                 kind: ActivityKind.Consumer,
                 parentContext: context,
-                tags: tags);
+                tags: tags,
+                links: links);
         }
         finally
         {

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -168,14 +168,22 @@ internal static class Telemetry
             ? $"{nats.SpanDestinationName(subject)} {Constants.RequestReplyActivityName}"
             : Constants.RequestReplyActivityName;
 
-        return StartSendActivity(name, connection, subject, replyTo: null);
+        return StartSendActivity(name, connection, subject, replyTo: null, operation: Constants.OpReq);
     }
 
+    // operation is the value for the messaging.operation tag. It is not always publish: this
+    // starts the span for subscribe and request too, and those have to agree with the metrics
+    // describing the same operation, which have always used distinct values.
+    //
+    // kind is Producer for the operations that put a message on the wire. Subscribe passes
+    // Client because it produces nothing; it is a control plane call to the server.
     public static Activity? StartSendActivity(
         string name,
         INatsConnection? connection,
         string subject,
         string? replyTo,
+        string operation,
+        ActivityKind kind = ActivityKind.Producer,
         ActivityContext parentContext = default)
     {
         if (!NatsActivities.HasListeners())
@@ -206,7 +214,7 @@ internal static class Telemetry
             var serverHost = conn.ServerHost; // grabbed once per ServerInfo change
             tags = new KeyValuePair<string, object?>[len];
             tags[0] = new KeyValuePair<string, object?>(Constants.SystemKey, Constants.SystemVal);
-            tags[1] = new KeyValuePair<string, object?>(Constants.OpKey, Constants.OpPub);
+            tags[1] = new KeyValuePair<string, object?>(Constants.OpKey, operation);
             tags[2] = new KeyValuePair<string, object?>(Constants.DestName, LowCardinalitySubject(conn, subject));
 
             tags[3] = new KeyValuePair<string, object?>(Constants.ClientId, conn.ClientId);
@@ -229,7 +237,7 @@ internal static class Telemetry
 
             tags = new KeyValuePair<string, object?>[len];
             tags[0] = new KeyValuePair<string, object?>(Constants.SystemKey, Constants.SystemVal);
-            tags[1] = new KeyValuePair<string, object?>(Constants.OpKey, Constants.OpPub);
+            tags[1] = new KeyValuePair<string, object?>(Constants.OpKey, operation);
             tags[2] = new KeyValuePair<string, object?>(Constants.DestName, subject);
 
             if (replyTo is not null)
@@ -238,7 +246,7 @@ internal static class Telemetry
 
         var activity = NatsActivities.StartActivity(
             name,
-            kind: ActivityKind.Producer,
+            kind: kind,
             parentContext: parentContext,
             tags: tags);
 

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -353,7 +353,13 @@ internal static class Telemetry
             tags = new KeyValuePair<string, object?>[len];
             tags[0] = new KeyValuePair<string, object?>(Constants.SystemKey, Constants.SystemVal);
             tags[1] = new KeyValuePair<string, object?>(Constants.OpKey, Constants.OpRec);
-            tags[2] = new KeyValuePair<string, object?>(Constants.DestTemplate, subscriptionSubject);
+
+            // Collapsed like the other subject tags. A request/reply subscription's subject is
+            // a unique _INBOX.<nuid>, and destination.template is meant to be a low cardinality
+            // template of the destination rather than a concrete name. Temporariness is decided
+            // from the raw subject, before collapsing, and against this connection's own inbox
+            // prefix rather than the bare one.
+            tags[2] = new KeyValuePair<string, object?>(Constants.DestTemplate, LowCardinalitySubject(conn, subscriptionSubject));
             tags[3] = new KeyValuePair<string, object?>(Constants.DestIsTemporary, subscriptionSubject.StartsWith(conn.InboxPrefix, StringComparison.Ordinal) ? Constants.True : Constants.False);
             var lowCardinalitySubject = LowCardinalitySubject(conn, subject);
             tags[4] = new KeyValuePair<string, object?>(Constants.Subject, lowCardinalitySubject);
@@ -378,23 +384,31 @@ internal static class Telemetry
         }
         else
         {
-            var len = 9;
+            // Matches the branch above: the queue group tag is only present when there is a
+            // queue group. It used to be written unconditionally here, landing as a null valued
+            // tag that exporters drop, which was harmless only for as long as the tag could
+            // never fire at all.
+            var len = 8;
             if (replyTo is not null)
+                len++;
+            if (queueGroup is not null)
                 len++;
 
             tags = new KeyValuePair<string, object?>[len];
             tags[0] = new KeyValuePair<string, object?>(Constants.SystemKey, Constants.SystemVal);
             tags[1] = new KeyValuePair<string, object?>(Constants.OpKey, Constants.OpRec);
             tags[2] = new KeyValuePair<string, object?>(Constants.DestTemplate, subscriptionSubject);
-            tags[3] = new KeyValuePair<string, object?>(Constants.QueueGroup, queueGroup);
-            tags[4] = new KeyValuePair<string, object?>(Constants.Subject, subject);
-            tags[5] = new KeyValuePair<string, object?>(Constants.DestName, subject);
-            tags[6] = new KeyValuePair<string, object?>(Constants.DestPubName, subject);
-            tags[7] = new KeyValuePair<string, object?>(Constants.MsgBodySize, bodySize.ToString());
-            tags[8] = new KeyValuePair<string, object?>(Constants.MsgTotalSize, size.ToString());
+            tags[3] = new KeyValuePair<string, object?>(Constants.Subject, subject);
+            tags[4] = new KeyValuePair<string, object?>(Constants.DestName, subject);
+            tags[5] = new KeyValuePair<string, object?>(Constants.DestPubName, subject);
+            tags[6] = new KeyValuePair<string, object?>(Constants.MsgBodySize, bodySize.ToString());
+            tags[7] = new KeyValuePair<string, object?>(Constants.MsgTotalSize, size.ToString());
 
+            var index = 8;
             if (replyTo is not null)
-                tags[9] = new KeyValuePair<string, object?>(Constants.ReplyTo, replyTo);
+                tags[index++] = new KeyValuePair<string, object?>(Constants.ReplyTo, replyTo);
+            if (queueGroup is not null)
+                tags[index] = new KeyValuePair<string, object?>(Constants.QueueGroup, queueGroup);
         }
 
         // A receive activity's parent comes exclusively from the message's trace

--- a/src/NATS.Client.Core/Internal/Telemetry.cs
+++ b/src/NATS.Client.Core/Internal/Telemetry.cs
@@ -200,7 +200,7 @@ internal static class Telemetry
             ParentContext: parentContext);
 
         var options = NatsInstrumentationOptions.Default;
-        if (options.Filter is { } filter && !filter(instrumentationContext))
+        if (!ShouldCollect(options, instrumentationContext))
             return null;
 
         KeyValuePair<string, object?>[] tags;
@@ -251,7 +251,7 @@ internal static class Telemetry
             tags: tags);
 
         if (activity is not null)
-            options.Enrich?.Invoke(activity, instrumentationContext);
+            Enrich(options, activity, instrumentationContext);
 
         return activity;
     }
@@ -343,7 +343,7 @@ internal static class Telemetry
             ParentContext: context)
         { Baggage = baggage };
 
-        if (options.Filter is { } filter && !filter(instrumentationContext))
+        if (!ShouldCollect(options, instrumentationContext))
             return null;
 
         KeyValuePair<string, object?>[] tags;
@@ -458,7 +458,7 @@ internal static class Telemetry
                     activity.AddBaggage(item.Key, item.Value);
             }
 
-            options.Enrich?.Invoke(activity, instrumentationContext);
+            Enrich(options, activity, instrumentationContext);
         }
 
         return activity;
@@ -561,6 +561,52 @@ internal static class Telemetry
         // order may differ from the source activity; consumers must not rely on order.
         foreach (var item in from.Baggage)
             to.AddBaggage(item.Key, item.Value);
+    }
+
+    /// <summary>
+    /// Applies <see cref="NatsInstrumentationOptions.Filter"/>, treating a throwing filter as a
+    /// decision not to collect.
+    /// </summary>
+    /// <remarks>
+    /// This is what the Filter documentation has always promised. Without the guard the
+    /// exception propagated out of publish, and out of message construction on receive, so a
+    /// filter bug broke messaging rather than telemetry.
+    /// </remarks>
+    private static bool ShouldCollect(NatsInstrumentationOptions options, in NatsInstrumentationContext context)
+    {
+        if (options.Filter is not { } filter)
+            return true;
+
+        try
+        {
+            return filter(context);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Applies <see cref="NatsInstrumentationOptions.Enrich"/>, swallowing anything it throws.
+    /// </summary>
+    /// <remarks>
+    /// Enrichment is decoration on top of an activity that is otherwise complete. Letting it
+    /// escape would fail the publish or the message build for the sake of a tag.
+    /// </remarks>
+    private static void Enrich(NatsInstrumentationOptions options, Activity activity, in NatsInstrumentationContext context)
+    {
+        if (options.Enrich is not { } enrich)
+            return;
+
+        try
+        {
+            enrich(activity, context);
+        }
+        catch
+        {
+            // Deliberately ignored, see above.
+        }
     }
 
     // Inbox subjects (_INBOX.<nuid>[.<nuid>]) are unique per request, so emitting them as

--- a/src/NATS.Client.Core/NatsConnection.Publish.cs
+++ b/src/NATS.Client.Core/NatsConnection.Publish.cs
@@ -22,7 +22,7 @@ public partial class NatsConnection
         ValueTask task;
         if (Telemetry.HasListeners())
         {
-            using var activity = Telemetry.StartSendActivity($"{SpanDestinationName(subject)} {Telemetry.Constants.PublishActivityName}", this, subject, replyTo);
+            using var activity = Telemetry.StartSendActivity($"{SpanDestinationName(subject)} {Telemetry.Constants.PublishActivityName}", this, subject, replyTo, Telemetry.Constants.OpPub);
             Telemetry.AddTraceContextHeaders(activity, ref headers);
             try
             {
@@ -74,7 +74,7 @@ public partial class NatsConnection
         ValueTask task;
         if (Telemetry.HasListeners())
         {
-            using var activity = Telemetry.StartSendActivity($"{SpanDestinationName(subject)} {Telemetry.Constants.PublishActivityName}", this, subject, replyTo);
+            using var activity = Telemetry.StartSendActivity($"{SpanDestinationName(subject)} {Telemetry.Constants.PublishActivityName}", this, subject, replyTo, Telemetry.Constants.OpPub);
             Telemetry.AddTraceContextHeaders(activity, ref headers);
             try
             {

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -48,7 +48,7 @@ public partial class NatsConnection
         {
             if (Telemetry.HasListeners())
             {
-                using var activity = Telemetry.StartSendActivity($"{SpanDestinationName(subject)} {Telemetry.Constants.RequestReplyActivityName}", this, subject, null);
+                using var activity = Telemetry.StartRequestActivity(this, subject);
                 try
                 {
                     replyOpts = SetReplyOptsDefaults(replyOpts);
@@ -188,6 +188,12 @@ public partial class NatsConnection
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         replyOpts = SetReplyManyOptsDefaults(replyOpts);
+
+        // RequestMany started no request activity, so the reply subscription, the publish and
+        // every reply's receive activity were roots of three or more separate traces. The
+        // subscription is created inside this scope so that it and the replies nest under it.
+        using var activity = Telemetry.StartRequestActivity(this, subject);
+
         await using var sub = await CreateRequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/NATS.Client.Core/NatsConnection.RequestReply.cs
+++ b/src/NATS.Client.Core/NatsConnection.RequestReply.cs
@@ -58,13 +58,10 @@ public partial class NatsConnection
                         using var rt = _replyTaskFactory.CreateReplyTask(replySerializer, replyOpts.Timeout, replyOpts.ThrowIfNoResponders ?? true);
                         requestSerializer ??= Opts.SerializerRegistry.GetSerializer<TRequest>();
                         await PublishAsync(subject, data, headers, rt.Subject, requestSerializer, requestOpts, cancellationToken).ConfigureAwait(false);
-                        var msg = await rt.GetResultAsync(cancellationToken).ConfigureAwait(false);
 
-                        // End the activity from the headers to avoid leaking it. Direct mode
-                        // materializes the reply on the read loop, so nothing else ends it.
-                        Telemetry.EndActivity(msg.Headers?.Activity);
-
-                        return msg;
+                        // ReplyTask owns the reply's receive activity and ends it on every
+                        // exit, so this branch and the untraced one below behave the same.
+                        return await rt.GetResultAsync(cancellationToken).ConfigureAwait(false);
                     }
 
                     await using var sub1 = await CreateRequestSubAsync<TRequest, TReply>(subject, data, headers, requestSerializer, replySerializer, requestOpts, replyOpts, cancellationToken)

--- a/src/NATS.Client.Core/NatsConnection.cs
+++ b/src/NATS.Client.Core/NatsConnection.cs
@@ -390,7 +390,18 @@ public partial class NatsConnection : INatsConnection
             return "inbox";
 
         if (NatsInstrumentationOptions.Default.SpanDestinationNameFormatter is { } formatter)
-            return formatter(subject);
+        {
+            try
+            {
+                return formatter(subject);
+            }
+            catch
+            {
+                // A formatter is only choosing a span name. Letting it throw would take out the
+                // publish, or the message build on receive, which is never a trade worth making
+                // for a name. Fall through to the default below.
+            }
+        }
 
         // to avoid long span names and low cardinality, only take the first two tokens
         var subjectSpan = subject.AsSpan();

--- a/src/NATS.Client.Core/NatsInstrumentationOptions.cs
+++ b/src/NATS.Client.Core/NatsInstrumentationOptions.cs
@@ -36,6 +36,18 @@ public sealed class NatsInstrumentationOptions
     /// <summary>
     /// Gets or sets an action to enrich an Activity.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An exception thrown here is caught and ignored; the activity keeps whatever the callback
+    /// managed to set before it threw.
+    /// </para>
+    /// <para>
+    /// Use the <see cref="Activity"/> argument rather than <see cref="Activity.Current"/>. On the
+    /// send path the new activity is current, but on the receive path it is not: receive
+    /// activities are created on the connection's read loop and are deliberately kept off the
+    /// ambient context.
+    /// </para>
+    /// </remarks>
     public Action<Activity, NatsInstrumentationContext>? Enrich
     {
         get => _enrich;
@@ -46,7 +58,17 @@ public sealed class NatsInstrumentationOptions
     /// Gets or sets a function that formats the destination name used in span names.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The input is the raw NATS subject. This only changes activity names, not telemetry tags.
+    /// </para>
+    /// <para>
+    /// It replaces the default two-token truncation entirely, so a formatter is responsible for
+    /// keeping the names it returns low cardinality. Inbox subjects never reach it: they are
+    /// collapsed to <c>inbox</c> first.
+    /// </para>
+    /// <para>
+    /// An exception thrown here is caught and the default naming is used for that span.
+    /// </para>
     /// </remarks>
     public Func<string, string>? SpanDestinationNameFormatter
     {

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -355,6 +355,12 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
     /// Set by the request/reply paths so a reply is traced under the request that caused it.
     /// Pass <c>default</c> for messages that are not replies.
     /// </param>
+    /// <param name="subscriptionSubject">
+    /// The subject the subscription was created with, which is the low cardinality template
+    /// the delivered subject matched. Defaults to the delivered subject when the caller has no
+    /// subscription to hand.
+    /// </param>
+    /// <param name="queueGroup">The subscription's queue group, if it joined one.</param>
     /// <returns>A new <see cref="NatsMsg{T}"/> instance containing the provided data.</returns>
     /// <exception cref="NatsException">Thrown if there is an error during the processing of the message.</exception>
     internal static NatsMsg<T> BuildInternal(
@@ -365,7 +371,9 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
         INatsConnection? connection,
         NatsHeaderParser headerParser,
         INatsDeserialize<T> serializer,
-        ActivityContext replyParentContext)
+        ActivityContext replyParentContext,
+        string? subscriptionSubject = null,
+        string? queueGroup = null)
     {
         NatsHeaders? headers = null;
         var flags = NatsMsgFlags.None;
@@ -413,8 +421,8 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
             var activity = Telemetry.StartReceiveActivity(
                 connection,
                 name: activityName,
-                subscriptionSubject: subject,
-                queueGroup: null,
+                subscriptionSubject: subscriptionSubject ?? subject,
+                queueGroup: queueGroup,
                 subject: subject,
                 replyTo: replyTo,
                 bodySize: payloadBuffer.Length,

--- a/src/NATS.Client.Core/NatsMsg.cs
+++ b/src/NATS.Client.Core/NatsMsg.cs
@@ -410,6 +410,7 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
                    + (headersBuffer?.Length ?? 0)
                    + payloadBuffer.Length;
 
+        Activity? receiveActivity = null;
         if (Telemetry.HasListeners())
         {
             var activityName = connection is NatsConnection nats
@@ -418,7 +419,7 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
 
             headers ??= new NatsHeaders();
 
-            var activity = Telemetry.StartReceiveActivity(
+            receiveActivity = Telemetry.StartReceiveActivity(
                 connection,
                 name: activityName,
                 subscriptionSubject: subscriptionSubject ?? subject,
@@ -430,15 +431,24 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
                 headers: headers,
                 fallbackParentContext: replyParentContext);
 
-            if (activity is not null)
+            if (receiveActivity is not null)
             {
-                headers.Activity = activity;
+                headers.Activity = receiveActivity;
             }
         }
 
         T? data;
         if (headers?.Error == null)
         {
+            // Deserialization is part of receiving the message, so a deserializer that starts
+            // its own span should nest under the receive activity. Receive activities are kept
+            // off the ambient context because they are created on the read loop, so it has to
+            // be put there for the call and taken back out. Only paid when tracing is on and
+            // the message was not filtered out.
+            var ambient = Activity.Current;
+            if (receiveActivity is not null)
+                Activity.Current = receiveActivity;
+
             try
             {
                 data = serializer.Deserialize(payloadBuffer, new NatsMsgContext(subject, replyTo, headers));
@@ -448,6 +458,11 @@ public readonly record struct NatsMsg<T> : INatsMsg<T>
                 headers ??= new NatsHeaders();
                 headers.Error = new NatsDeserializeException(payloadBuffer.ToArray(), e);
                 data = default;
+            }
+            finally
+            {
+                if (receiveActivity is not null)
+                    Telemetry.RestoreCurrentActivity(ambient);
             }
         }
         else

--- a/src/NATS.Client.Core/NatsSub.cs
+++ b/src/NATS.Client.Core/NatsSub.cs
@@ -50,7 +50,9 @@ public sealed class NatsSub<T> : NatsSubBase, INatsSub<T>
             Connection,
             Connection.HeaderParser,
             Serializer,
-            ReplyParentContext);
+            ReplyParentContext,
+            subscriptionSubject: Subject,
+            queueGroup: QueueGroup);
 
         ReceiveActivity = natsMsg.Headers?.Activity;
 

--- a/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSConsume.cs
@@ -474,14 +474,17 @@ internal class NatsJSConsume<TMsg> : NatsSubBase
             _consecutive503Errors = 0;
 
             var msg = new NatsJSMsg<TMsg>(
-                NatsMsg<TMsg>.Build(
+                NatsMsg<TMsg>.BuildInternal(
                     subject,
                     replyTo,
                     headersBuffer,
                     payloadBuffer,
                     Connection,
                     Connection.HeaderParser,
-                    _serializer),
+                    _serializer,
+                    replyParentContext: default,
+                    subscriptionSubject: Subject,
+                    queueGroup: QueueGroup),
                 _context);
 
             ReceiveActivity = msg.Headers?.Activity;

--- a/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSFetch.cs
@@ -278,14 +278,17 @@ internal class NatsJSFetch<TMsg> : NatsSubBase
         else
         {
             var msg = new NatsJSMsg<TMsg>(
-                NatsMsg<TMsg>.Build(
+                NatsMsg<TMsg>.BuildInternal(
                     subject,
                     replyTo,
                     headersBuffer,
                     payloadBuffer,
                     Connection,
                     Connection.HeaderParser,
-                    _serializer),
+                    _serializer,
+                    replyParentContext: default,
+                    subscriptionSubject: Subject,
+                    queueGroup: QueueGroup),
                 _context);
 
             ReceiveActivity = msg.Headers?.Activity;

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedConsume.cs
@@ -281,14 +281,17 @@ internal class NatsJSOrderedConsume<TMsg> : NatsSubBase
         else
         {
             var msg = new NatsJSMsg<TMsg>(
-                NatsMsg<TMsg>.Build(
+                NatsMsg<TMsg>.BuildInternal(
                     subject,
                     replyTo,
                     headersBuffer,
                     payloadBuffer,
                     Connection,
                     Connection.HeaderParser,
-                    _serializer),
+                    _serializer,
+                    replyParentContext: default,
+                    subscriptionSubject: Subject,
+                    queueGroup: QueueGroup),
                 _context);
 
             ReceiveActivity = msg.Headers?.Activity;

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
@@ -317,6 +317,16 @@ internal class NatsJSOrderedPushConsumer<T>
                     {
                         _logger.LogWarning(NatsJSLogEvents.Internal, e, "Command error");
                     }
+                    finally
+                    {
+                        // Nothing downstream ends this receive activity: the message goes to an
+                        // internal consumer (the object store) rather than through an
+                        // ActivityEndingMsgReader. End it here, once the command loop is done
+                        // with it on whichever branch it took. _msgChannel is bounded to 1, so
+                        // for messages that are forwarded this is the point the reader picked
+                        // the previous one up. Ready commands carry no headers, so no-op.
+                        Telemetry.EndActivity(command.Msg.Headers?.Activity);
+                    }
                 }
             }
         }
@@ -499,6 +509,12 @@ internal class NatsJSOrderedPushConsumerSub<T> : NatsSubBase
         ReadOnlySequence<byte> payloadBuffer)
     {
         var msg = new NatsJSMsg<T>(NatsMsg<T>.Build(subject, replyTo, headersBuffer, payloadBuffer, _nats, _headerParser, _serializer), _context);
+
+        // Handed to the base class so a message that never makes it onto the command channel
+        // still has its receive activity ended. Once it is on the channel the command loop
+        // owns it.
+        ReceiveActivity = msg.Headers?.Activity;
+
         await _commandChannel.Writer.WriteAsync(new NatsJSOrderedPushConsumerMsg<T> { Command = NatsJSOrderedPushConsumerCommand.Msg, Msg = msg }, _cancellationToken).ConfigureAwait(false);
 
         ResetSlowConsumer(_commandChannel.Reader.Count);

--- a/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
+++ b/src/NATS.Client.JetStream/Internal/NatsJSOrderedPushConsumer.cs
@@ -508,7 +508,9 @@ internal class NatsJSOrderedPushConsumerSub<T> : NatsSubBase
         ReadOnlySequence<byte>? headersBuffer,
         ReadOnlySequence<byte> payloadBuffer)
     {
-        var msg = new NatsJSMsg<T>(NatsMsg<T>.Build(subject, replyTo, headersBuffer, payloadBuffer, _nats, _headerParser, _serializer), _context);
+        var msg = new NatsJSMsg<T>(
+            NatsMsg<T>.BuildInternal(subject, replyTo, headersBuffer, payloadBuffer, _nats, _headerParser, _serializer, replyParentContext: default, subscriptionSubject: Subject, queueGroup: QueueGroup),
+            _context);
 
         // Handed to the base class so a message that never makes it onto the command channel
         // still has its receive activity ended. Once it is on the channel the command loop

--- a/src/NATS.Client.JetStream/NatsJSContext.cs
+++ b/src/NATS.Client.JetStream/NatsJSContext.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using NATS.Client.Core;
+using NATS.Client.Core.Internal;
 using NATS.Client.JetStream.Internal;
 using NATS.Client.JetStream.Models;
 
@@ -217,6 +218,11 @@ public partial class NatsJSContext
                 return msg.Data;
             }
 
+            // The Direct branch above goes through RequestAsync, which starts this. Driving
+            // CreateRequestSubAsync directly does not, so without it the subscribe, publish and
+            // receive spans are three separate traces. One per attempt: a retry is a new request.
+            using var activity = Telemetry.StartRequestActivity(Connection, subject);
+
             await using var sub = await Connection.CreateRequestSubAsync<T, PubAckResponse>(
                     subject: subject,
                     data: data,
@@ -320,6 +326,13 @@ public partial class NatsJSContext
         }
 
         opts ??= NatsJSPubOpts.Default;
+
+        // Scoped to issuing the request rather than to the future, which the caller may hold
+        // for any length of time and is not obliged to dispose. CreateRequestSubAsync captures
+        // this activity's context (ids only) onto the reply subscription, so the ack's receive
+        // span still parents under this one when it arrives after the span has ended, which is
+        // ordinary for asynchronous messaging.
+        using var activity = Telemetry.StartRequestActivity(Connection, subject);
 
         var sub = await Connection.CreateRequestSubAsync<T, PubAckResponse>(
                     subject: subject,
@@ -476,6 +489,11 @@ public partial class NatsJSContext
 
             return new NatsJSResponse<TResponse>(msg.Data.Value, null);
         }
+
+        // The Direct branch above goes through RequestAsync, which starts this. Without it
+        // every JetStream API call in SharedInbox mode produced a subscribe, a publish and a
+        // receive span in three unrelated traces.
+        using var activity = Telemetry.StartRequestActivity(Connection, subject);
 
         await using var sub = await Connection.CreateRequestSubAsync<TRequest, NatsJSApiResult<TResponse>>(
                 subject: subject,

--- a/src/NATS.Client.KeyValueStore/Internal/NatsKVWatchSub.cs
+++ b/src/NATS.Client.KeyValueStore/Internal/NatsKVWatchSub.cs
@@ -54,7 +54,9 @@ internal class NatsKVWatchSub<T> : NatsSubBase
         ReadOnlySequence<byte>? headersBuffer,
         ReadOnlySequence<byte> payloadBuffer)
     {
-        var msg = new NatsJSMsg<T>(NatsMsg<T>.Build(subject, replyTo, headersBuffer, payloadBuffer, _nats, _headerParser, _serializer), _context);
+        var msg = new NatsJSMsg<T>(
+            NatsMsg<T>.BuildInternal(subject, replyTo, headersBuffer, payloadBuffer, _nats, _headerParser, _serializer, replyParentContext: default, subscriptionSubject: Subject, queueGroup: QueueGroup),
+            _context);
 
         // Handed to the base class so a message that never makes it onto the command channel
         // still has its receive activity ended. Once it is on the channel the watcher's

--- a/src/NATS.Client.KeyValueStore/Internal/NatsKVWatchSub.cs
+++ b/src/NATS.Client.KeyValueStore/Internal/NatsKVWatchSub.cs
@@ -55,6 +55,12 @@ internal class NatsKVWatchSub<T> : NatsSubBase
         ReadOnlySequence<byte> payloadBuffer)
     {
         var msg = new NatsJSMsg<T>(NatsMsg<T>.Build(subject, replyTo, headersBuffer, payloadBuffer, _nats, _headerParser, _serializer), _context);
+
+        // Handed to the base class so a message that never makes it onto the command channel
+        // still has its receive activity ended. Once it is on the channel the watcher's
+        // command loop owns it.
+        ReceiveActivity = msg.Headers?.Activity;
+
         await _commandChannel.Writer.WriteAsync(new NatsKVWatchCommandMsg<T> { Command = NatsKVWatchCommand.Msg, Msg = msg }, _cancellationToken).ConfigureAwait(false);
 
         ResetSlowConsumer(_commandChannel.Reader.Count);

--- a/src/NATS.Client.KeyValueStore/Internal/NatsKVWatcher.cs
+++ b/src/NATS.Client.KeyValueStore/Internal/NatsKVWatcher.cs
@@ -347,6 +347,16 @@ internal sealed class NatsKVWatcher<T> : IAsyncDisposable
                     {
                         _logger.LogWarning(NatsKVLogEvents.Internal, e, "Command error");
                     }
+                    finally
+                    {
+                        // The watcher consumes the message itself rather than handing it to the
+                        // application, so there is no ActivityEndingMsgReader to end its receive
+                        // activity and nothing else ever would. This is the equivalent point:
+                        // the command loop is done with the message, whichever branch it took.
+                        // Ready commands carry a default message with no headers, so this is a
+                        // no-op for them.
+                        Telemetry.EndActivity(command.Msg.Headers?.Activity);
+                    }
                 }
             }
         }

--- a/src/NATS.Client.Services/NatsSvcEndPoint.cs
+++ b/src/NATS.Client.Services/NatsSvcEndPoint.cs
@@ -209,6 +209,11 @@ public class NatsSvcEndpoint<T> : NatsSvcEndpointBase
             msg = new NatsMsg<T>(subject, replyTo, subject.Length + (replyTo?.Length ?? 0), default, default, _nats);
         }
 
+        // Hand the receive activity to the base class so a failure part way through the
+        // hand-off is recorded against the right span, and so a message that never reaches
+        // the handler loop still has its activity ended.
+        ReceiveActivity = msg.Headers?.Activity;
+
         if (exception is not null)
         {
             _logger.LogWarning(NatsSvcLogEvents.Endpoint, exception, "Endpoint {Name} error receiving message", Name);
@@ -230,12 +235,26 @@ public class NatsSvcEndpoint<T> : NatsSvcEndpointBase
             {
                 Interlocked.Increment(ref _requests);
                 stopwatch.Restart();
+
+                // The endpoint is the server side of the request, so this message's receive
+                // activity is the span its handling belongs to. Make it current for the
+                // duration of the handler so spans the handler starts nest under it: receive
+                // activities are kept off the ambient context because they are created on the
+                // read loop, but this is the handler loop's own task and the ambient value is
+                // put back below.
+                var activity = svcMsg.Headers?.Activity;
+                var ambient = Activity.Current;
+                if (activity is not null)
+                    Activity.Current = activity;
+
                 try
                 {
                     await _handler(svcMsg).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
+                    Telemetry.SetException(activity, e);
+
                     int code;
                     string message;
                     string body;
@@ -276,6 +295,14 @@ public class NatsSvcEndpoint<T> : NatsSvcEndpointBase
                 finally
                 {
                     Interlocked.Add(ref _processingTime, ToNanos(stopwatch.Elapsed));
+
+                    // Restore before ending: EndActivity preserves whatever is current, and
+                    // right now that is the activity about to be stopped.
+                    Telemetry.RestoreCurrentActivity(ambient);
+
+                    // The endpoint consumes the message itself rather than handing it to an
+                    // ActivityEndingMsgReader, so nothing downstream would ever end this.
+                    Telemetry.EndActivity(activity);
                 }
             }
         }

--- a/src/NATS.Client.Services/NatsSvcEndPoint.cs
+++ b/src/NATS.Client.Services/NatsSvcEndPoint.cs
@@ -196,7 +196,7 @@ public class NatsSvcEndpoint<T> : NatsSvcEndpointBase
         Exception? exception;
         try
         {
-            msg = NatsMsg<T>.Build(subject, replyTo, headersBuffer, payloadBuffer, _nats, _nats.HeaderParser, _serializer);
+            msg = NatsMsg<T>.BuildInternal(subject, replyTo, headersBuffer, payloadBuffer, _nats, _nats.HeaderParser, _serializer, replyParentContext: default, subscriptionSubject: Subject, queueGroup: QueueGroup);
             exception = msg.Error;
         }
         catch (Exception e)

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
@@ -443,6 +443,95 @@ public class NatsConnectionTelemetryTests
         }
     }
 
+    [Fact]
+    public async Task Enrich_sees_the_receive_activity_as_current()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var previous = NatsInstrumentationOptions.Default.Enrich;
+        try
+        {
+            Activity? seen = null;
+            NatsInstrumentationOptions.Default.Enrich = (_, _) => seen = Activity.Current;
+
+            await using var nats = new NatsConnection();
+
+            using var activity = Telemetry.StartReceiveActivity(
+                nats,
+                name: "receive",
+                subscriptionSubject: "foo.bar",
+                queueGroup: null,
+                subject: "foo.bar",
+                replyTo: null,
+                bodySize: 0,
+                size: 0,
+                headers: null);
+
+            activity.Should().NotBeNull();
+
+            // Send and receive must agree on what the callback sees. The send path leaves its
+            // activity current, so the receive path makes its own current for the call.
+            seen.Should().BeSameAs(activity);
+
+            // ...and puts the ambient context back afterwards, which is the whole reason
+            // receive activities are kept off it in the first place.
+            Activity.Current.Should().BeNull();
+        }
+        finally
+        {
+            NatsInstrumentationOptions.Default.Enrich = previous;
+        }
+    }
+
+    [Fact]
+    public async Task Deserializer_runs_under_the_receive_activity()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await using var nats = new NatsConnection();
+
+        var deserializer = new CurrentActivityCapturingDeserializer();
+
+        var msg = NatsMsg<string>.Build(
+            "foo.bar",
+            replyTo: null,
+            headersBuffer: null,
+            payloadBuffer: new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes("hello")),
+            nats,
+            nats.HeaderParser,
+            deserializer);
+
+        var activity = msg.Headers?.Activity;
+        activity.Should().NotBeNull();
+
+        // A deserializer that starts its own span belongs under the receive span. Without this
+        // it became a child of whatever the caller happened to hold, or a root.
+        deserializer.Seen.Should().BeSameAs(activity);
+
+        Activity.Current.Should().BeNull("the read loop's ambient context must be left as it was");
+    }
+
+    private sealed class CurrentActivityCapturingDeserializer : INatsDeserialize<string>
+    {
+        public Activity? Seen { get; private set; }
+
+        public string Deserialize(in ReadOnlySequence<byte> buffer)
+        {
+            Seen = Activity.Current;
+            return Encoding.UTF8.GetString(buffer.ToArray());
+        }
+    }
+
     private sealed class NoopSubscriptionManager : INatsSubscriptionManager
     {
         public ValueTask RemoveAsync(NatsSubBase sub) => default;

--- a/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
+++ b/tests/NATS.Client.CoreUnit.Tests/NatsConnectionTelemetryTests.cs
@@ -341,6 +341,108 @@ public class NatsConnectionTelemetryTests
         }
     }
 
+    [Fact]
+    public async Task SpanDestinationName_falls_back_to_default_when_formatter_throws()
+    {
+        var previous = NatsInstrumentationOptions.Default.SpanDestinationNameFormatter;
+        try
+        {
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = _ => throw new InvalidOperationException("boom");
+
+            await using var nats = new NatsConnection();
+
+            // A formatter only chooses a span name. It used to propagate out of publish and out
+            // of message construction on receive, so a bug in it broke messaging.
+            nats.SpanDestinationName("foo.bar.baz").Should().Be("foo.bar");
+        }
+        finally
+        {
+            NatsInstrumentationOptions.Default.SpanDestinationNameFormatter = previous;
+        }
+    }
+
+    [Fact]
+    public async Task Throwing_filter_means_the_request_is_not_collected()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var previous = NatsInstrumentationOptions.Default.Filter;
+        try
+        {
+            NatsInstrumentationOptions.Default.Filter = _ => throw new InvalidOperationException("boom");
+
+            await using var nats = new NatsConnection();
+
+            // What the Filter documentation has always claimed: "If filter returns false or
+            // throws an exception the request is NOT collected." There was no try/catch.
+            Telemetry.StartReceiveActivity(
+                nats,
+                name: "receive",
+                subscriptionSubject: "foo.bar",
+                queueGroup: null,
+                subject: "foo.bar",
+                replyTo: null,
+                bodySize: 0,
+                size: 0,
+                headers: null).Should().BeNull();
+
+            Telemetry.StartSendActivity("foo.bar publish", nats, "foo.bar", replyTo: null, operation: Telemetry.Constants.OpPub)
+                .Should().BeNull();
+        }
+        finally
+        {
+            NatsInstrumentationOptions.Default.Filter = previous;
+        }
+    }
+
+    [Fact]
+    public async Task Throwing_enrich_leaves_the_activity_usable()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.NatsActivitySource,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var previous = NatsInstrumentationOptions.Default.Enrich;
+        try
+        {
+            NatsInstrumentationOptions.Default.Enrich = (activity, _) =>
+            {
+                activity.SetTag("set.before.throwing", "yes");
+                throw new InvalidOperationException("boom");
+            };
+
+            await using var nats = new NatsConnection();
+
+            using var activity = Telemetry.StartReceiveActivity(
+                nats,
+                name: "receive",
+                subscriptionSubject: "foo.bar",
+                queueGroup: null,
+                subject: "foo.bar",
+                replyTo: null,
+                bodySize: 0,
+                size: 0,
+                headers: null);
+
+            // Enrichment is decoration on an activity that is already complete. Failing the
+            // message build for the sake of a tag is never the right trade.
+            activity.Should().NotBeNull();
+            activity!.GetTagItem("set.before.throwing").Should().Be("yes");
+        }
+        finally
+        {
+            NatsInstrumentationOptions.Default.Enrich = previous;
+        }
+    }
+
     private sealed class NoopSubscriptionManager : INatsSubscriptionManager
     {
         public ValueTask RemoveAsync(NatsSubBase sub) => default;

--- a/tests/NATS.Net.OpenTelemetry.Tests/NATS.Net.OpenTelemetry.Tests.csproj
+++ b/tests/NATS.Net.OpenTelemetry.Tests/NATS.Net.OpenTelemetry.Tests.csproj
@@ -35,6 +35,9 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\NATS.Client.JetStream\NATS.Client.JetStream.csproj" />
+        <ProjectReference Include="..\..\src\NATS.Client.KeyValueStore\NATS.Client.KeyValueStore.csproj" />
+        <ProjectReference Include="..\..\src\NATS.Client.ObjectStore\NATS.Client.ObjectStore.csproj" />
+        <ProjectReference Include="..\..\src\NATS.Client.Services\NATS.Client.Services.csproj" />
         <ProjectReference Include="..\..\src\NATS.Client.OpenTelemetry\NATS.Client.OpenTelemetry.csproj" />
         <ProjectReference Include="..\..\src\NATS.Client.Serializers.Json\NATS.Client.Serializers.Json.csproj" />
         <ProjectReference Include="..\NATS.Client.TestUtilities\NATS.Client.TestUtilities.csproj" />

--- a/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
@@ -606,6 +606,49 @@ public class OpenTelemetryTest
     }
 
     [Fact]
+    public async Task Send_spans_are_tagged_with_the_operation_they_perform()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await using var sub = await nats.SubscribeCoreAsync<int>("op.demo", cancellationToken: cts.Token);
+        var reg = sub.Register(async msg => await msg.ReplyAsync(msg.Data * 2, cancellationToken: cts.Token));
+
+        await nats.PublishAsync("op.plain", 1, cancellationToken: cts.Token);
+        var reply = await nats.RequestAsync<int, int>("op.demo", 21, cancellationToken: cts.Token);
+        reply.Data.Should().Be(42);
+
+        var activities = tracker.StartedFor(server.Port);
+
+        // messaging.operation used to be hardcoded to publish on every send-side span, so it
+        // disagreed with the metric describing the same operation: operation.duration is
+        // tagged request for RequestAsync and subscribe for SubscribeAsync. Neither filtering
+        // nor joining on the attribute worked.
+        var subscribe = activities.Single(a => a.OperationName == "op.demo subscribe");
+        subscribe.GetTagItem("messaging.operation").Should().Be("subscribe");
+
+        // Nothing is produced by a subscribe; it is a control plane call to the server.
+        subscribe.Kind.Should().Be(ActivityKind.Client);
+
+        var request = activities.Single(a => a.OperationName == "op.demo request");
+        request.GetTagItem("messaging.operation").Should().Be("request");
+        request.Kind.Should().Be(ActivityKind.Producer);
+
+        var publish = activities.Single(a => a.OperationName == "op.plain publish");
+        publish.GetTagItem("messaging.operation").Should().Be("publish");
+        publish.Kind.Should().Be(ActivityKind.Producer);
+
+        activities.Where(a => a.Kind == ActivityKind.Consumer)
+            .Should().AllSatisfy(a => a.GetTagItem("messaging.operation").Should().Be("receive"));
+
+        await sub.DisposeAsync();
+        await reg;
+    }
+
+    [Fact]
     public async Task Receive_span_carries_subscription_subject_and_queue_group()
     {
         using var tracker = new ActivityTracker();

--- a/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/OpenTelemetryTest.cs
@@ -586,6 +586,10 @@ public class OpenTelemetryTest
             "messaging.destination_publish.name",
             "messaging.nats.message.subject",
             "messaging.nats.message.reply_to",
+
+            // Now carries the subscription's subject, which for a reply subscription is the
+            // unique inbox, so it needs the same collapsing as the rest.
+            "messaging.destination.template",
         ];
 
         foreach (var activity in tracker.Started)
@@ -599,6 +603,53 @@ public class OpenTelemetryTest
 
         await sub.DisposeAsync();
         await reg;
+    }
+
+    [Fact]
+    public async Task Receive_span_carries_subscription_subject_and_queue_group()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await using var sub = await nats.SubscribeCoreAsync<int>("orders.*", queueGroup: "workers", cancellationToken: cts.Token);
+        await nats.PingAsync(cts.Token);
+        await nats.PublishAsync("orders.new", 1, cancellationToken: cts.Token);
+
+        var msg = await sub.Msgs.ReadAsync(cts.Token);
+        msg.Data.Should().Be(1);
+
+        var receive = tracker.StartedFor(server.Port).Single(a => a.Kind == ActivityKind.Consumer);
+
+        // The template is the subscription's subject, not the concrete delivered subject.
+        // It used to be given the delivered subject, which is not a template at all.
+        receive.GetTagItem("messaging.destination.template").Should().Be("orders.*");
+        receive.GetTagItem("messaging.nats.message.subject").Should().Be("orders.new");
+
+        // Could never be emitted before, because the queue group was hardcoded to null.
+        receive.GetTagItem("messaging.consumer.group.name").Should().Be("workers");
+    }
+
+    [Fact]
+    public async Task Receive_span_omits_queue_group_tag_when_there_is_none()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await using var sub = await nats.SubscribeCoreAsync<int>("plain.subject", cancellationToken: cts.Token);
+        await nats.PingAsync(cts.Token);
+        await nats.PublishAsync("plain.subject", 1, cancellationToken: cts.Token);
+
+        var msg = await sub.Msgs.ReadAsync(cts.Token);
+        msg.Data.Should().Be(1);
+
+        var receive = tracker.StartedFor(server.Port).Single(a => a.Kind == ActivityKind.Consumer);
+        receive.GetTagItem("messaging.consumer.group.name").Should().BeNull();
     }
 
     [Fact]

--- a/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
@@ -273,15 +273,20 @@ public class ReceiveActivityLifecycleTest
             .Should().Contain(a => (a.GetTagItem("messaging.nats.message.subject") as string ?? string.Empty).StartsWith("$O.blobs", StringComparison.Ordinal));
     }
 
-    [Fact]
-    public async Task Reply_from_a_different_trace_is_linked_rather_than_parented()
+    // Both modes supply a request context for a reply that carries none, and so both reach
+    // the branch under test: direct mode from ReplyTask, shared inbox from the reply
+    // subscription's ReplyParentContext. The dispatch paths differ, the decision does not.
+    [Theory]
+    [InlineData(NatsRequestReplyMode.Direct)]
+    [InlineData(NatsRequestReplyMode.SharedInbox)]
+    public async Task Reply_from_a_different_trace_is_linked_rather_than_parented(NatsRequestReplyMode mode)
     {
         using var tracker = new ActivityTracker();
         await using var server = await NatsServerProcess.StartAsync();
         await using var nats = new NatsConnection(new NatsOpts
         {
             Url = server.Url,
-            RequestReplyMode = NatsRequestReplyMode.Direct,
+            RequestReplyMode = mode,
         });
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));

--- a/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
@@ -274,6 +274,75 @@ public class ReceiveActivityLifecycleTest
     }
 
     [Fact]
+    public async Task Reply_from_a_different_trace_is_linked_rather_than_parented()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            RequestReplyMode = NatsRequestReplyMode.Direct,
+        });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await nats.ConnectAsync();
+
+        using var storedListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "test-stored-write",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(storedListener);
+        using var storedSource = new ActivitySource("test-stored-write");
+
+        // A trace of its own, unrelated to the request about to be made. This stands in for
+        // the traceparent stored alongside a value and replayed verbatim by something like a
+        // JetStream direct get, written by whoever put the value there and possibly long ago.
+        var storedContext = new ActivityContext(
+            ActivityTraceId.CreateRandom(),
+            ActivitySpanId.CreateRandom(),
+            ActivityTraceFlags.Recorded);
+
+        var sub = await nats.SubscribeCoreAsync<int>("stored.get", cancellationToken: cts.Token);
+        var reg = sub.Register(async msg =>
+        {
+            // Replying while this is current puts its trace context, not the caller's, in the
+            // reply's headers, which is what the replayed message does.
+            using var stored = storedSource.StartActivity("stored-write", ActivityKind.Producer, storedContext);
+            await msg.ReplyAsync(msg.Data, cancellationToken: cts.Token);
+        });
+
+        var reply = await nats.RequestAsync<int, int>("stored.get", 1, cancellationToken: cts.Token);
+        reply.Data.Should().Be(1);
+
+        var activities = tracker.StartedFor(server.Port);
+        var request = activities.Single(a => a.OperationName.EndsWith(" request", StringComparison.Ordinal));
+
+        // The other consumer activity is the responder receiving the request itself.
+        var replyReceive = activities
+            .Where(a => a.Kind == ActivityKind.Consumer)
+            .Single(a => a.GetTagItem("messaging.nats.message.subject") as string != "stored.get");
+
+        // Following the reply's own trace context would move the receive span into the
+        // writer's trace, once per read for the life of the value. Backends treat a trace as
+        // complete after a period of inactivity, so a span arriving minutes later is dropped
+        // or orphaned: the read's trace loses a span and the write's gains nothing usable.
+        replyReceive.TraceId.Should().Be(request.TraceId);
+        replyReceive.ParentSpanId.Should().Be(request.SpanId);
+        replyReceive.TraceId.Should().NotBe(storedContext.TraceId);
+
+        // The message's context is still worth keeping, as a link: the mechanism for pointing
+        // at a different and possibly stale trace without claiming the two are one.
+        replyReceive.Links.Select(l => l.Context.TraceId)
+            .Should().ContainSingle().Which.Should().Be(storedContext.TraceId);
+
+        tracker.AssertAllStopped(server.Port);
+
+        await sub.DisposeAsync();
+        await reg;
+    }
+
+    [Fact]
     public async Task Direct_mode_ends_the_reply_activity_when_no_responders_throws()
     {
         using var tracker = new ActivityTracker();

--- a/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
+++ b/tests/NATS.Net.OpenTelemetry.Tests/ReceiveActivityLifecycleTest.cs
@@ -1,5 +1,10 @@
 using System.Diagnostics;
+using System.Text;
 using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+using NATS.Client.KeyValueStore;
+using NATS.Client.ObjectStore;
+using NATS.Client.Services;
 using Synadia.Orbit.Testing.NatsServerProcessManager;
 
 namespace NATS.Client.Core.Tests;
@@ -119,6 +124,179 @@ public class ReceiveActivityLifecycleTest
         receives.Should().AllSatisfy(a => a.TraceId.Should().NotBe(
             ambient.TraceId,
             "receive activities must not inherit the trace that happened to be current when the connection was established"));
+
+        tracker.AssertAllStopped(server.Port);
+    }
+
+    [Fact]
+    public async Task Service_endpoint_receive_span_is_exported_and_covers_the_handler()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        using var handlerSource = new ActivitySource("test-svc-handler");
+        using var handlerListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "test-svc-handler",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(handlerListener);
+
+        Activity? handlerSpan = null;
+
+        var svc = new NatsSvcContext(nats);
+        await using var service = await svc.AddServiceAsync("demo", "1.0.0", cancellationToken: cts.Token);
+        await service.AddEndpointAsync<int>(
+            name: "demo-echo",
+            subject: "demo.echo",
+            handler: async msg =>
+            {
+                handlerSpan = handlerSource.StartActivity("handler-work");
+                handlerSpan?.Stop();
+                await msg.ReplyAsync(msg.Data, cancellationToken: cts.Token);
+            },
+            cancellationToken: cts.Token);
+
+        var reply = await nats.RequestAsync<int, int>("demo.echo", 7, cancellationToken: cts.Token);
+        reply.Data.Should().Be(7);
+
+        // The endpoint consumes the message itself, so nothing used to end its receive
+        // activity and the span was never exported. A service request showed the caller's
+        // request, publish and reply spans and nothing for the endpoint handling it.
+        var endpointReceive = tracker.Stopped
+            .Where(a => a.Kind == ActivityKind.Consumer)
+            .Single(a => a.GetTagItem("messaging.nats.message.subject") as string == "demo.echo");
+
+        endpointReceive.Duration.Should().BeGreaterThan(TimeSpan.Zero);
+
+        // The endpoint span is the server side of the request, so the handler's own work
+        // belongs under it.
+        handlerSpan.Should().NotBeNull();
+        handlerSpan!.ParentSpanId.Should().Be(endpointReceive.SpanId);
+    }
+
+    [Fact]
+    public async Task Service_endpoint_receive_span_records_a_handler_failure()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var svc = new NatsSvcContext(nats);
+        await using var service = await svc.AddServiceAsync("boom", "1.0.0", cancellationToken: cts.Token);
+        await service.AddEndpointAsync<int>(
+            name: "boom-endpoint",
+            subject: "boom.endpoint",
+            handler: _ => throw new InvalidOperationException("handler exploded"),
+            cancellationToken: cts.Token);
+
+        var reply = await nats.RequestAsync<int, int>("boom.endpoint", 1, cancellationToken: cts.Token);
+        reply.Headers.Should().NotBeNull();
+        reply.Headers!["Nats-Service-Error-Code"].ToString().Should().Be("999");
+
+        var endpointReceive = tracker.Stopped
+            .Where(a => a.Kind == ActivityKind.Consumer)
+            .Single(a => a.GetTagItem("messaging.nats.message.subject") as string == "boom.endpoint");
+
+        // No error status on the endpoint span was the third thing #1227 called out.
+        endpointReceive.Status.Should().Be(ActivityStatusCode.Error);
+        endpointReceive.Events.Should().Contain(e => e.Name == "exception");
+    }
+
+    [Fact]
+    public async Task Key_value_watch_receive_spans_are_exported()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var kv = new NatsKVContext(new NatsJSContext(nats));
+        var store = await kv.CreateStoreAsync("shape", cts.Token);
+
+        var watched = new TaskCompletionSource();
+        var watcher = Task.Run(
+            async () =>
+            {
+                await foreach (var entry in store.WatchAsync<int>(cancellationToken: cts.Token))
+                {
+                    if (entry.Value == 42)
+                    {
+                        watched.TrySetResult();
+                        return;
+                    }
+                }
+            },
+            cts.Token);
+
+        await store.PutAsync("key", 42, cancellationToken: cts.Token);
+        await watched.Task.WaitAsync(TimeSpan.FromSeconds(20), cts.Token);
+
+        // The watcher consumes the message rather than handing it to an
+        // ActivityEndingMsgReader, so its receive activity was created and never stopped.
+        // Exporters are driven by ActivityStopped, so the span never existed at all.
+        tracker.Stopped
+            .Where(a => a.Kind == ActivityKind.Consumer)
+            .Should().Contain(a => (a.GetTagItem("messaging.nats.message.subject") as string ?? string.Empty).StartsWith("$KV.shape", StringComparison.Ordinal));
+
+        await watcher;
+    }
+
+    [Fact]
+    public async Task Object_store_watch_receive_spans_are_exported()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var obj = new NatsObjContext(new NatsJSContext(nats));
+        var store = await obj.CreateObjectStoreAsync("blobs", cts.Token);
+
+        await store.PutAsync("thing", new MemoryStream(Encoding.UTF8.GetBytes("payload")), cancellationToken: cts.Token);
+
+        // The get streams the object's chunks through the ordered push consumer, which is the
+        // other internal consumer that never ended its receive activities.
+        var target = new MemoryStream();
+        await store.GetAsync("thing", target, cancellationToken: cts.Token);
+        Encoding.UTF8.GetString(target.ToArray()).Should().Be("payload");
+
+        tracker.Stopped
+            .Where(a => a.Kind == ActivityKind.Consumer)
+            .Should().Contain(a => (a.GetTagItem("messaging.nats.message.subject") as string ?? string.Empty).StartsWith("$O.blobs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Direct_mode_ends_the_reply_activity_when_no_responders_throws()
+    {
+        using var tracker = new ActivityTracker();
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts
+        {
+            Url = server.Url,
+            RequestReplyMode = NatsRequestReplyMode.Direct,
+        });
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await nats.ConnectAsync();
+
+        // Direct mode builds the 503 sentinel reply on the read loop, which starts a receive
+        // activity. RequestAsync ended it only on the path that returns a message, and with
+        // ThrowIfNoResponders set this path throws instead, so the span was never exported.
+        var act = async () => await nats.RequestAsync<int, int>(
+            "nobody.listening",
+            1,
+            replyOpts: new NatsSubOpts { ThrowIfNoResponders = true },
+            cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<NatsNoRespondersException>();
 
         tracker.AssertAllStopped(server.Port);
     }

--- a/tools/site_src/documentation/advanced/opentelemetry.md
+++ b/tools/site_src/documentation/advanced/opentelemetry.md
@@ -67,6 +67,56 @@ custom tags to every activity:
 
 [!code-csharp[](../../../../tests/NATS.Net.DocsExamples/Advanced/OpenTelemetryPage.cs#enrich)]
 
+Use the `Activity` passed as the first argument rather than `Activity.Current`. Both are the same thing on
+the send path, but receive activities are created on the connection's read loop and are deliberately kept
+off the ambient context, so `Activity.Current` on the receive path is not the activity being enriched.
+
+`Filter`, `Enrich` and `SpanDestinationNameFormatter` all run inside publish and inside message
+construction on receive, so none of them is allowed to break the operation it is instrumenting. A `Filter`
+that throws means the operation is not collected, an `Enrich` that throws is ignored and leaves the
+activity with whatever it set before throwing, and a formatter that throws falls back to the default span
+name.
+
+## Span Names and Redacting Subjects
+
+Span names are `<destination> <operation>`, for example `orders.new publish`. The destination defaults to
+the first two tokens of the subject, so `orders.new.eu.de` becomes `orders.new`, and inbox subjects are
+collapsed to the constant `inbox` before anything else runs.
+
+If you need spans but not subjects in their names, set
+[`NatsInstrumentationOptions.Default.SpanDestinationNameFormatter`](xref:NATS.Client.Core.NatsInstrumentationOptions):
+
+```csharp
+NatsInstrumentationOptions.Default.SpanDestinationNameFormatter =
+    subject => subject.StartsWith("tenant.") ? "tenant" : subject;
+```
+
+The formatter replaces the default two-token truncation rather than running after it, so a formatter that
+returns the subject unchanged produces full-subject span names and it is up to you to keep them low
+cardinality. It never sees inbox subjects, which are already collapsed.
+
+The formatter only affects span names. Subjects also appear in tags, which the formatter does not touch:
+
+| Tag | Contents |
+|---|---|
+| `messaging.destination.name` | Delivered subject, inbox collapsed |
+| `messaging.destination_publish.name` | Delivered subject, inbox collapsed |
+| `messaging.nats.message.subject` | Delivered subject, inbox collapsed |
+| `messaging.destination.template` | Subscription subject, inbox collapsed |
+| `messaging.nats.message.reply_to` | Reply-to subject, inbox collapsed |
+
+To remove or rewrite those, use `Enrich`, which runs after the tags are set:
+
+```csharp
+NatsInstrumentationOptions.Default.Enrich = (activity, _) =>
+{
+    activity.SetTag("messaging.destination.name", "redacted");
+    activity.SetTag("messaging.nats.message.subject", "redacted");
+};
+```
+
+Metrics carry no subject at all, so nothing needs redacting there.
+
 ## Baggage Propagation
 
 [W3C Baggage](https://www.w3.org/TR/baggage/) lets you attach arbitrary key/value context (a tenant ID,
@@ -116,8 +166,9 @@ The following attributes are set on activities:
 | Attribute | Example | Description |
 |---|---|---|
 | `messaging.system` | `nats` | Always `nats` |
-| `messaging.operation` | `publish` / `receive` | Operation type |
+| `messaging.operation` | `publish` / `subscribe` / `request` / `receive` | Operation type, matching the value the metrics use for the same operation |
 | `messaging.destination.name` | `orders.new` | Subject name |
+| `messaging.nats.message.reply_to` | `inbox` | Reply-to subject, if the message has one |
 | `messaging.client_id` | `42` | NATS client ID |
 | `server.address` | `localhost` | Server host |
 | `server.port` | `4222` | Server port |
@@ -127,14 +178,38 @@ The following attributes are set on activities:
 | `network.peer.port` | `4222` | Remote port |
 | `network.local.address` | `127.0.0.1` | Local IP |
 
+Span kind is `Producer` for `publish` and `request`, `Consumer` for `receive`, and `Client` for
+`subscribe`, which produces nothing and is a control plane call to the server.
+
 Receive activities include additional attributes:
 
 | Attribute | Example | Description |
 |---|---|---|
-| `messaging.destination.template` | `orders.*` | Subscription subject pattern |
+| `messaging.destination.template` | `orders.*` | Subject the subscription was created with |
+| `messaging.destination.temporary` | `false` | `true` when the subscription is on this connection's inbox |
+| `messaging.destination_publish.name` | `orders.new` | Subject the message was published to |
+| `messaging.nats.message.subject` | `orders.new` | Delivered subject |
 | `messaging.message.body.size` | `1024` | Message body size in bytes |
 | `messaging.message.envelope.size` | `1280` | Total message size in bytes |
-| `messaging.consumer.group.name` | `workers` | Queue group (if used) |
+| `messaging.consumer.group.name` | `workers` | Queue group, omitted when the subscription joined none |
+
+Every subject-valued tag has inbox subjects collapsed to `inbox`; see
+[Span Names and Redacting Subjects](#span-names-and-redacting-subjects).
+
+### Replies Carrying Stored Trace Context
+
+A receive activity normally takes its parent from the trace context carried in the message headers, and
+falls back to the request it is a reply to when the message carries none.
+
+Messages returned verbatim from storage are the exception. A JetStream direct get replays the stored
+message headers, including the `traceparent` written when the value was published, which may be hours
+old and belong to a trace the backend has long since closed. When a reply carries a trace id different
+from the request waiting on it, the receive span is parented from the request and the message's context
+is recorded as a [span link](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) instead.
+The read stays in one trace and the connection to the write is still visible.
+
+A responder that continues the caller's trace shares its trace id, so ordinary request/reply is
+unaffected.
 
 ## Metrics
 
@@ -149,6 +224,7 @@ The following instruments are exposed on the `NATS.Net` meter:
 | `nats.client.reconnects` | Counter | `{reconnect}` | Successful reconnects since process start |
 | `nats.client.sent.bytes` | Counter | `By` | Bytes sent in published messages (body + headers) |
 | `nats.client.received.bytes` | Counter | `By` | Bytes received in consumed messages (body + headers) |
+| `nats.client.messages.dropped` | Counter | `{message}` | Messages evicted from a full subscription channel (slow consumer) |
 
 All instruments carry these tags:
 
@@ -168,6 +244,11 @@ application, per the OTel definition ("messages delivered to the application"). 
 frames consumed internally by the client are excluded: no-responder `503` replies and JetStream heartbeats,
 flow-control, and protocol notifications. The two counters stay consistent, so `received.bytes / consumed.messages`
 reflects average delivered message size.
+
+`nats.client.received.bytes` is a NATS-specific counter with no semantic convention to match, and the bytes
+of an excluded status frame were physically on the wire, so it could be argued either way. Deliberately
+excluding them keeps it aligned with `consumed.messages`, which is what makes the ratio above meaningful.
+Use `nats.client.messages.dropped` and the connection's own statistics if you need wire-level accounting.
 
 ### Histogram Buckets
 


### PR DESCRIPTION
> [!NOTE]
> this PR was created and verified using AI coding agents

Fixes the cluster of OpenTelemetry issues opened over the last few weeks. They turned out to share four root causes, so they are handled together rather than as separate PRs; the commits are ordered so each can be read on its own.

**Spans that were never exported.** A receive activity is ended by the read that hands its message to the application, which `ActivityEndingMsgReader` does for `NatsSub`. Three consumers read from their own channels and never got an equivalent: the Key/Value watcher, the ordered push consumer behind the Object Store, and service endpoints. Exporters are driven by `ActivityStopped`, so those spans never reached a backend at all. Direct mode had the same problem on the two paths where `GetResultAsync` throws instead of returning: the 503 sentinel and a reply arriving after a timeout. Ending now lives with the message rather than with the call site, which also removes an inconsistency where `Telemetry.HasListeners()` was checked twice in `RequestAsync` and a listener attaching between the two checks produced an activity on a path with no code to end it.

Service endpoints get a little more than the minimum: the endpoint span now covers the handler, records a handler exception, and is current while the handler runs so spans the handler starts nest under it. That is what makes it a usable server-side span rather than just a span that exists.

**Traces that were disconnected.** `RequestAsync` starts the activity that a request's subscribe, publish and reply spans nest under, but it is not the only way into request/reply. `RequestManyAsync` and the JetStream shared-inbox paths drive `CreateRequestSubAsync` directly, so in SharedInbox mode a JetStream API call produced three unrelated traces and no request span, where Direct mode produced one. Those four call sites now start one.

**Replies carrying stored trace context.** A JetStream direct get returns the stored message verbatim, so the reply carries the `traceparent` written when the value was published and the receive span joined the trace of the write, once per read for the life of the value. Since backends close a trace after a period of inactivity, a read minutes after the write emits a span into a trace that no longer exists. When a reply's trace id differs from the request waiting on it, the span is now parented from the request and the message's context is recorded as a span link. A responder continuing the caller's trace shares the trace id and is unaffected.

**Tags that were wrong.** `messaging.destination.template` was given the concrete delivered subject and skipped the inbox collapsing every other subject tag gets, so a reply span carried a raw `_INBOX.<nuid>.<nuid>`; `messaging.consumer.group.name` could never be emitted at all; and every send-side span was tagged `messaging.operation=publish` regardless of the operation, so spans and the metrics describing the same operation disagreed.

Also guards `Filter`, `Enrich` and `SpanDestinationNameFormatter`, none of which had a try/catch despite the `Filter` documentation promising that a throwing filter means the request is not collected. A callback bug broke messaging rather than telemetry.

### Worth a second opinion

Three choices here are judgement calls rather than bug fixes, all visible in a backend:

- `messaging.operation` on subscribe and request spans now reads `subscribe` and `request`, matching the values the metrics already use, rather than being restricted to the enum in the current messaging semantic conventions. `messaging.operation` is the older attribute and modern semconv splits it into `messaging.operation.type` and `messaging.operation.name`; migrating to that pair has to move spans and metrics together and is better as its own change. This makes the client self-consistent in the meantime.
- The subscribe span changes from `ActivityKind.Producer` to `ActivityKind.Client`. Nothing is produced by a subscribe; it is a control plane call to the server.
- The span link change also affects a genuine cross-service reply where the responder deliberately started a new trace. Those become linked rather than parented. I think that is more correct, but it is the one change here that could surprise someone.

Two smaller boundaries chosen rather than derived: the Key/Value and Object Store receive spans end when their command loop is done with the message, which is the point the internal consumer has taken it, not when the application later reads the resulting entry or object. And the concurrent JetStream publish scopes its request span to issuing the request rather than to the returned future, which the caller may hold indefinitely and is not obliged to dispose; the ack's receive span still parents correctly because only ids are captured.

### Tests

Each new lifecycle test fails without its fix, verified by disabling the fixes and re-running. They assert on stopped activities rather than started ones, since that is the distinction that decides whether a span reaches a backend. The Key/Value, Object Store and Services projects are now referenced by the OpenTelemetry test project, which only had JetStream.

Full suite green: 849 tests across Core, CoreUnit, Core2, JetStream, KeyValueStore, ObjectStore, Services and OpenTelemetry.

Fixes #1221. Fixes #1223. Fixes #1226. Fixes #1227. Fixes #1228. Fixes #1230. Fixes #1232. Fixes #1233. Fixes #1168.
