### PR TITLE
Fix KV reads on buckets with AllowDirect disabled

### DIFF
--- a/src/NATS.Client.KeyValueStore/NatsKVStore.cs
+++ b/src/NATS.Client.KeyValueStore/NatsKVStore.cs
@@ -50,6 +50,7 @@ public class NatsKVStore : INatsKVStore
     private static readonly NatsKVException MissingSequenceHeaderException = new("Missing sequence header");
     private static readonly NatsKVException MissingTimestampHeaderException = new("Missing timestamp header");
     private static readonly NatsKVException MissingHeadersException = new("Missing headers");
+    private static readonly NatsKVException InvalidHeadersException = new("Can't parse headers");
     private static readonly NatsKVException UnexpectedSubjectException = new("Unexpected subject");
     private static readonly NatsKVException UnexpectedNumberOfOperationHeadersException = new("Unexpected number of operation headers");
     private static readonly NatsKVException InvalidSequenceException = new("Can't parse sequence header");
@@ -331,30 +332,9 @@ public class NatsKVStore : INatsKVStore
                 if (!DateTimeOffset.TryParse(timestampValue, out var timestamp))
                     return InvalidTimestampException;
 
-                var operation = NatsKVOperation.Put;
-                if (headers.TryGetValue(KVOperation, out var operationValues))
+                if (TryGetOperation(headers, out var operation) is { } operationError)
                 {
-                    if (operationValues.Count != 1)
-                        return UnexpectedNumberOfOperationHeadersException;
-
-                    if (!Enum.TryParse(operationValues[0], ignoreCase: true, out operation))
-                        return InvalidOperationException;
-                }
-                else if (headers.TryGetValue(NatsMarkerReason, out var markerReasonValues))
-                {
-                    var reason = markerReasonValues.Last();
-                    if (reason is "MaxAge" or "Purge")
-                    {
-                        operation = NatsKVOperation.Purge;
-                    }
-                    else if (reason is "Remove")
-                    {
-                        operation = NatsKVOperation.Del;
-                    }
-                    else
-                    {
-                        return InvalidOperationException;
-                    }
+                    return operationError;
                 }
 
                 if (operation is NatsKVOperation.Del or NatsKVOperation.Purge)
@@ -386,10 +366,44 @@ public class NatsKVStore : INatsKVStore
 
             if (revision != default)
             {
-                if (string.Equals(response.Message.Subject, keySubject, StringComparison.Ordinal))
+                if (!string.Equals(response.Message.Subject, keySubject, StringComparison.Ordinal))
                 {
                     return UnexpectedSubjectException;
                 }
+            }
+
+            // Non-direct get carries the headers base64 encoded on the response rather than
+            // on the message itself. Decode them so delete and purge markers are honored the
+            // same way as the direct get path above; a value received from either method with
+            // KV-Operation set means the data has been deleted.
+            var operation = NatsKVOperation.Put;
+            if (response.Message.Hdrs is { Length: > 0 } encodedHeaders)
+            {
+                byte[] headerBytes;
+                try
+                {
+                    headerBytes = Convert.FromBase64String(encodedHeaders);
+                }
+                catch (FormatException)
+                {
+                    return InvalidHeadersException;
+                }
+
+                var headers = new NatsHeaders();
+                if (!JetStreamContext.Connection.HeaderParser.ParseHeaders(new SequenceReader<byte>(new ReadOnlySequence<byte>(headerBytes)), headers))
+                {
+                    return InvalidHeadersException;
+                }
+
+                if (TryGetOperation(headers, out operation) is { } operationError)
+                {
+                    return operationError;
+                }
+            }
+
+            if (operation is NatsKVOperation.Del or NatsKVOperation.Purge)
+            {
+                return new NatsKVKeyDeletedException(response.Message.Seq);
             }
 
             T? data;
@@ -417,6 +431,7 @@ public class NatsKVStore : INatsKVStore
             {
                 Created = response.Message.Time,
                 Revision = response.Message.Seq,
+                Operation = operation,
                 Value = data,
                 UsedDirectGet = false,
                 Error = deserializeException,
@@ -727,6 +742,43 @@ public class NatsKVStore : INatsKVStore
         }
 
         return NatsResult.Default;
