### PR TITLE
Fix consumer list test against nats-server main

### DIFF
--- a/tests/NATS.Client.JetStream.Tests/ListTests.cs
+++ b/tests/NATS.Client.JetStream.Tests/ListTests.cs
@@ -104,9 +104,12 @@ public class ListTests
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 
-        var stream = await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", [$"{prefix}s1.*"]), cts.Token);
-
         const int total = 1200;
+
+        // Streams that do not set MaxConsumers get the server default, which is 1000 from
+        // nats-server 2.15 onwards. Listing only pages past JSApiNamesLimit (1024) if there
+        // are more consumers than that, so the stream needs a limit of its own.
+        var stream = await js.CreateStreamAsync(new StreamConfig($"{prefix}s1", [$"{prefix}s1.*"]) { MaxConsumers = total }, cts.Token);
 
         for (var i = 0; i < total; i++)
         {


### PR DESCRIPTION
nats-server 2.15 gives every stream a default limit of 1000 consumers unless the stream sets one itself, so the consumer list test fails against the server main branch while creating the 1200 consumers it needs to page past the names API limit. The stream now carries an explicit limit. Note that -1 does not work: the server substitutes its default for any value not greater than zero, so unlimited is no longer expressible per stream.

Currently red on every open PR.
