### PR TITLE
Add offline asset reporting to stream and consumer lists

### DIFF
--- a/src/NATS.Client.JetStream/Models/ConsumerListResponse.cs
+++ b/src/NATS.Client.JetStream/Models/ConsumerListResponse.cs
@@ -13,4 +13,19 @@ public record ConsumerListResponse : IterableResponse
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.Never)]
     [System.ComponentModel.DataAnnotations.Required]
     public ICollection<ConsumerInfo> Consumers { get; set; } = new System.Collections.ObjectModel.Collection<ConsumerInfo>();
+
+    /// <summary>
+    /// In clustered environments gathering Consumer info might time out, this list would be a list of Consumers for which information was not obtainable
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("missing")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public ICollection<string>? Missing { get; set; }
+
+    /// <summary>
+    /// Consumers that are offline, keyed by Consumer name with the reason as the value. A Consumer goes offline when
+    /// it requires a higher API level than the server supports. Offline Consumers are also listed in <see cref="Missing"/>.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("offline")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public IDictionary<string, string>? Offline { get; set; }
 }

--- a/src/NATS.Client.JetStream/Models/StreamListResponse.cs
+++ b/src/NATS.Client.JetStream/Models/StreamListResponse.cs
@@ -20,4 +20,12 @@ public record StreamListResponse : IterableResponse
     [System.Text.Json.Serialization.JsonPropertyName("missing")]
     [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
     public ICollection<string>? Missing { get; set; }
+
+    /// <summary>
+    /// Streams that are offline, keyed by Stream name with the reason as the value. A Stream goes offline when it
+    /// requires a higher API level than the server supports. Offline Streams are also listed in <see cref="Missing"/>.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("offline")]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault)]
+    public IDictionary<string, string>? Offline { get; set; }
 }

--- a/tests/NATS.Client.JetStream.Tests/ParseJsonTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/ParseJsonTests.cs
@@ -78,4 +78,56 @@ public class ParseJsonTests
         Assert.Equal(256 * 1024, result.ChunkSize);
         Assert.Equal(16 * 1024 * 1024, result.WindowSize);
     }
+
+    [Fact]
+    public void Stream_list_response_should_parse_offline_streams()
+    {
+        // A stream that needs a higher API level than the server has is reported in
+        // 'offline' rather than 'streams', and its name is repeated in 'missing'.
+        const string json = """
+                            {
+                              "type": "io.nats.jetstream.api.v1.stream_list_response",
+                              "total": 0,
+                              "offset": 0,
+                              "limit": 256,
+                              "streams": [],
+                              "missing": ["s1"],
+                              "offline": {"s1": "unsupported required api level 99, server supports 2"}
+                            }
+                            """;
+
+        var serializer = NatsJSJsonSerializer<StreamListResponse>.Default;
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(json)));
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Streams);
+        Assert.Equal(["s1"], result.Missing);
+        Assert.NotNull(result.Offline);
+        Assert.Equal("unsupported required api level 99, server supports 2", result.Offline["s1"]);
+    }
+
+    [Fact]
+    public void Consumer_list_response_should_parse_offline_consumers()
+    {
+        const string json = """
+                            {
+                              "type": "io.nats.jetstream.api.v1.consumer_list_response",
+                              "total": 0,
+                              "offset": 0,
+                              "limit": 256,
+                              "consumers": [],
+                              "missing": ["c1"],
+                              "offline": {"c1": "unsupported required api level 99, server supports 2"}
+                            }
+                            """;
+
+        var serializer = NatsJSJsonSerializer<ConsumerListResponse>.Default;
+        var result = serializer.Deserialize(new ReadOnlySequence<byte>(Encoding.UTF8.GetBytes(json)));
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Consumers);
+        Assert.Equal(["c1"], result.Missing);
+        Assert.NotNull(result.Offline);
+        Assert.Equal("unsupported required api level 99, server supports 2", result.Offline["c1"]);
+    }
 }


### PR DESCRIPTION
Server 2.14 reports assets that need a higher API level than the server supports in an offline map on the stream and consumer list responses, keyed by name with the reason as the value, and repeats the name in missing. Both were dropped, and the consumer list response had no missing either.