+    }
+
+    /// <summary>
+    /// Resolves the entry operation from its headers. Shared by the direct and non-direct
+    /// get paths so both classify delete and purge markers identically.
+    /// </summary>
+    /// <returns>The error to surface, or <c>null</c> when <paramref name="operation"/> is set.</returns>
+    private static Exception? TryGetOperation(NatsHeaders headers, out NatsKVOperation operation)
+    {
+        operation = NatsKVOperation.Put;
+
+        if (headers.TryGetValue(KVOperation, out var operationValues))
+        {
+            if (operationValues.Count != 1)
+                return UnexpectedNumberOfOperationHeadersException;
+
+            if (!Enum.TryParse(operationValues[0], ignoreCase: true, out operation))
+                return InvalidOperationException;
+        }
+        else if (headers.TryGetValue(NatsMarkerReason, out var markerReasonValues))
+        {
+            var reason = markerReasonValues.Last();
+            if (reason is "MaxAge" or "Purge")
+            {
+                operation = NatsKVOperation.Purge;
+            }
+            else if (reason is "Remove")
+            {
+                operation = NatsKVOperation.Del;
+            }
+            else
+            {
+                return InvalidOperationException;
+            }
+        }
+
+        return null;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/NATS.Client.KeyValueStore.Tests/NonDirectGetTest.cs
+++ b/tests/NATS.Client.KeyValueStore.Tests/NonDirectGetTest.cs
@@ -1,0 +1,88 @@
+using NATS.Client.Core.Tests;
+using NATS.Client.JetStream.Models;
+using NATS.Client.TestUtilities2;
+using Synadia.Orbit.Testing.NatsServerProcessManager;
+
+namespace NATS.Client.KeyValueStore.Tests;
+
+/// <summary>
+/// Buckets whose stream has AllowDirect disabled take the non-direct read path.
+/// ADR-8 supports reading those legacy buckets, and requires delete and purge
+/// markers to be honored regardless of which read method was used, so this path
+/// has to behave exactly like the direct one.
+/// </summary>
+public class NonDirectGetTest(ITestOutputHelper output)
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Reads_behave_the_same_with_and_without_direct_get(bool allowDirect)
+    {
+        await using var server = await NatsServerProcess.StartAsync();
+        await using var nats = new NatsConnection(new NatsOpts { Url = server.Url });
+        await nats.ConnectRetryAsync();
+
+        var js = new NatsJSContext(nats);
+        var kv = new NatsKVContext(js);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var cancellationToken = cts.Token;
+
+        var bucket = allowDirect ? "direct" : "nondirect";
+
+        INatsKVStore store;
+        if (allowDirect)
+        {
+            store = await kv.CreateStoreAsync(new NatsKVConfig(bucket), cancellationToken);
+        }
+        else
+        {
+            // The KV API always creates buckets with AllowDirect enabled, so build the
+            // stream directly to reproduce a legacy bucket that has it turned off.
+            await js.CreateStreamAsync(
+                new StreamConfig($"KV_{bucket}", new[] { $"$KV.{bucket}.>" })
+                {
+                    AllowDirect = false,
+                    MaxMsgsPerSubject = 10,
+                    AllowRollupHdrs = true,
+                    DenyDelete = true,
+                    Discard = StreamConfigDiscard.New,
+                },
+                cancellationToken);
+
+            store = await kv.GetStoreAsync(bucket, cancellationToken);
+        }
+
+        var stream = await js.GetStreamAsync($"KV_{bucket}", cancellationToken: cancellationToken);
+        Assert.Equal(allowDirect, stream.Info.Config.AllowDirect);
+        output.WriteLine($"bucket {bucket} AllowDirect={stream.Info.Config.AllowDirect}");
+
+        var revision = await store.PutAsync("k", "v1", cancellationToken: cancellationToken);
+
+        // Plain get
+        var entry = await store.GetEntryAsync<string>("k", cancellationToken: cancellationToken);
+        Assert.Equal("v1", entry.Value);
+        Assert.Equal(NatsKVOperation.Put, entry.Operation);
+
+        // Get by revision. The non-direct path used to reject the correct subject and
+        // always throw NatsKVException("Unexpected subject") here.
+        var byRevision = await store.GetEntryAsync<string>("k", revision: revision, cancellationToken: cancellationToken);
+        Assert.Equal("v1", byRevision.Value);
+        Assert.Equal(revision, byRevision.Revision);
+
+        // Deleted keys must report as deleted, not come back as a live entry. The
+        // non-direct path never looked at the headers so it returned Operation = Put.
+        await store.DeleteAsync("k", cancellationToken: cancellationToken);
+        await Assert.ThrowsAsync<NatsKVKeyDeletedException>(async () =>
+            await store.GetEntryAsync<string>("k", cancellationToken: cancellationToken));
+
+        // Re-creating a deleted key must succeed. It failed permanently while the
+        // delete marker was mistaken for a live entry.
+        var recreated = await store.CreateAsync("k", "v2", cancellationToken: cancellationToken);
+        Assert.True(recreated > revision);
+
+        var after = await store.GetEntryAsync<string>("k", cancellationToken: cancellationToken);
+        Assert.Equal("v2", after.Value);
+        Assert.Equal(NatsKVOperation.Put, after.Operation);
+    }
+}


### PR DESCRIPTION
On buckets whose stream has AllowDirect disabled, the non-direct read path in TryGetEntryAsync had its subject check inverted, so GetEntryAsync with a revision always threw "Unexpected subject". It also never decoded the response headers, so KV-Operation DEL and PURGE were ignored and deleted keys came back as live entries with Operation = Put, which affects plain GetEntryAsync too and left CreateAsync failing permanently on a deleted key.

Operation parsing now lives in one helper shared by both paths, matching nats.go which parses the message once for both. ADR-8 supports reading legacy buckets with direct get disabled and requires delete markers to be honored from either read method. The test asserts a normal bucket and one without direct get behave identically.

Fixes #1238
