### PR TITLE
Fix TlsPreferTest hang that aborts the Core2 test run

### DIFF
--- a/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
+++ b/tests/NATS.Client.Core2.Tests/TlsPreferTest.cs
@@ -31,6 +31,8 @@ public class TlsPreferTest(ITestOutputHelper output)
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
         var connectLine = string.Empty;
+        var handshakeDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handshakeReg = cts.Token.Register(() => handshakeDone.TrySetCanceled());
 
         var serverTask = Task.Run(
             async () =>
@@ -71,6 +73,20 @@ public class TlsPreferTest(ITestOutputHelper output)
                         break; // handshake complete
                     }
                 }
+
+                handshakeDone.TrySetResult();
+
+                // Hold the socket open until the test is done with it. Closing here races
+                // ConnectAsync: the client reconnects on a dropped connection, and a
+                // reconnect that starts before ConnectAsync returns leaves it waiting on a
+                // connection this listener will never accept, since its one accept is spent.
+                try
+                {
+                    await Task.Delay(Timeout.Infinite, cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                }
             },
             cts.Token);
 
@@ -88,6 +104,8 @@ public class TlsPreferTest(ITestOutputHelper output)
         });
 
         await nats.ConnectRetryAsync();
+        await handshakeDone.Task;
+        cts.Cancel();
         await serverTask;
         listener.Stop();
 
@@ -325,6 +343,8 @@ public class TlsPreferTest(ITestOutputHelper output)
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
         var connectLine = string.Empty;
+        var handshakeDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handshakeReg = cts.Token.Register(() => handshakeDone.TrySetCanceled());
 
         var serverTask = Task.Run(
             async () =>
@@ -362,6 +382,17 @@ public class TlsPreferTest(ITestOutputHelper output)
                         break;
                     }
                 }
+
+                handshakeDone.TrySetResult();
+
+                // Hold the socket open until the test is done with it, as above.
+                try
+                {
+                    await Task.Delay(Timeout.Infinite, cts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                }
             },
             cts.Token);
 
@@ -373,6 +404,8 @@ public class TlsPreferTest(ITestOutputHelper output)
         });
 
         await nats.ConnectRetryAsync();
+        await handshakeDone.Task;
+        cts.Cancel();
         await serverTask;
         listener.Stop();
 

--- a/tests/xunit.runsettings
+++ b/tests/xunit.runsettings
@@ -5,5 +5,11 @@
     </RunConfiguration>
     <xUnit>
         <MaxParallelThreads>1</MaxParallelThreads>
+        <!--  A test that outlives TestSessionTimeout aborts the whole assembly, and the abort
+              prints no per-test output, so the hung test is unidentifiable from CI logs alone.
+              These two name it every 60s instead. LongRunningTestSeconds is delivered as a
+              diagnostic message, so it does nothing unless DiagnosticMessages is also set.  -->
+        <DiagnosticMessages>true</DiagnosticMessages>
+        <LongRunningTestSeconds>60</LongRunningTestSeconds>
     </xUnit>
 </RunSettings>


### PR DESCRIPTION
The fake server closed the socket as soon as the handshake completed. When that beat ConnectAsync's return the client was mid-reconnect, and ConnectAsync waited on a connection the single-accept listener could never give it, hanging the assembly until the 600s session timeout. Cause of the intermittent Core2 timeouts since June.

Second commit reports long-running tests, since an aborted assembly names nothing.