### PR TITLE
Add consumer reset to stream and consumer objects

### DIFF
--- a/src/NATS.Client.JetStream/INatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/INatsJSConsumer.cs
@@ -122,6 +122,17 @@ public interface INatsJSConsumer
     ValueTask UnpinAsync(string group, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Reset this consumer's delivery state and update this consumer.
+    /// </summary>
+    /// <param name="seq">Stream sequence to reset to. Zero (the default) resets the consumer to its current ack floor.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <returns>The reset response, including the consumer info and the sequence the consumer was reset to.</returns>
+    /// <exception cref="NatsJSException">There was an issue retrieving the response.</exception>
+    /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
+    /// <remarks>This feature is only available on NATS server v2.14 and later.</remarks>
+    ValueTask<ConsumerResetResponse> ResetAsync(ulong seq = 0, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Consume a set number of messages from the stream using this consumer.
     /// Returns immediately if no messages are available.
     /// </summary>

--- a/src/NATS.Client.JetStream/INatsJSStream.cs
+++ b/src/NATS.Client.JetStream/INatsJSStream.cs
@@ -103,6 +103,18 @@ public interface INatsJSStream
     ValueTask<bool> DeleteConsumerAsync(string consumer, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Reset a consumer's delivery state on this stream.
+    /// </summary>
+    /// <param name="consumer">Consumer name to be reset.</param>
+    /// <param name="seq">Stream sequence to reset to. Zero (the default) resets the consumer to its current ack floor.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <returns>The reset response, including the consumer info and the sequence the consumer was reset to.</returns>
+    /// <exception cref="NatsJSException">There is an error retrieving the response or this stream object isn't valid anymore because it was deleted earlier.</exception>
+    /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
+    /// <remarks>This feature is only available on NATS server v2.14 and later.</remarks>
+    ValueTask<ConsumerResetResponse> ResetConsumerAsync(string consumer, ulong seq = 0, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Retrieve the stream info from the server and update this stream.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>

--- a/src/NATS.Client.JetStream/NatsJSConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSConsumer.cs
@@ -381,6 +381,17 @@ public class NatsJSConsumer : INatsJSConsumer
         SetPinId(null);
     }
 
+    /// <inheritdoc />
+    public async ValueTask<ConsumerResetResponse> ResetAsync(ulong seq = 0, CancellationToken cancellationToken = default)
+    {
+        ThrowIfDeleted();
+        var response = await _context.ResetConsumerAsync(_stream, _consumer, seq, cancellationToken).ConfigureAwait(false);
+
+        // The reset response is a superset of consumer info.
+        Info = response;
+        return response;
+    }
+
     /// <summary>
     /// Gets the current pin ID for pinned client priority policy.
     /// </summary>

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -384,6 +384,16 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
     public ValueTask UnpinAsync(string group, CancellationToken cancellationToken = default) => default;
 
+    /// <summary>
+    /// Not supported for ordered consumers, which recreate their underlying ephemeral consumer to seek.
+    /// </summary>
+    /// <param name="seq">Stream sequence to reset to.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <returns>Never returns.</returns>
+    /// <exception cref="NotSupportedException">Always thrown.</exception>
+    public ValueTask<ConsumerResetResponse> ResetAsync(ulong seq = 0, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Ordered consumers cannot be reset; they recreate their underlying consumer to seek.");
+
     private async Task<NatsJSConsumer> RecreateConsumer(string consumer, ulong seq, CancellationToken cancellationToken)
     {
         var consumerOpts = _opts;

--- a/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
+++ b/src/NATS.Client.JetStream/NatsJSOrderedConsumer.cs
@@ -389,10 +389,10 @@ public class NatsJSOrderedConsumer : INatsJSConsumer
     /// </summary>
     /// <param name="seq">Stream sequence to reset to.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
-    /// <returns>Never returns.</returns>
-    /// <exception cref="NotSupportedException">Always thrown.</exception>
+    /// <returns>A faulted task.</returns>
+    /// <exception cref="NotSupportedException">Always.</exception>
     public ValueTask<ConsumerResetResponse> ResetAsync(ulong seq = 0, CancellationToken cancellationToken = default)
-        => throw new NotSupportedException("Ordered consumers cannot be reset; they recreate their underlying consumer to seek.");
+        => new(Task.FromException<ConsumerResetResponse>(new NotSupportedException("Ordered consumers cannot be reset; they recreate their underlying consumer to seek.")));
 
     private async Task<NatsJSConsumer> RecreateConsumer(string consumer, ulong seq, CancellationToken cancellationToken)
     {

--- a/src/NATS.Client.JetStream/NatsJSStream.cs
+++ b/src/NATS.Client.JetStream/NatsJSStream.cs
@@ -160,6 +160,22 @@ public class NatsJSStream : INatsJSStream
     }
 
     /// <summary>
+    /// Reset a consumer's delivery state on this stream.
+    /// </summary>
+    /// <param name="consumer">Consumer name to be reset.</param>
+    /// <param name="seq">Stream sequence to reset to. Zero (the default) resets the consumer to its current ack floor.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>
+    /// <returns>The reset response, including the consumer info and the sequence the consumer was reset to.</returns>
+    /// <exception cref="NatsJSException">There is an error retrieving the response or this stream object isn't valid anymore because it was deleted earlier.</exception>
+    /// <exception cref="NatsJSApiException">Server responded with an error.</exception>
+    /// <remarks>This feature is only available on NATS server v2.14 and later.</remarks>
+    public ValueTask<ConsumerResetResponse> ResetConsumerAsync(string consumer, ulong seq = 0, CancellationToken cancellationToken = default)
+    {
+        ThrowIfDeleted();
+        return _context.ResetConsumerAsync(_name, consumer, seq, cancellationToken);
+    }
+
+    /// <summary>
     /// Retrieve the stream info from the server and update this stream.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> used to cancel the API call.</param>

--- a/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
+++ b/tests/NATS.Client.JetStream.Tests/ManageConsumerTest.cs
@@ -245,6 +245,94 @@ public class ManageConsumerTest
         }
     }
 
+    [SkipIfNatsServer(versionEarlierThan: "2.14")]
+    public async Task Reset_consumer_from_stream()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", [$"{prefix}s1.*"]), cts.Token);
+
+        for (var i = 1; i <= 5; i++)
+        {
+            var ack = await js.PublishAsync($"{prefix}s1.x", i, cancellationToken: cts.Token);
+            ack.EnsureSuccess();
+        }
+
+        var consumer = await stream.CreateOrUpdateConsumerAsync(new ConsumerConfig($"{prefix}c1"), cts.Token);
+
+        var resetResponse = await stream.ResetConsumerAsync($"{prefix}c1", seq: 3, cts.Token);
+        Assert.Equal(3ul, resetResponse.ResetSeq);
+        Assert.Equal($"{prefix}c1", resetResponse.Name);
+
+        var next = await consumer.NextAsync<int>(cancellationToken: cts.Token);
+        Assert.NotNull(next);
+        Assert.Equal(3ul, next!.Metadata!.Value.Sequence.Stream);
+        Assert.Equal(3, next.Data);
+    }
+
+    [SkipIfNatsServer(versionEarlierThan: "2.14")]
+    public async Task Reset_consumer_from_consumer()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", [$"{prefix}s1.*"]), cts.Token);
+
+        for (var i = 1; i <= 5; i++)
+        {
+            var ack = await js.PublishAsync($"{prefix}s1.x", i, cancellationToken: cts.Token);
+            ack.EnsureSuccess();
+        }
+
+        var consumer = await js.CreateOrUpdateConsumerAsync($"{prefix}s1", new ConsumerConfig($"{prefix}c1"), cts.Token);
+
+        var fetchOpts = new NatsJSFetchOpts { MaxMsgs = 2, Expires = TimeSpan.FromSeconds(5) };
+        await foreach (var msg in consumer.FetchAsync<int>(opts: fetchOpts, cancellationToken: cts.Token))
+        {
+            await msg.AckAsync(new AckOpts { DoubleAck = true }, cancellationToken: cts.Token);
+        }
+
+        await consumer.RefreshAsync(cts.Token);
+        Assert.Equal(2ul, consumer.Info.AckFloor.StreamSeq);
+
+        var resetResponse = await consumer.ResetAsync(seq: 4, cancellationToken: cts.Token);
+        Assert.Equal(4ul, resetResponse.ResetSeq);
+
+        // Info is refreshed from the reset response without a further INFO call.
+        Assert.Equal($"{prefix}c1", consumer.Info.Name);
+        Assert.Equal(3ul, consumer.Info.AckFloor.StreamSeq);
+
+        var next = await consumer.NextAsync<int>(cancellationToken: cts.Token);
+        Assert.NotNull(next);
+        Assert.Equal(4ul, next!.Metadata!.Value.Sequence.Stream);
+        Assert.Equal(4, next.Data);
+    }
+
+    [Fact]
+    public async Task Reset_ordered_consumer_is_not_supported()
+    {
+        await using var nats = new NatsConnection(new NatsOpts { Url = _server.Url });
+        await nats.ConnectRetryAsync();
+        var prefix = _server.GetNextId();
+        var js = new NatsJSContext(nats);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var stream = await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", [$"{prefix}s1.*"]), cts.Token);
+        var consumer = await stream.CreateOrderedConsumerAsync(cancellationToken: cts.Token);
+
+        await Assert.ThrowsAsync<NotSupportedException>(async () => await consumer.ResetAsync(cancellationToken: cts.Token));
+    }
+
     [SkipIfNatsServer(versionEarlierThan: "2.10")]
     public async Task Consumer_create_update_action()
     {


### PR DESCRIPTION
CONSUMER.RESET was only reachable from the JetStream context, unlike Go, JS, Rust and Python which also expose it on the stream and the consumer. The consumer overload refreshes Info from the reset response, which is a superset of consumer info. Ordered consumers throw, since they recreate their underlying consumer to seek.